### PR TITLE
feat(llm): add multi-provider wrappers and serializers

### DIFF
--- a/src/openbrowser/llm/anthropic/__init__.py
+++ b/src/openbrowser/llm/anthropic/__init__.py
@@ -1,0 +1,6 @@
+"""Anthropic LLM integration."""
+
+from .chat import ChatAnthropic
+
+__all__ = ["ChatAnthropic"]
+

--- a/src/openbrowser/llm/anthropic/chat.py
+++ b/src/openbrowser/llm/anthropic/chat.py
@@ -1,0 +1,211 @@
+"""Anthropic Claude chat model wrapper."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Type, TypeVar
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ChatAnthropic(BaseChatModel):
+    """
+    LangChain-compatible wrapper for Anthropic Claude models.
+    Requires: pip install anthropic
+    """
+
+    model_name: str = Field(default="claude-sonnet-4-20250514", alias="model")
+    temperature: float = Field(default=0.0)
+    max_tokens: int = Field(default=4096)
+    api_key: Optional[str] = Field(default=None)
+    timeout: float = Field(default=60.0)
+    max_retries: int = Field(default=3)
+
+    _client: Any = PrivateAttr(default=None)
+    _bound_tools: List[Any] = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._bound_tools = []
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize Anthropic client."""
+        try:
+            from anthropic import AsyncAnthropic
+        except ImportError:
+            raise ImportError("Please install anthropic: pip install anthropic")
+
+        api_key = self.api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError("ANTHROPIC_API_KEY not set")
+
+        self._client = AsyncAnthropic(
+            api_key=api_key,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
+
+    @property
+    def _llm_type(self) -> str:
+        return "anthropic"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "temperature": self.temperature}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Synchronous generation - raises NotImplementedError."""
+        raise NotImplementedError("Use ainvoke for async generation")
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation with Anthropic API."""
+        anthropic_messages = self._convert_messages(messages)
+        system_message = None
+        filtered_messages = []
+
+        for msg in anthropic_messages:
+            if msg["role"] == "system":
+                system_message = msg["content"]
+            else:
+                filtered_messages.append(msg)
+
+        request_params = {
+            "model": self.model_name,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": filtered_messages,
+        }
+
+        if system_message:
+            request_params["system"] = system_message
+
+        if self._bound_tools:
+            request_params["tools"] = self._bound_tools
+
+        if stop:
+            request_params["stop_sequences"] = stop
+
+        response = await self._client.messages.create(**request_params)
+
+        # Convert response to LangChain format
+        content = ""
+        tool_calls = []
+
+        for block in response.content:
+            if block.type == "text":
+                content += block.text
+            elif block.type == "tool_use":
+                tool_calls.append({
+                    "id": block.id,
+                    "name": block.name,
+                    "args": block.input,
+                })
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _convert_messages(self, messages: List[BaseMessage]) -> List[dict]:
+        """Convert LangChain messages to Anthropic format."""
+        result = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                result.append({"role": "system", "content": msg.content})
+            elif isinstance(msg, HumanMessage):
+                content = msg.content
+                if isinstance(content, list):
+                    # Handle multimodal content
+                    anthropic_content = []
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                anthropic_content.append({"type": "text", "text": item["text"]})
+                            elif item.get("type") == "image_url":
+                                image_url = item.get("image_url", {}).get("url", "")
+                                if image_url.startswith("data:image"):
+                                    # Extract base64 data
+                                    media_type = image_url.split(";")[0].split(":")[1]
+                                    base64_data = image_url.split(",")[1]
+                                    anthropic_content.append({
+                                        "type": "image",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": media_type,
+                                            "data": base64_data,
+                                        }
+                                    })
+                        else:
+                            anthropic_content.append({"type": "text", "text": str(item)})
+                    result.append({"role": "user", "content": anthropic_content})
+                else:
+                    result.append({"role": "user", "content": content})
+            elif isinstance(msg, AIMessage):
+                result.append({"role": "assistant", "content": msg.content})
+        return result
+
+    def bind_tools(self, tools: List[Any], **kwargs: Any) -> ChatAnthropic:
+        """Bind tools for function calling."""
+        new_instance = ChatAnthropic(
+            model=self.model_name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            api_key=self.api_key,
+        )
+        new_instance._bound_tools = self._convert_tools(tools)
+        return new_instance
+
+    def _convert_tools(self, tools: List[Any]) -> List[dict]:
+        """Convert tools to Anthropic format."""
+        anthropic_tools = []
+        for tool in tools:
+            if hasattr(tool, "name") and hasattr(tool, "description"):
+                schema = {}
+                if hasattr(tool, "args_schema"):
+                    schema = tool.args_schema.model_json_schema()
+                anthropic_tools.append({
+                    "name": tool.name,
+                    "description": tool.description,
+                    "input_schema": schema,
+                })
+            elif isinstance(tool, dict):
+                anthropic_tools.append(tool)
+        return anthropic_tools
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> ChatAnthropic:
+        """Configure for structured output using tool use."""
+        tool = {
+            "name": schema.__name__,
+            "description": f"Output structured data as {schema.__name__}",
+            "input_schema": schema.model_json_schema(),
+        }
+        return self.bind_tools([tool])
+

--- a/src/openbrowser/llm/anthropic/serializer.py
+++ b/src/openbrowser/llm/anthropic/serializer.py
@@ -1,0 +1,216 @@
+"""Anthropic message serializer."""
+
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.agent.views import (
+    AssistantMessage,
+    BaseMessage,
+    ContentPartImageParam,
+    ContentPartTextParam,
+    SystemMessage,
+    UserMessage,
+)
+from src.openbrowser.llm.serializer import BaseMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class AnthropicMessageSerializer(BaseMessageSerializer):
+    """Serializer for converting messages to Anthropic format.
+    
+    Anthropic has a different message format where system messages are
+    passed separately from the messages array.
+    """
+
+    def serialize(self, message: BaseMessage) -> dict[str, Any]:
+        """Serialize a message to Anthropic format."""
+        if isinstance(message, UserMessage):
+            return {
+                'role': 'user',
+                'content': self._serialize_user_content(message.content),
+            }
+
+        elif isinstance(message, SystemMessage):
+            # System messages are handled separately in Anthropic
+            # Return as user message with system prefix for compatibility
+            return {
+                'role': 'user',
+                'content': f"[SYSTEM]: {self._get_text_content(message.content)}",
+            }
+
+        elif isinstance(message, AssistantMessage):
+            content = []
+            if message.content is not None:
+                content = self._serialize_assistant_content(message.content)
+            
+            if message.tool_calls:
+                for tc in message.tool_calls:
+                    content.append({
+                        'type': 'tool_use',
+                        'id': tc.id,
+                        'name': tc.function.name,
+                        'input': json.loads(tc.function.arguments) if tc.function.arguments else {},
+                    })
+            
+            return {'role': 'assistant', 'content': content if content else ''}
+
+        else:
+            raise ValueError(f'Unknown message type: {type(message)}')
+
+    def _serialize_user_content(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartImageParam],
+    ) -> list[dict[str, Any]]:
+        """Serialize user content to Anthropic format."""
+        if isinstance(content, str):
+            return [{'type': 'text', 'text': content}]
+
+        parts = []
+        for part in content:
+            if part.type == 'text':
+                parts.append({'type': 'text', 'text': part.text})
+            elif part.type == 'image_url':
+                # Anthropic uses different image format
+                parts.append({
+                    'type': 'image',
+                    'source': {
+                        'type': 'base64' if part.image_url.url.startswith('data:') else 'url',
+                        'media_type': self._get_media_type(part.image_url.url),
+                        'data': self._extract_base64(part.image_url.url) if part.image_url.url.startswith('data:') else part.image_url.url,
+                    }
+                })
+        return parts
+
+    def _serialize_assistant_content(
+        self,
+        content: str | list,
+    ) -> list[dict[str, Any]]:
+        """Serialize assistant content to Anthropic format."""
+        if isinstance(content, str):
+            return [{'type': 'text', 'text': content}]
+
+        parts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                parts.append({'type': 'text', 'text': part.text})
+        return parts
+
+    def _get_text_content(self, content: str | list) -> str:
+        """Extract text from content."""
+        if isinstance(content, str):
+            return content
+        
+        texts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                texts.append(part.text)
+        return '\n'.join(texts)
+
+    def _get_media_type(self, url: str) -> str:
+        """Get media type from data URL or file extension."""
+        if url.startswith('data:'):
+            # Extract media type from data URL
+            parts = url.split(';')[0].split(':')
+            if len(parts) > 1:
+                return parts[1]
+        elif url.lower().endswith('.png'):
+            return 'image/png'
+        elif url.lower().endswith(('.jpg', '.jpeg')):
+            return 'image/jpeg'
+        elif url.lower().endswith('.gif'):
+            return 'image/gif'
+        elif url.lower().endswith('.webp'):
+            return 'image/webp'
+        return 'image/jpeg'  # Default
+
+    def _extract_base64(self, data_url: str) -> str:
+        """Extract base64 data from data URL."""
+        if ',' in data_url:
+            return data_url.split(',', 1)[1]
+        return data_url
+
+    def extract_system_message(
+        self,
+        messages: list[BaseMessage],
+    ) -> tuple[str | None, list[BaseMessage]]:
+        """Extract system message from message list.
+        
+        Anthropic requires system message to be passed separately.
+        
+        Returns:
+            Tuple of (system_content, remaining_messages)
+        """
+        system_content = None
+        remaining = []
+
+        for msg in messages:
+            if isinstance(msg, SystemMessage) and system_content is None:
+                system_content = self._get_text_content(msg.content)
+            else:
+                remaining.append(msg)
+
+        return system_content, remaining
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to Anthropic tool format."""
+        schema = output_format.model_json_schema()
+        
+        # Remove $defs and resolve references
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "name": output_format.__name__,
+            "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+            "input_schema": schema,
+        }
+
+    def _resolve_refs(self, obj: Any, defs: dict) -> Any:
+        """Recursively resolve $ref references in schema."""
+        if isinstance(obj, dict):
+            if '$ref' in obj:
+                ref_path = obj['$ref'].split('/')[-1]
+                if ref_path in defs:
+                    return self._resolve_refs(defs[ref_path], defs)
+            return {k: self._resolve_refs(v, defs) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._resolve_refs(item, defs) for item in obj]
+        return obj
+
+    def parse_tool_call_response(
+        self,
+        response: dict[str, Any],
+        output_format: type[T],
+    ) -> T:
+        """Parse an Anthropic tool use response into a Pydantic model."""
+        content = response.get('content', [])
+        
+        for block in content:
+            if block.get('type') == 'tool_use':
+                data = block.get('input', {})
+                return output_format.model_validate(data)
+
+        raise ValueError("No tool use block in response")
+
+    def parse_content_response(self, response: dict[str, Any]) -> str:
+        """Parse plain text content from Anthropic response."""
+        content = response.get('content', [])
+        texts = []
+        
+        for block in content:
+            if block.get('type') == 'text':
+                texts.append(block.get('text', ''))
+        
+        return '\n'.join(texts)
+
+
+# Singleton instance
+anthropic_serializer = AnthropicMessageSerializer()
+

--- a/src/openbrowser/llm/aws/__init__.py
+++ b/src/openbrowser/llm/aws/__init__.py
@@ -1,0 +1,6 @@
+"""AWS Bedrock LLM integration."""
+
+from .chat import ChatAWSBedrock
+
+__all__ = ["ChatAWSBedrock"]
+

--- a/src/openbrowser/llm/aws/chat.py
+++ b/src/openbrowser/llm/aws/chat.py
@@ -1,0 +1,222 @@
+"""AWS Bedrock chat model wrapper for Claude via AWS."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, List, Optional, Type, TypeVar
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ChatAWSBedrock(BaseChatModel):
+    """
+    LangChain-compatible wrapper for AWS Bedrock (Claude models).
+    Requires: pip install boto3
+    """
+
+    model_name: str = Field(default="anthropic.claude-3-5-sonnet-20241022-v2:0", alias="model")
+    temperature: float = Field(default=0.0)
+    max_tokens: int = Field(default=4096)
+    region_name: str = Field(default="us-east-1")
+    aws_access_key_id: Optional[str] = Field(default=None)
+    aws_secret_access_key: Optional[str] = Field(default=None)
+    aws_session_token: Optional[str] = Field(default=None)
+
+    _client: Any = PrivateAttr(default=None)
+    _bound_tools: List[Any] = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._bound_tools = []
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize AWS Bedrock client."""
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("Please install boto3: pip install boto3")
+
+        session_kwargs = {"region_name": self.region_name}
+
+        if self.aws_access_key_id:
+            session_kwargs["aws_access_key_id"] = self.aws_access_key_id
+        if self.aws_secret_access_key:
+            session_kwargs["aws_secret_access_key"] = self.aws_secret_access_key
+        if self.aws_session_token:
+            session_kwargs["aws_session_token"] = self.aws_session_token
+
+        session = boto3.Session(**session_kwargs)
+        self._client = session.client("bedrock-runtime")
+
+    @property
+    def _llm_type(self) -> str:
+        return "aws_bedrock"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "temperature": self.temperature}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        raise NotImplementedError("Use ainvoke for async generation")
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation with AWS Bedrock API."""
+        import asyncio
+
+        # Convert messages to Anthropic format
+        anthropic_messages, system = self._convert_messages(messages)
+
+        request_body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": anthropic_messages,
+        }
+
+        if system:
+            request_body["system"] = system
+
+        if self._bound_tools:
+            request_body["tools"] = self._bound_tools
+
+        if stop:
+            request_body["stop_sequences"] = stop
+
+        # Run sync boto3 call in executor
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(
+            None,
+            lambda: self._client.invoke_model(
+                modelId=self.model_name,
+                body=json.dumps(request_body),
+            ),
+        )
+
+        response_body = json.loads(response["body"].read())
+
+        content = ""
+        tool_calls = []
+
+        for block in response_body.get("content", []):
+            if block.get("type") == "text":
+                content += block.get("text", "")
+            elif block.get("type") == "tool_use":
+                tool_calls.append({
+                    "id": block.get("id"),
+                    "name": block.get("name"),
+                    "args": block.get("input", {}),
+                })
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _convert_messages(self, messages: List[BaseMessage]) -> tuple[List[dict], str]:
+        """Convert LangChain messages to Anthropic format for Bedrock."""
+        result = []
+        system = ""
+
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                system = msg.content
+            elif isinstance(msg, HumanMessage):
+                content = msg.content
+                if isinstance(content, list):
+                    anthropic_content = []
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                anthropic_content.append({"type": "text", "text": item["text"]})
+                            elif item.get("type") == "image_url":
+                                image_url = item.get("image_url", {}).get("url", "")
+                                if image_url.startswith("data:image"):
+                                    media_type = image_url.split(";")[0].split(":")[1]
+                                    base64_data = image_url.split(",")[1]
+                                    anthropic_content.append({
+                                        "type": "image",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": media_type,
+                                            "data": base64_data,
+                                        }
+                                    })
+                        else:
+                            anthropic_content.append({"type": "text", "text": str(item)})
+                    result.append({"role": "user", "content": anthropic_content})
+                else:
+                    result.append({"role": "user", "content": content})
+            elif isinstance(msg, AIMessage):
+                result.append({"role": "assistant", "content": msg.content})
+
+        return result, system
+
+    def bind_tools(self, tools: List[Any], **kwargs: Any) -> ChatAWSBedrock:
+        """Bind tools for function calling."""
+        new_instance = ChatAWSBedrock(
+            model=self.model_name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            region_name=self.region_name,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
+        )
+        new_instance._bound_tools = self._convert_tools(tools)
+        return new_instance
+
+    def _convert_tools(self, tools: List[Any]) -> List[dict]:
+        """Convert tools to Anthropic format."""
+        anthropic_tools = []
+        for tool in tools:
+            if hasattr(tool, "name") and hasattr(tool, "description"):
+                schema = {}
+                if hasattr(tool, "args_schema"):
+                    schema = tool.args_schema.model_json_schema()
+                anthropic_tools.append({
+                    "name": tool.name,
+                    "description": tool.description,
+                    "input_schema": schema,
+                })
+            elif isinstance(tool, dict):
+                anthropic_tools.append(tool)
+        return anthropic_tools
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> ChatAWSBedrock:
+        """Configure for structured output."""
+        tool = {
+            "name": schema.__name__,
+            "description": f"Output structured data as {schema.__name__}",
+            "input_schema": schema.model_json_schema(),
+        }
+        return self.bind_tools([tool])
+

--- a/src/openbrowser/llm/aws/serializer.py
+++ b/src/openbrowser/llm/aws/serializer.py
@@ -1,0 +1,210 @@
+"""AWS Bedrock message serializer."""
+
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.agent.views import (
+    AssistantMessage,
+    BaseMessage,
+    ContentPartImageParam,
+    ContentPartTextParam,
+    SystemMessage,
+    UserMessage,
+)
+from src.openbrowser.llm.serializer import BaseMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class AWSBedrockMessageSerializer(BaseMessageSerializer):
+    """Serializer for converting messages to AWS Bedrock format.
+    
+    AWS Bedrock supports multiple model families with different formats.
+    This serializer primarily targets Anthropic Claude models on Bedrock.
+    """
+
+    def serialize(self, message: BaseMessage) -> dict[str, Any]:
+        """Serialize a message to AWS Bedrock (Claude) format."""
+        if isinstance(message, UserMessage):
+            return {
+                'role': 'user',
+                'content': self._serialize_user_content(message.content),
+            }
+
+        elif isinstance(message, SystemMessage):
+            # System messages are handled separately
+            return {
+                'role': 'user',
+                'content': [{'type': 'text', 'text': f"[SYSTEM]: {self._get_text_content(message.content)}"}],
+            }
+
+        elif isinstance(message, AssistantMessage):
+            content = []
+            if message.content is not None:
+                content = self._serialize_assistant_content(message.content)
+            
+            if message.tool_calls:
+                for tc in message.tool_calls:
+                    content.append({
+                        'type': 'tool_use',
+                        'id': tc.id,
+                        'name': tc.function.name,
+                        'input': json.loads(tc.function.arguments) if tc.function.arguments else {},
+                    })
+            
+            return {'role': 'assistant', 'content': content if content else [{'type': 'text', 'text': ''}]}
+
+        else:
+            raise ValueError(f'Unknown message type: {type(message)}')
+
+    def _serialize_user_content(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartImageParam],
+    ) -> list[dict[str, Any]]:
+        """Serialize user content to Bedrock format."""
+        if isinstance(content, str):
+            return [{'type': 'text', 'text': content}]
+
+        parts = []
+        for part in content:
+            if part.type == 'text':
+                parts.append({'type': 'text', 'text': part.text})
+            elif part.type == 'image_url':
+                parts.append({
+                    'type': 'image',
+                    'source': {
+                        'type': 'base64',
+                        'media_type': self._get_media_type(part.image_url.url),
+                        'data': self._extract_base64(part.image_url.url),
+                    }
+                })
+        return parts
+
+    def _serialize_assistant_content(
+        self,
+        content: str | list,
+    ) -> list[dict[str, Any]]:
+        """Serialize assistant content to Bedrock format."""
+        if isinstance(content, str):
+            return [{'type': 'text', 'text': content}]
+
+        parts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                parts.append({'type': 'text', 'text': part.text})
+        return parts
+
+    def _get_text_content(self, content: str | list) -> str:
+        """Extract text from content."""
+        if isinstance(content, str):
+            return content
+        
+        texts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                texts.append(part.text)
+        return '\n'.join(texts)
+
+    def _get_media_type(self, url: str) -> str:
+        """Get media type from URL."""
+        if url.startswith('data:'):
+            parts = url.split(';')[0].split(':')
+            if len(parts) > 1:
+                return parts[1]
+        elif url.lower().endswith('.png'):
+            return 'image/png'
+        elif url.lower().endswith(('.jpg', '.jpeg')):
+            return 'image/jpeg'
+        elif url.lower().endswith('.gif'):
+            return 'image/gif'
+        elif url.lower().endswith('.webp'):
+            return 'image/webp'
+        return 'image/jpeg'
+
+    def _extract_base64(self, data_url: str) -> str:
+        """Extract base64 data from data URL."""
+        if ',' in data_url:
+            return data_url.split(',', 1)[1]
+        return data_url
+
+    def extract_system(
+        self,
+        messages: list[BaseMessage],
+    ) -> tuple[list[dict[str, Any]] | None, list[BaseMessage]]:
+        """Extract system messages for Bedrock's system parameter.
+        
+        Returns:
+            Tuple of (system_content, remaining_messages)
+        """
+        system_content = None
+        remaining = []
+
+        for msg in messages:
+            if isinstance(msg, SystemMessage) and system_content is None:
+                system_content = [{'type': 'text', 'text': self._get_text_content(msg.content)}]
+            else:
+                remaining.append(msg)
+
+        return system_content, remaining
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to Bedrock tool format."""
+        schema = output_format.model_json_schema()
+        
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "name": output_format.__name__,
+            "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+            "input_schema": schema,
+        }
+
+    def _resolve_refs(self, obj: Any, defs: dict) -> Any:
+        """Recursively resolve $ref references in schema."""
+        if isinstance(obj, dict):
+            if '$ref' in obj:
+                ref_path = obj['$ref'].split('/')[-1]
+                if ref_path in defs:
+                    return self._resolve_refs(defs[ref_path], defs)
+            return {k: self._resolve_refs(v, defs) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._resolve_refs(item, defs) for item in obj]
+        return obj
+
+    def parse_tool_call_response(
+        self,
+        response: dict[str, Any],
+        output_format: type[T],
+    ) -> T:
+        """Parse a Bedrock tool use response into a Pydantic model."""
+        content = response.get('content', [])
+        
+        for block in content:
+            if block.get('type') == 'tool_use':
+                data = block.get('input', {})
+                return output_format.model_validate(data)
+
+        raise ValueError("No tool use block in response")
+
+    def parse_content_response(self, response: dict[str, Any]) -> str:
+        """Parse plain text content from Bedrock response."""
+        content = response.get('content', [])
+        texts = []
+        
+        for block in content:
+            if block.get('type') == 'text':
+                texts.append(block.get('text', ''))
+        
+        return '\n'.join(texts)
+
+
+# Singleton instance
+aws_bedrock_serializer = AWSBedrockMessageSerializer()
+

--- a/src/openbrowser/llm/azure/__init__.py
+++ b/src/openbrowser/llm/azure/__init__.py
@@ -1,0 +1,6 @@
+"""Azure OpenAI LLM integration."""
+
+from .chat import ChatAzureOpenAI
+
+__all__ = ["ChatAzureOpenAI"]
+

--- a/src/openbrowser/llm/azure/chat.py
+++ b/src/openbrowser/llm/azure/chat.py
@@ -1,0 +1,200 @@
+"""Azure OpenAI chat model wrapper."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Type, TypeVar
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ChatAzureOpenAI(BaseChatModel):
+    """
+    LangChain-compatible wrapper for Azure OpenAI.
+    Uses OpenAI SDK with Azure endpoint.
+    """
+
+    model_name: str = Field(default="gpt-4o", alias="model")
+    deployment_name: str = Field(default="gpt-4o")
+    temperature: float = Field(default=0.0)
+    max_tokens: int = Field(default=4096)
+    api_key: Optional[str] = Field(default=None)
+    azure_endpoint: Optional[str] = Field(default=None)
+    api_version: str = Field(default="2024-02-01")
+    timeout: float = Field(default=60.0)
+
+    _client: Any = PrivateAttr(default=None)
+    _bound_tools: List[Any] = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._bound_tools = []
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize Azure OpenAI client."""
+        try:
+            from openai import AsyncAzureOpenAI
+        except ImportError:
+            raise ImportError("Please install openai: pip install openai")
+
+        api_key = self.api_key or os.environ.get("AZURE_OPENAI_API_KEY")
+        azure_endpoint = self.azure_endpoint or os.environ.get("AZURE_OPENAI_ENDPOINT")
+
+        if not api_key:
+            raise ValueError("AZURE_OPENAI_API_KEY not set")
+        if not azure_endpoint:
+            raise ValueError("AZURE_OPENAI_ENDPOINT not set")
+
+        self._client = AsyncAzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=self.api_version,
+            timeout=self.timeout,
+        )
+
+    @property
+    def _llm_type(self) -> str:
+        return "azure_openai"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "deployment_name": self.deployment_name}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        raise NotImplementedError("Use ainvoke for async generation")
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation with Azure OpenAI API."""
+        openai_messages = self._convert_messages(messages)
+
+        request_params = {
+            "model": self.deployment_name,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": openai_messages,
+        }
+
+        if self._bound_tools:
+            request_params["tools"] = self._bound_tools
+
+        if stop:
+            request_params["stop"] = stop
+
+        response = await self._client.chat.completions.create(**request_params)
+
+        choice = response.choices[0]
+        content = choice.message.content or ""
+        tool_calls = []
+
+        if choice.message.tool_calls:
+            for tc in choice.message.tool_calls:
+                tool_calls.append({
+                    "id": tc.id,
+                    "name": tc.function.name,
+                    "args": tc.function.arguments,
+                })
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _convert_messages(self, messages: List[BaseMessage]) -> List[dict]:
+        """Convert LangChain messages to OpenAI format."""
+        result = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                result.append({"role": "system", "content": msg.content})
+            elif isinstance(msg, HumanMessage):
+                content = msg.content
+                if isinstance(content, list):
+                    openai_content = []
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                openai_content.append({"type": "text", "text": item["text"]})
+                            elif item.get("type") == "image_url":
+                                openai_content.append(item)
+                        else:
+                            openai_content.append({"type": "text", "text": str(item)})
+                    result.append({"role": "user", "content": openai_content})
+                else:
+                    result.append({"role": "user", "content": content})
+            elif isinstance(msg, AIMessage):
+                result.append({"role": "assistant", "content": msg.content})
+        return result
+
+    def bind_tools(self, tools: List[Any], **kwargs: Any) -> ChatAzureOpenAI:
+        """Bind tools for function calling."""
+        new_instance = ChatAzureOpenAI(
+            model=self.model_name,
+            deployment_name=self.deployment_name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            api_key=self.api_key,
+            azure_endpoint=self.azure_endpoint,
+            api_version=self.api_version,
+        )
+        new_instance._bound_tools = self._convert_tools(tools)
+        return new_instance
+
+    def _convert_tools(self, tools: List[Any]) -> List[dict]:
+        """Convert tools to OpenAI format."""
+        openai_tools = []
+        for tool in tools:
+            if hasattr(tool, "name") and hasattr(tool, "description"):
+                schema = {}
+                if hasattr(tool, "args_schema"):
+                    schema = tool.args_schema.model_json_schema()
+                openai_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": schema,
+                    },
+                })
+            elif isinstance(tool, dict):
+                openai_tools.append(tool)
+        return openai_tools
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> ChatAzureOpenAI:
+        """Configure for structured output."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": schema.__name__,
+                "description": f"Output structured data as {schema.__name__}",
+                "parameters": schema.model_json_schema(),
+            },
+        }
+        return self.bind_tools([tool])
+

--- a/src/openbrowser/llm/azure/serializer.py
+++ b/src/openbrowser/llm/azure/serializer.py
@@ -1,0 +1,28 @@
+"""Azure OpenAI message serializer.
+
+Azure OpenAI uses the same format as OpenAI, so we inherit from OpenAI serializer.
+"""
+
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.llm.openai.serializer import OpenAIMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class AzureOpenAIMessageSerializer(OpenAIMessageSerializer):
+    """Serializer for converting messages to Azure OpenAI format.
+    
+    Azure OpenAI uses the same format as OpenAI with identical message structure.
+    """
+    pass
+
+
+# Singleton instance
+azure_openai_serializer = AzureOpenAIMessageSerializer()
+

--- a/src/openbrowser/llm/base.py
+++ b/src/openbrowser/llm/base.py
@@ -1,0 +1,94 @@
+"""Base LLM chat model following browser-use pattern."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, TypeVar, Type, Optional
+
+from langchain_core.language_models import BaseChatModel as LangChainBaseChatModel
+from langchain_core.messages import BaseMessage
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class BaseChatModel(ABC):
+    """
+    Abstract base class for chat models.
+    Provides a consistent interface for all LLM providers.
+    """
+
+    @property
+    @abstractmethod
+    def provider(self) -> str:
+        """Return the provider name."""
+        pass
+
+    @property
+    @abstractmethod
+    def model(self) -> str:
+        """Return the model name."""
+        pass
+
+    @abstractmethod
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        **kwargs: Any,
+    ) -> BaseMessage:
+        """Async invoke the model with messages."""
+        pass
+
+    @abstractmethod
+    def bind_tools(self, tools: list[Any]) -> BaseChatModel:
+        """Bind tools to the model for function calling."""
+        pass
+
+    @abstractmethod
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> BaseChatModel:
+        """Configure the model to return structured output."""
+        pass
+
+
+class LangChainChatModelWrapper(BaseChatModel):
+    """
+    Wrapper for LangChain chat models to provide a consistent interface.
+    """
+
+    def __init__(self, llm: LangChainBaseChatModel):
+        self._llm = llm
+
+    @property
+    def provider(self) -> str:
+        return getattr(self._llm, "provider", "unknown")
+
+    @property
+    def model(self) -> str:
+        return getattr(self._llm, "model_name", getattr(self._llm, "model", "unknown"))
+
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        **kwargs: Any,
+    ) -> BaseMessage:
+        return await self._llm.ainvoke(messages, **kwargs)
+
+    def bind_tools(self, tools: list[Any]) -> LangChainChatModelWrapper:
+        bound = self._llm.bind_tools(tools)
+        return LangChainChatModelWrapper(bound)
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> LangChainChatModelWrapper:
+        structured = self._llm.with_structured_output(schema, **kwargs)
+        return LangChainChatModelWrapper(structured)
+

--- a/src/openbrowser/llm/browser_use/__init__.py
+++ b/src/openbrowser/llm/browser_use/__init__.py
@@ -1,0 +1,6 @@
+"""Browser-use cloud LLM integration."""
+
+from src.openbrowser.llm.browser_use.chat import ChatBrowserUse
+
+__all__ = ["ChatBrowserUse"]
+

--- a/src/openbrowser/llm/browser_use/chat.py
+++ b/src/openbrowser/llm/browser_use/chat.py
@@ -1,0 +1,227 @@
+"""Browser-use cloud LLM integration.
+
+This module provides integration with browser-use's hosted LLM endpoint,
+allowing users to leverage browser-use's cloud infrastructure for LLM calls.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import PrivateAttr
+
+from src.openbrowser.llm.exceptions import ModelProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class ChatBrowserUse(BaseChatModel):
+    """
+    Chat model for browser-use's hosted LLM endpoint.
+
+    This provides access to browser-use's cloud LLM service, which handles
+    model selection and optimization for browser automation tasks.
+
+    Args:
+        api_key: Browser-use API key (defaults to BROWSER_USE_API_KEY env var)
+        base_url: Browser-use API base URL
+        model: Model preference (optional, service may auto-select)
+        temperature: Temperature for response generation
+        max_tokens: Maximum tokens in response
+        **kwargs: Additional parameters
+    """
+
+    _api_key: str = PrivateAttr()
+    _base_url: str = PrivateAttr()
+    _model: str = PrivateAttr()
+    _temperature: float = PrivateAttr()
+    _max_tokens: int = PrivateAttr()
+    _client: httpx.AsyncClient = PrivateAttr()
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str = "https://api.browser-use.com",
+        model: str = "auto",
+        temperature: float = 0,
+        max_tokens: int = 4096,
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self._api_key = api_key or os.getenv("BROWSER_USE_API_KEY", "")
+        self._base_url = base_url.rstrip('/')
+        self._model = model
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._client = httpx.AsyncClient(timeout=120.0)
+
+        if not self._api_key:
+            raise ValueError("BROWSER_USE_API_KEY is not set and no api_key provided")
+
+    @property
+    def model(self) -> str:
+        """Get the model name."""
+        return self._model
+
+    @property
+    def _llm_type(self) -> str:
+        return "browser-use"
+
+    def bind_tools(self, tools: list[Any]) -> "ChatBrowserUse":
+        """Bind tools to this LLM instance."""
+        # Browser-use cloud handles tool binding internally
+        return self
+
+    def with_structured_output(self, output_schema: type[Any], **kwargs: Any) -> Any:
+        """Get structured output from the model."""
+        return self
+
+    async def ainvoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the model with the given messages."""
+        from langchain_core.messages import AIMessage
+
+        # Convert messages to OpenAI-compatible format
+        formatted_messages = []
+        for msg in messages:
+            if hasattr(msg, 'type'):
+                role = 'system' if msg.type == 'system' else ('assistant' if msg.type == 'ai' else 'user')
+                content = msg.content
+                
+                # Handle multimodal content
+                if isinstance(content, list):
+                    formatted_content = []
+                    for part in content:
+                        if hasattr(part, 'type'):
+                            if part.type == 'text':
+                                formatted_content.append({"type": "text", "text": part.text})
+                            elif part.type == 'image_url':
+                                formatted_content.append({
+                                    "type": "image_url",
+                                    "image_url": {"url": part.image_url.url}
+                                })
+                    content = formatted_content
+                
+                formatted_messages.append({"role": role, "content": content})
+            elif isinstance(msg, dict):
+                formatted_messages.append(msg)
+
+        request_body = {
+            "model": self._model,
+            "messages": formatted_messages,
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+        }
+
+        # Add any structured output schema if provided
+        output_format = kwargs.get("output_format")
+        if output_format:
+            schema = output_format.model_json_schema()
+            request_body["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": output_format.__name__,
+                    "schema": schema,
+                }
+            }
+
+        try:
+            response = await self._client.post(
+                f"{self._base_url}/v1/chat/completions",
+                json=request_body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                    "X-Client": "openbrowser",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            
+            # Handle structured output
+            if output_format and content:
+                try:
+                    parsed = json.loads(content)
+                    return AIMessage(content=content, additional_kwargs={"parsed": parsed})
+                except json.JSONDecodeError:
+                    pass
+
+            return AIMessage(content=content)
+
+        except httpx.HTTPStatusError as e:
+            raise ModelProviderError(
+                message=f"Browser-use API error: {e.response.text}",
+                status_code=e.response.status_code,
+                model=self._model,
+            )
+
+    def invoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Synchronously invoke the model."""
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(
+            self.ainvoke(messages, config, **kwargs)
+        )
+
+    def _generate(
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Internal generate method required by BaseChatModel."""
+        from langchain_core.outputs import ChatGeneration, ChatResult
+        result = self.invoke(messages, **kwargs)
+        return ChatResult(generations=[ChatGeneration(message=result)])
+
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+
+    # Browser-use specific methods
+
+    async def get_usage(self) -> dict[str, Any]:
+        """Get API usage statistics."""
+        try:
+            response = await self._client.get(
+                f"{self._base_url}/v1/usage",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                },
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to get usage: {e}")
+            return {}
+
+    async def get_available_models(self) -> list[str]:
+        """Get list of available models."""
+        try:
+            response = await self._client.get(
+                f"{self._base_url}/v1/models",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            return [m["id"] for m in data.get("data", [])]
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to get models: {e}")
+            return []
+

--- a/src/openbrowser/llm/cerebras/__init__.py
+++ b/src/openbrowser/llm/cerebras/__init__.py
@@ -1,0 +1,6 @@
+"""Cerebras LLM integration."""
+
+from src.openbrowser.llm.cerebras.chat import ChatCerebras
+
+__all__ = ["ChatCerebras"]
+

--- a/src/openbrowser/llm/cerebras/chat.py
+++ b/src/openbrowser/llm/cerebras/chat.py
@@ -1,0 +1,151 @@
+"""Cerebras LLM integration for fast inference."""
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import PrivateAttr
+
+from src.openbrowser.llm.exceptions import ModelProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class ChatCerebras(BaseChatModel):
+    """
+    Chat model for Cerebras fast inference.
+
+    Cerebras provides extremely fast inference for LLMs.
+    Uses OpenAI-compatible API format.
+
+    Args:
+        model: The Cerebras model to use (e.g., "llama3.1-70b", "llama3.1-8b")
+        temperature: Temperature for response generation
+        api_key: Cerebras API key (defaults to CEREBRAS_API_KEY env var)
+        max_tokens: Maximum tokens in response
+        **kwargs: Additional parameters
+    """
+
+    _model: str = PrivateAttr()
+    _temperature: float = PrivateAttr()
+    _api_key: str = PrivateAttr()
+    _max_tokens: int = PrivateAttr()
+    _client: httpx.AsyncClient = PrivateAttr()
+    _base_url: str = PrivateAttr()
+
+    def __init__(
+        self,
+        model: str = "llama3.1-70b",
+        temperature: float = 0,
+        api_key: str | None = None,
+        max_tokens: int = 4096,
+        base_url: str = "https://api.cerebras.ai/v1",
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self._model = model
+        self._temperature = temperature
+        self._api_key = api_key or os.getenv("CEREBRAS_API_KEY", "")
+        self._max_tokens = max_tokens
+        self._base_url = base_url
+        self._client = httpx.AsyncClient(timeout=120.0)
+
+        if not self._api_key:
+            raise ValueError("CEREBRAS_API_KEY is not set and no api_key provided")
+
+    @property
+    def model(self) -> str:
+        """Get the model name."""
+        return self._model
+
+    @property
+    def _llm_type(self) -> str:
+        return "cerebras"
+
+    def bind_tools(self, tools: list[Any]) -> "ChatCerebras":
+        """Bind tools to this LLM instance."""
+        logger.warning("Cerebras tool binding support may be limited")
+        return self
+
+    def with_structured_output(self, output_schema: type[Any], **kwargs: Any) -> Any:
+        """Get structured output from the model."""
+        return self
+
+    async def ainvoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the model with the given messages."""
+        from langchain_core.messages import AIMessage
+
+        # Convert messages to OpenAI format
+        formatted_messages = []
+        for msg in messages:
+            if hasattr(msg, 'type'):
+                role = 'system' if msg.type == 'system' else ('assistant' if msg.type == 'ai' else 'user')
+                formatted_messages.append({"role": role, "content": msg.content})
+            elif isinstance(msg, dict):
+                formatted_messages.append(msg)
+
+        request_body = {
+            "model": self._model,
+            "messages": formatted_messages,
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+        }
+
+        try:
+            response = await self._client.post(
+                f"{self._base_url}/chat/completions",
+                json=request_body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            return AIMessage(content=content)
+
+        except httpx.HTTPStatusError as e:
+            raise ModelProviderError(
+                message=f"Cerebras API error: {e.response.text}",
+                status_code=e.response.status_code,
+                model=self._model,
+            )
+
+    def invoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Synchronously invoke the model."""
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(
+            self.ainvoke(messages, config, **kwargs)
+        )
+
+    def _generate(
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Internal generate method required by BaseChatModel."""
+        from langchain_core.outputs import ChatGeneration, ChatResult
+        result = self.invoke(messages, **kwargs)
+        return ChatResult(generations=[ChatGeneration(message=result)])
+
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+

--- a/src/openbrowser/llm/deepseek/__init__.py
+++ b/src/openbrowser/llm/deepseek/__init__.py
@@ -1,0 +1,6 @@
+"""DeepSeek LLM integration."""
+
+from src.openbrowser.llm.deepseek.chat import ChatDeepSeek
+
+__all__ = ["ChatDeepSeek"]
+

--- a/src/openbrowser/llm/deepseek/chat.py
+++ b/src/openbrowser/llm/deepseek/chat.py
@@ -1,0 +1,166 @@
+"""DeepSeek LLM integration with reasoning support."""
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import PrivateAttr
+
+from src.openbrowser.llm.exceptions import ModelProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class ChatDeepSeek(BaseChatModel):
+    """
+    Chat model for DeepSeek with reasoning support.
+
+    DeepSeek provides models with strong reasoning capabilities.
+    Uses OpenAI-compatible API format.
+
+    Args:
+        model: The DeepSeek model to use (e.g., "deepseek-chat", "deepseek-reasoner")
+        temperature: Temperature for response generation
+        api_key: DeepSeek API key (defaults to DEEPSEEK_API_KEY env var)
+        max_tokens: Maximum tokens in response
+        **kwargs: Additional parameters
+    """
+
+    _model: str = PrivateAttr()
+    _temperature: float = PrivateAttr()
+    _api_key: str = PrivateAttr()
+    _max_tokens: int = PrivateAttr()
+    _client: httpx.AsyncClient = PrivateAttr()
+    _base_url: str = PrivateAttr()
+    _reasoning_enabled: bool = PrivateAttr()
+
+    def __init__(
+        self,
+        model: str = "deepseek-chat",
+        temperature: float = 0,
+        api_key: str | None = None,
+        max_tokens: int = 4096,
+        base_url: str = "https://api.deepseek.com/v1",
+        reasoning_enabled: bool = False,
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self._model = model
+        self._temperature = temperature
+        self._api_key = api_key or os.getenv("DEEPSEEK_API_KEY", "")
+        self._max_tokens = max_tokens
+        self._base_url = base_url
+        self._reasoning_enabled = reasoning_enabled
+        self._client = httpx.AsyncClient(timeout=120.0)
+
+        if not self._api_key:
+            raise ValueError("DEEPSEEK_API_KEY is not set and no api_key provided")
+
+    @property
+    def model(self) -> str:
+        """Get the model name."""
+        return self._model
+
+    @property
+    def _llm_type(self) -> str:
+        return "deepseek"
+
+    def bind_tools(self, tools: list[Any]) -> "ChatDeepSeek":
+        """Bind tools to this LLM instance."""
+        # DeepSeek supports function calling
+        return self
+
+    def with_structured_output(self, output_schema: type[Any], **kwargs: Any) -> Any:
+        """Get structured output from the model."""
+        return self
+
+    async def ainvoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the model with the given messages."""
+        from langchain_core.messages import AIMessage
+
+        # Convert messages to OpenAI format
+        formatted_messages = []
+        for msg in messages:
+            if hasattr(msg, 'type'):
+                role = 'system' if msg.type == 'system' else ('assistant' if msg.type == 'ai' else 'user')
+                formatted_messages.append({"role": role, "content": msg.content})
+            elif isinstance(msg, dict):
+                formatted_messages.append(msg)
+
+        request_body = {
+            "model": self._model,
+            "messages": formatted_messages,
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+        }
+
+        # Add reasoning mode if enabled
+        if self._reasoning_enabled:
+            request_body["response_format"] = {"type": "text"}
+
+        try:
+            response = await self._client.post(
+                f"{self._base_url}/chat/completions",
+                json=request_body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            choice = data.get("choices", [{}])[0]
+            message = choice.get("message", {})
+            content = message.get("content", "")
+            
+            # Extract reasoning if present
+            reasoning_content = message.get("reasoning_content", "")
+            if reasoning_content:
+                logger.debug(f"DeepSeek reasoning: {reasoning_content[:200]}...")
+
+            return AIMessage(content=content)
+
+        except httpx.HTTPStatusError as e:
+            raise ModelProviderError(
+                message=f"DeepSeek API error: {e.response.text}",
+                status_code=e.response.status_code,
+                model=self._model,
+            )
+
+    def invoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Synchronously invoke the model."""
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(
+            self.ainvoke(messages, config, **kwargs)
+        )
+
+    def _generate(
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Internal generate method required by BaseChatModel."""
+        from langchain_core.outputs import ChatGeneration, ChatResult
+        result = self.invoke(messages, **kwargs)
+        return ChatResult(generations=[ChatGeneration(message=result)])
+
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+

--- a/src/openbrowser/llm/exceptions.py
+++ b/src/openbrowser/llm/exceptions.py
@@ -1,0 +1,124 @@
+"""LLM exceptions module for handling LLM-specific errors."""
+
+
+class ModelError(Exception):
+    """Base exception for all model-related errors."""
+    pass
+
+
+class ModelProviderError(ModelError):
+    """Exception raised when a model provider returns an error."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 502,
+        model: str | None = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.model = model
+
+    def __str__(self) -> str:
+        if self.model:
+            return f"[{self.status_code}] {self.model}: {self.message}"
+        return f"[{self.status_code}] {self.message}"
+
+
+class ModelRateLimitError(ModelProviderError):
+    """Exception raised when a model provider returns a rate limit error."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 429,
+        model: str | None = None,
+        retry_after: float | None = None,
+    ):
+        super().__init__(message, status_code, model)
+        self.retry_after = retry_after
+
+
+class ModelAuthenticationError(ModelProviderError):
+    """Exception raised when authentication with a model provider fails."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 401,
+        model: str | None = None,
+    ):
+        super().__init__(message, status_code, model)
+
+
+class ModelContextLengthError(ModelProviderError):
+    """Exception raised when the context length exceeds the model's limit."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 400,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        requested_tokens: int | None = None,
+    ):
+        super().__init__(message, status_code, model)
+        self.max_tokens = max_tokens
+        self.requested_tokens = requested_tokens
+
+
+class ModelInvalidResponseError(ModelError):
+    """Exception raised when the model returns an invalid or unparseable response."""
+
+    def __init__(
+        self,
+        message: str,
+        raw_response: str | None = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.raw_response = raw_response
+
+
+class ModelTimeoutError(ModelError):
+    """Exception raised when a model request times out."""
+
+    def __init__(
+        self,
+        message: str,
+        timeout_seconds: float | None = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.timeout_seconds = timeout_seconds
+
+
+class ModelNotFoundError(ModelProviderError):
+    """Exception raised when the requested model is not found."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 404,
+        model: str | None = None,
+    ):
+        super().__init__(message, status_code, model)
+
+
+class LLMException(Exception):
+    """Generic exception for LLM interaction errors.
+    
+    This is a convenience alias for backward compatibility.
+    """
+
+    def __init__(self, message: str, status_code: int | None = None):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        if self.status_code:
+            return f"[{self.status_code}] {self.message}"
+        return self.message
+

--- a/src/openbrowser/llm/google/serializer.py
+++ b/src/openbrowser/llm/google/serializer.py
@@ -1,0 +1,246 @@
+"""Google (Gemini) message serializer."""
+
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.agent.views import (
+    AssistantMessage,
+    BaseMessage,
+    ContentPartImageParam,
+    ContentPartTextParam,
+    SystemMessage,
+    UserMessage,
+)
+from src.openbrowser.llm.serializer import BaseMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class GoogleMessageSerializer(BaseMessageSerializer):
+    """Serializer for converting messages to Google Gemini format."""
+
+    def serialize(self, message: BaseMessage) -> dict[str, Any]:
+        """Serialize a message to Google Gemini format."""
+        if isinstance(message, UserMessage):
+            return {
+                'role': 'user',
+                'parts': self._serialize_user_parts(message.content),
+            }
+
+        elif isinstance(message, SystemMessage):
+            # Google handles system messages as system_instruction
+            # Return as user message for compatibility in messages array
+            return {
+                'role': 'user',
+                'parts': [{'text': self._get_text_content(message.content)}],
+            }
+
+        elif isinstance(message, AssistantMessage):
+            parts = []
+            if message.content is not None:
+                parts = self._serialize_assistant_parts(message.content)
+            
+            if message.tool_calls:
+                for tc in message.tool_calls:
+                    parts.append({
+                        'functionCall': {
+                            'name': tc.function.name,
+                            'args': json.loads(tc.function.arguments) if tc.function.arguments else {},
+                        }
+                    })
+            
+            return {'role': 'model', 'parts': parts}
+
+        else:
+            raise ValueError(f'Unknown message type: {type(message)}')
+
+    def _serialize_user_parts(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartImageParam],
+    ) -> list[dict[str, Any]]:
+        """Serialize user content to Google parts format."""
+        if isinstance(content, str):
+            return [{'text': content}]
+
+        parts = []
+        for part in content:
+            if part.type == 'text':
+                parts.append({'text': part.text})
+            elif part.type == 'image_url':
+                parts.append({
+                    'inlineData': {
+                        'mimeType': self._get_mime_type(part.image_url.url),
+                        'data': self._extract_base64(part.image_url.url),
+                    }
+                })
+        return parts
+
+    def _serialize_assistant_parts(
+        self,
+        content: str | list,
+    ) -> list[dict[str, Any]]:
+        """Serialize assistant content to Google parts format."""
+        if isinstance(content, str):
+            return [{'text': content}]
+
+        parts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                parts.append({'text': part.text})
+        return parts
+
+    def _get_text_content(self, content: str | list) -> str:
+        """Extract text from content."""
+        if isinstance(content, str):
+            return content
+        
+        texts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                texts.append(part.text)
+        return '\n'.join(texts)
+
+    def _get_mime_type(self, url: str) -> str:
+        """Get MIME type from URL."""
+        if url.startswith('data:'):
+            parts = url.split(';')[0].split(':')
+            if len(parts) > 1:
+                return parts[1]
+        elif url.lower().endswith('.png'):
+            return 'image/png'
+        elif url.lower().endswith(('.jpg', '.jpeg')):
+            return 'image/jpeg'
+        elif url.lower().endswith('.gif'):
+            return 'image/gif'
+        elif url.lower().endswith('.webp'):
+            return 'image/webp'
+        return 'image/jpeg'
+
+    def _extract_base64(self, data_url: str) -> str:
+        """Extract base64 data from data URL."""
+        if ',' in data_url:
+            return data_url.split(',', 1)[1]
+        return data_url
+
+    def extract_system_instruction(
+        self,
+        messages: list[BaseMessage],
+    ) -> tuple[str | None, list[BaseMessage]]:
+        """Extract system instruction from message list.
+        
+        Google uses system_instruction parameter.
+        
+        Returns:
+            Tuple of (system_instruction, remaining_messages)
+        """
+        system_instruction = None
+        remaining = []
+
+        for msg in messages:
+            if isinstance(msg, SystemMessage) and system_instruction is None:
+                system_instruction = self._get_text_content(msg.content)
+            else:
+                remaining.append(msg)
+
+        return system_instruction, remaining
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to Google function declaration format."""
+        schema = output_format.model_json_schema()
+        
+        # Remove $defs and resolve references
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        # Google uses different schema format
+        return {
+            "name": output_format.__name__,
+            "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+            "parameters": self._convert_to_google_schema(schema),
+        }
+
+    def _convert_to_google_schema(self, schema: dict) -> dict:
+        """Convert JSON Schema to Google's schema format."""
+        result = {}
+        
+        if 'type' in schema:
+            result['type'] = schema['type'].upper()
+        
+        if 'properties' in schema:
+            result['properties'] = {
+                k: self._convert_to_google_schema(v)
+                for k, v in schema['properties'].items()
+            }
+        
+        if 'required' in schema:
+            result['required'] = schema['required']
+        
+        if 'items' in schema:
+            result['items'] = self._convert_to_google_schema(schema['items'])
+        
+        if 'description' in schema:
+            result['description'] = schema['description']
+        
+        if 'enum' in schema:
+            result['enum'] = schema['enum']
+        
+        return result
+
+    def _resolve_refs(self, obj: Any, defs: dict) -> Any:
+        """Recursively resolve $ref references in schema."""
+        if isinstance(obj, dict):
+            if '$ref' in obj:
+                ref_path = obj['$ref'].split('/')[-1]
+                if ref_path in defs:
+                    return self._resolve_refs(defs[ref_path], defs)
+            return {k: self._resolve_refs(v, defs) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._resolve_refs(item, defs) for item in obj]
+        return obj
+
+    def parse_tool_call_response(
+        self,
+        response: dict[str, Any],
+        output_format: type[T],
+    ) -> T:
+        """Parse a Google function call response into a Pydantic model."""
+        candidates = response.get('candidates', [])
+        if not candidates:
+            raise ValueError("No candidates in response")
+
+        content = candidates[0].get('content', {})
+        parts = content.get('parts', [])
+
+        for part in parts:
+            if 'functionCall' in part:
+                data = part['functionCall'].get('args', {})
+                return output_format.model_validate(data)
+
+        raise ValueError("No function call in response")
+
+    def parse_content_response(self, response: dict[str, Any]) -> str:
+        """Parse plain text content from Google response."""
+        candidates = response.get('candidates', [])
+        if not candidates:
+            return ""
+        
+        content = candidates[0].get('content', {})
+        parts = content.get('parts', [])
+        texts = []
+        
+        for part in parts:
+            if 'text' in part:
+                texts.append(part['text'])
+        
+        return '\n'.join(texts)
+
+
+# Singleton instance
+google_serializer = GoogleMessageSerializer()
+

--- a/src/openbrowser/llm/groq/__init__.py
+++ b/src/openbrowser/llm/groq/__init__.py
@@ -1,0 +1,6 @@
+"""Groq LLM integration."""
+
+from .chat import ChatGroq
+
+__all__ = ["ChatGroq"]
+

--- a/src/openbrowser/llm/groq/chat.py
+++ b/src/openbrowser/llm/groq/chat.py
@@ -1,0 +1,172 @@
+"""Groq chat model wrapper for fast inference."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Type, TypeVar
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ChatGroq(BaseChatModel):
+    """
+    LangChain-compatible wrapper for Groq API.
+    Requires: pip install groq
+    """
+
+    model_name: str = Field(default="llama-3.3-70b-versatile", alias="model")
+    temperature: float = Field(default=0.0)
+    max_tokens: int = Field(default=4096)
+    api_key: Optional[str] = Field(default=None)
+    timeout: float = Field(default=60.0)
+
+    _client: Any = PrivateAttr(default=None)
+    _bound_tools: List[Any] = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._bound_tools = []
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize Groq client."""
+        try:
+            from groq import AsyncGroq
+        except ImportError:
+            raise ImportError("Please install groq: pip install groq")
+
+        api_key = self.api_key or os.environ.get("GROQ_API_KEY")
+        if not api_key:
+            raise ValueError("GROQ_API_KEY not set")
+
+        self._client = AsyncGroq(api_key=api_key, timeout=self.timeout)
+
+    @property
+    def _llm_type(self) -> str:
+        return "groq"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "temperature": self.temperature}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        raise NotImplementedError("Use ainvoke for async generation")
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation with Groq API."""
+        openai_messages = self._convert_messages(messages)
+
+        request_params = {
+            "model": self.model_name,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": openai_messages,
+        }
+
+        if self._bound_tools:
+            request_params["tools"] = self._bound_tools
+
+        if stop:
+            request_params["stop"] = stop
+
+        response = await self._client.chat.completions.create(**request_params)
+
+        choice = response.choices[0]
+        content = choice.message.content or ""
+        tool_calls = []
+
+        if choice.message.tool_calls:
+            for tc in choice.message.tool_calls:
+                tool_calls.append({
+                    "id": tc.id,
+                    "name": tc.function.name,
+                    "args": tc.function.arguments,
+                })
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _convert_messages(self, messages: List[BaseMessage]) -> List[dict]:
+        """Convert LangChain messages to OpenAI format."""
+        result = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                result.append({"role": "system", "content": msg.content})
+            elif isinstance(msg, HumanMessage):
+                result.append({"role": "user", "content": msg.content})
+            elif isinstance(msg, AIMessage):
+                result.append({"role": "assistant", "content": msg.content})
+        return result
+
+    def bind_tools(self, tools: List[Any], **kwargs: Any) -> ChatGroq:
+        """Bind tools for function calling."""
+        new_instance = ChatGroq(
+            model=self.model_name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            api_key=self.api_key,
+        )
+        new_instance._bound_tools = self._convert_tools(tools)
+        return new_instance
+
+    def _convert_tools(self, tools: List[Any]) -> List[dict]:
+        """Convert tools to OpenAI format."""
+        openai_tools = []
+        for tool in tools:
+            if hasattr(tool, "name") and hasattr(tool, "description"):
+                schema = {}
+                if hasattr(tool, "args_schema"):
+                    schema = tool.args_schema.model_json_schema()
+                openai_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": schema,
+                    },
+                })
+            elif isinstance(tool, dict):
+                openai_tools.append(tool)
+        return openai_tools
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> ChatGroq:
+        """Configure for structured output."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": schema.__name__,
+                "description": f"Output structured data as {schema.__name__}",
+                "parameters": schema.model_json_schema(),
+            },
+        }
+        return self.bind_tools([tool])
+

--- a/src/openbrowser/llm/groq/serializer.py
+++ b/src/openbrowser/llm/groq/serializer.py
@@ -1,0 +1,50 @@
+"""Groq message serializer.
+
+Groq uses OpenAI-compatible API format, so we inherit from OpenAI serializer.
+"""
+
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.llm.openai.serializer import OpenAIMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class GroqMessageSerializer(OpenAIMessageSerializer):
+    """Serializer for converting messages to Groq format.
+    
+    Groq uses OpenAI-compatible format with some limitations:
+    - Some models may not support function calling
+    - Image support varies by model
+    """
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to Groq function calling format.
+        
+        Note: Not all Groq models support function calling.
+        """
+        schema = output_format.model_json_schema()
+        
+        # Remove $defs and resolve references
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "type": "function",
+            "function": {
+                "name": output_format.__name__,
+                "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+                "parameters": schema,
+            }
+        }
+
+
+# Singleton instance
+groq_serializer = GroqMessageSerializer()
+

--- a/src/openbrowser/llm/oci/__init__.py
+++ b/src/openbrowser/llm/oci/__init__.py
@@ -1,0 +1,6 @@
+"""OCI (Oracle Cloud Infrastructure) GenAI LLM integration."""
+
+from src.openbrowser.llm.oci.chat import ChatOCI
+
+__all__ = ["ChatOCI"]
+

--- a/src/openbrowser/llm/oci/chat.py
+++ b/src/openbrowser/llm/oci/chat.py
@@ -1,0 +1,198 @@
+"""OCI (Oracle Cloud Infrastructure) GenAI LLM integration."""
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import PrivateAttr
+
+from src.openbrowser.llm.exceptions import ModelProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class ChatOCI(BaseChatModel):
+    """
+    Chat model for Oracle Cloud Infrastructure GenAI.
+
+    This class provides integration with OCI's generative AI service.
+
+    Args:
+        model: The OCI model to use
+        compartment_id: OCI compartment ID
+        endpoint: OCI GenAI endpoint URL
+        temperature: Temperature for response generation
+        max_tokens: Maximum tokens in response
+        **kwargs: Additional parameters
+    """
+
+    _model: str = PrivateAttr()
+    _compartment_id: str = PrivateAttr()
+    _endpoint: str = PrivateAttr()
+    _temperature: float = PrivateAttr()
+    _max_tokens: int = PrivateAttr()
+    _client: httpx.AsyncClient = PrivateAttr()
+    _config_profile: str = PrivateAttr()
+
+    def __init__(
+        self,
+        model: str = "cohere.command-r-plus",
+        compartment_id: str | None = None,
+        endpoint: str | None = None,
+        temperature: float = 0,
+        max_tokens: int = 4096,
+        config_profile: str = "DEFAULT",
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self._model = model
+        self._compartment_id = compartment_id or os.getenv("OCI_COMPARTMENT_ID", "")
+        self._endpoint = endpoint or os.getenv(
+            "OCI_GENAI_ENDPOINT",
+            "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+        )
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._config_profile = config_profile
+        self._client = httpx.AsyncClient(timeout=120.0)
+
+        if not self._compartment_id:
+            raise ValueError("OCI_COMPARTMENT_ID is not set and no compartment_id provided")
+
+    @property
+    def model(self) -> str:
+        """Get the model name."""
+        return self._model
+
+    @property
+    def _llm_type(self) -> str:
+        return "oci"
+
+    def _get_auth_header(self) -> dict[str, str]:
+        """Get OCI authentication headers.
+        
+        This uses OCI's SDK for authentication if available,
+        otherwise falls back to API key.
+        """
+        try:
+            import oci
+            config = oci.config.from_file(profile_name=self._config_profile)
+            signer = oci.signer.Signer(
+                tenancy=config["tenancy"],
+                user=config["user"],
+                fingerprint=config["fingerprint"],
+                private_key_file_location=config["key_file"],
+            )
+            # For simplicity, we'll use a static token approach
+            # In production, you'd use the full OCI SDK signer
+            return {}
+        except ImportError:
+            api_key = os.getenv("OCI_API_KEY", "")
+            if api_key:
+                return {"Authorization": f"Bearer {api_key}"}
+            return {}
+
+    def bind_tools(self, tools: list[Any]) -> "ChatOCI":
+        """Bind tools to this LLM instance."""
+        # OCI doesn't support function calling in the same way
+        logger.warning("OCI does not support tool binding in the same way as OpenAI")
+        return self
+
+    def with_structured_output(self, output_schema: type[Any], **kwargs: Any) -> Any:
+        """Get structured output from the model."""
+        # Return self with schema stored for later use
+        return self
+
+    async def ainvoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the model with the given messages."""
+        from langchain_core.messages import AIMessage
+
+        # Convert messages to OCI format
+        chat_history = []
+        system_message = None
+        
+        for msg in messages:
+            if hasattr(msg, 'type'):
+                if msg.type == 'system':
+                    system_message = msg.content
+                elif msg.type == 'human':
+                    chat_history.append({"role": "USER", "message": msg.content})
+                elif msg.type == 'ai':
+                    chat_history.append({"role": "CHATBOT", "message": msg.content})
+
+        request_body = {
+            "compartmentId": self._compartment_id,
+            "servingMode": {
+                "servingType": "ON_DEMAND",
+                "modelId": self._model,
+            },
+            "chatRequest": {
+                "apiFormat": "COHERE",
+                "message": chat_history[-1]["message"] if chat_history else "",
+                "chatHistory": chat_history[:-1] if len(chat_history) > 1 else [],
+                "maxTokens": self._max_tokens,
+                "temperature": self._temperature,
+            }
+        }
+
+        if system_message:
+            request_body["chatRequest"]["preambleOverride"] = system_message
+
+        try:
+            response = await self._client.post(
+                f"{self._endpoint}/20231130/actions/chat",
+                json=request_body,
+                headers={
+                    "Content-Type": "application/json",
+                    **self._get_auth_header(),
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            
+            text = data.get("chatResponse", {}).get("text", "")
+            return AIMessage(content=text)
+
+        except httpx.HTTPStatusError as e:
+            raise ModelProviderError(
+                message=f"OCI API error: {e.response.text}",
+                status_code=e.response.status_code,
+                model=self._model,
+            )
+
+    def invoke(
+        self,
+        messages: list[Any],
+        config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Synchronously invoke the model."""
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(
+            self.ainvoke(messages, config, **kwargs)
+        )
+
+    def _generate(
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Internal generate method required by BaseChatModel."""
+        from langchain_core.outputs import ChatGeneration, ChatResult
+        result = self.invoke(messages, **kwargs)
+        return ChatResult(generations=[ChatGeneration(message=result)])
+
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+

--- a/src/openbrowser/llm/ollama/__init__.py
+++ b/src/openbrowser/llm/ollama/__init__.py
@@ -1,0 +1,6 @@
+"""Ollama LLM integration for local models."""
+
+from .chat import ChatOllama
+
+__all__ = ["ChatOllama"]
+

--- a/src/openbrowser/llm/ollama/chat.py
+++ b/src/openbrowser/llm/ollama/chat.py
@@ -1,0 +1,182 @@
+"""Ollama chat model wrapper for local models."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Type, TypeVar
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ChatOllama(BaseChatModel):
+    """
+    LangChain-compatible wrapper for Ollama local models.
+    Requires: pip install ollama
+    """
+
+    model_name: str = Field(default="llama3.2", alias="model")
+    temperature: float = Field(default=0.0)
+    base_url: str = Field(default="http://localhost:11434")
+    timeout: float = Field(default=120.0)
+
+    _client: Any = PrivateAttr(default=None)
+    _bound_tools: List[Any] = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._bound_tools = []
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize Ollama client."""
+        try:
+            from ollama import AsyncClient
+        except ImportError:
+            raise ImportError("Please install ollama: pip install ollama")
+
+        self._client = AsyncClient(host=self.base_url, timeout=self.timeout)
+
+    @property
+    def _llm_type(self) -> str:
+        return "ollama"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "temperature": self.temperature}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        raise NotImplementedError("Use ainvoke for async generation")
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation with Ollama API."""
+        ollama_messages = self._convert_messages(messages)
+
+        options = {"temperature": self.temperature}
+        if stop:
+            options["stop"] = stop
+
+        response = await self._client.chat(
+            model=self.model_name,
+            messages=ollama_messages,
+            options=options,
+            tools=self._bound_tools if self._bound_tools else None,
+        )
+
+        content = response.get("message", {}).get("content", "")
+        tool_calls = []
+
+        if response.get("message", {}).get("tool_calls"):
+            for tc in response["message"]["tool_calls"]:
+                tool_calls.append({
+                    "id": tc.get("id", ""),
+                    "name": tc.get("function", {}).get("name", ""),
+                    "args": tc.get("function", {}).get("arguments", {}),
+                })
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _convert_messages(self, messages: List[BaseMessage]) -> List[dict]:
+        """Convert LangChain messages to Ollama format."""
+        result = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                result.append({"role": "system", "content": msg.content})
+            elif isinstance(msg, HumanMessage):
+                content = msg.content
+                if isinstance(content, list):
+                    # Handle multimodal - Ollama expects images separately
+                    text_parts = []
+                    images = []
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                text_parts.append(item["text"])
+                            elif item.get("type") == "image_url":
+                                image_url = item.get("image_url", {}).get("url", "")
+                                if image_url.startswith("data:image"):
+                                    base64_data = image_url.split(",")[1]
+                                    images.append(base64_data)
+                        else:
+                            text_parts.append(str(item))
+                    msg_dict = {"role": "user", "content": " ".join(text_parts)}
+                    if images:
+                        msg_dict["images"] = images
+                    result.append(msg_dict)
+                else:
+                    result.append({"role": "user", "content": content})
+            elif isinstance(msg, AIMessage):
+                result.append({"role": "assistant", "content": msg.content})
+        return result
+
+    def bind_tools(self, tools: List[Any], **kwargs: Any) -> ChatOllama:
+        """Bind tools for function calling."""
+        new_instance = ChatOllama(
+            model=self.model_name,
+            temperature=self.temperature,
+            base_url=self.base_url,
+        )
+        new_instance._bound_tools = self._convert_tools(tools)
+        return new_instance
+
+    def _convert_tools(self, tools: List[Any]) -> List[dict]:
+        """Convert tools to Ollama format."""
+        ollama_tools = []
+        for tool in tools:
+            if hasattr(tool, "name") and hasattr(tool, "description"):
+                schema = {}
+                if hasattr(tool, "args_schema"):
+                    schema = tool.args_schema.model_json_schema()
+                ollama_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": schema,
+                    },
+                })
+            elif isinstance(tool, dict):
+                ollama_tools.append(tool)
+        return ollama_tools
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> ChatOllama:
+        """Configure for structured output."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": schema.__name__,
+                "description": f"Output structured data as {schema.__name__}",
+                "parameters": schema.model_json_schema(),
+            },
+        }
+        return self.bind_tools([tool])
+

--- a/src/openbrowser/llm/ollama/serializer.py
+++ b/src/openbrowser/llm/ollama/serializer.py
@@ -1,0 +1,186 @@
+"""Ollama message serializer.
+
+Ollama uses OpenAI-compatible API format.
+"""
+
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.agent.views import (
+    AssistantMessage,
+    BaseMessage,
+    ContentPartImageParam,
+    ContentPartTextParam,
+    SystemMessage,
+    UserMessage,
+)
+from src.openbrowser.llm.serializer import BaseMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class OllamaMessageSerializer(BaseMessageSerializer):
+    """Serializer for converting messages to Ollama format.
+    
+    Ollama supports both its native format and OpenAI-compatible format.
+    This serializer uses the native Ollama format for better compatibility.
+    """
+
+    def serialize(self, message: BaseMessage) -> dict[str, Any]:
+        """Serialize a message to Ollama format."""
+        if isinstance(message, UserMessage):
+            result = {
+                'role': 'user',
+                'content': self._get_text_content(message.content),
+            }
+            # Add images if present
+            images = self._extract_images(message.content)
+            if images:
+                result['images'] = images
+            return result
+
+        elif isinstance(message, SystemMessage):
+            return {
+                'role': 'system',
+                'content': self._get_text_content(message.content),
+            }
+
+        elif isinstance(message, AssistantMessage):
+            result = {'role': 'assistant'}
+            
+            if message.content is not None:
+                result['content'] = self._get_text_content(message.content)
+            
+            if message.tool_calls:
+                result['tool_calls'] = [
+                    {
+                        'function': {
+                            'name': tc.function.name,
+                            'arguments': json.loads(tc.function.arguments) if tc.function.arguments else {},
+                        }
+                    }
+                    for tc in message.tool_calls
+                ]
+            
+            return result
+
+        else:
+            raise ValueError(f'Unknown message type: {type(message)}')
+
+    def _get_text_content(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartImageParam] | None,
+    ) -> str:
+        """Extract text from content."""
+        if content is None:
+            return ''
+        if isinstance(content, str):
+            return content
+        
+        texts = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'text':
+                texts.append(part.text)
+        return '\n'.join(texts)
+
+    def _extract_images(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartImageParam],
+    ) -> list[str]:
+        """Extract base64 images from content."""
+        if isinstance(content, str):
+            return []
+        
+        images = []
+        for part in content:
+            if hasattr(part, 'type') and part.type == 'image_url':
+                url = part.image_url.url
+                # Ollama expects raw base64 without data URL prefix
+                if url.startswith('data:'):
+                    if ',' in url:
+                        images.append(url.split(',', 1)[1])
+                else:
+                    images.append(url)
+        return images
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to Ollama tool format."""
+        schema = output_format.model_json_schema()
+        
+        # Remove $defs and resolve references
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "type": "function",
+            "function": {
+                "name": output_format.__name__,
+                "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+                "parameters": schema,
+            }
+        }
+
+    def _resolve_refs(self, obj: Any, defs: dict) -> Any:
+        """Recursively resolve $ref references in schema."""
+        if isinstance(obj, dict):
+            if '$ref' in obj:
+                ref_path = obj['$ref'].split('/')[-1]
+                if ref_path in defs:
+                    return self._resolve_refs(defs[ref_path], defs)
+            return {k: self._resolve_refs(v, defs) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._resolve_refs(item, defs) for item in obj]
+        return obj
+
+    def get_format_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Get the format parameter for Ollama structured output.
+        
+        Ollama supports a 'format' parameter for JSON output.
+        """
+        schema = output_format.model_json_schema()
+        
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return schema
+
+    def parse_tool_call_response(
+        self,
+        response: dict[str, Any],
+        output_format: type[T],
+    ) -> T:
+        """Parse an Ollama response into a Pydantic model."""
+        message = response.get('message', {})
+        tool_calls = message.get('tool_calls', [])
+
+        if tool_calls:
+            args = tool_calls[0].get('function', {}).get('arguments', {})
+            return output_format.model_validate(args)
+
+        # Try to parse content as JSON
+        content = message.get('content', '')
+        if content:
+            try:
+                data = json.loads(content)
+                return output_format.model_validate(data)
+            except json.JSONDecodeError:
+                pass
+
+        raise ValueError("No tool calls or valid JSON in response")
+
+    def parse_content_response(self, response: dict[str, Any]) -> str:
+        """Parse plain text content from Ollama response."""
+        message = response.get('message', {})
+        return message.get('content', '')
+
+
+# Singleton instance
+ollama_serializer = OllamaMessageSerializer()
+

--- a/src/openbrowser/llm/openai/serializer.py
+++ b/src/openbrowser/llm/openai/serializer.py
@@ -1,0 +1,158 @@
+"""OpenAI message serializer."""
+
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.agent.views import (
+    AssistantMessage,
+    BaseMessage,
+    SystemMessage,
+    UserMessage,
+)
+from src.openbrowser.llm.serializer import BaseMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class OpenAIMessageSerializer(BaseMessageSerializer):
+    """Serializer for converting messages to OpenAI format."""
+
+    def serialize(self, message: BaseMessage) -> dict[str, Any]:
+        """Serialize a message to OpenAI format."""
+        if isinstance(message, UserMessage):
+            result = {
+                'role': 'user',
+                'content': self.serialize_user_content(message.content),
+            }
+            if message.name is not None:
+                result['name'] = message.name
+            return result
+
+        elif isinstance(message, SystemMessage):
+            result = {
+                'role': 'system',
+                'content': self.serialize_system_content(message.content),
+            }
+            if message.name is not None:
+                result['name'] = message.name
+            return result
+
+        elif isinstance(message, AssistantMessage):
+            content = None
+            if message.content is not None:
+                content = self.serialize_assistant_content(message.content)
+
+            result = {'role': 'assistant'}
+
+            if content is not None:
+                result['content'] = content
+            if message.name is not None:
+                result['name'] = message.name
+            if message.refusal is not None:
+                result['refusal'] = message.refusal
+            if message.tool_calls:
+                result['tool_calls'] = [
+                    self.serialize_tool_call(tc) for tc in message.tool_calls
+                ]
+            return result
+
+        else:
+            raise ValueError(f'Unknown message type: {type(message)}')
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to OpenAI function calling format."""
+        schema = output_format.model_json_schema()
+        
+        # Remove definitions key if present and inline them
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "type": "function",
+            "function": {
+                "name": output_format.__name__,
+                "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+                "strict": True,
+                "parameters": schema,
+            }
+        }
+
+    def _resolve_refs(self, obj: Any, defs: dict) -> Any:
+        """Recursively resolve $ref references in schema."""
+        if isinstance(obj, dict):
+            if '$ref' in obj:
+                ref_path = obj['$ref'].split('/')[-1]
+                if ref_path in defs:
+                    return self._resolve_refs(defs[ref_path], defs)
+            return {k: self._resolve_refs(v, defs) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._resolve_refs(item, defs) for item in obj]
+        return obj
+
+    def get_response_format(self, output_format: type[T]) -> dict[str, Any]:
+        """Get response_format parameter for structured output.
+        
+        OpenAI supports json_schema response format for guaranteed JSON output.
+        """
+        schema = output_format.model_json_schema()
+        
+        # Remove definitions and resolve refs
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": output_format.__name__,
+                "strict": True,
+                "schema": schema,
+            }
+        }
+
+    def parse_tool_call_response(
+        self,
+        response: dict[str, Any],
+        output_format: type[T],
+    ) -> T:
+        """Parse an OpenAI tool call response into a Pydantic model."""
+        choices = response.get('choices', [])
+        if not choices:
+            raise ValueError("No choices in response")
+
+        message = choices[0].get('message', {})
+        tool_calls = message.get('tool_calls', [])
+
+        if tool_calls:
+            # Parse from tool call arguments
+            arguments = tool_calls[0].get('function', {}).get('arguments', '{}')
+            data = json.loads(arguments)
+            return output_format.model_validate(data)
+
+        # Parse from content if using response_format
+        content = message.get('content', '')
+        if content:
+            data = json.loads(content)
+            return output_format.model_validate(data)
+
+        raise ValueError("No tool calls or content in response")
+
+    def parse_content_response(self, response: dict[str, Any]) -> str:
+        """Parse plain text content from OpenAI response."""
+        choices = response.get('choices', [])
+        if not choices:
+            return ""
+        
+        message = choices[0].get('message', {})
+        return message.get('content', '') or ""
+
+
+# Singleton instance for convenience
+openai_serializer = OpenAIMessageSerializer()
+

--- a/src/openbrowser/llm/openrouter/__init__.py
+++ b/src/openbrowser/llm/openrouter/__init__.py
@@ -1,0 +1,6 @@
+"""OpenRouter LLM integration for multi-provider gateway."""
+
+from .chat import ChatOpenRouter
+
+__all__ = ["ChatOpenRouter"]
+

--- a/src/openbrowser/llm/openrouter/chat.py
+++ b/src/openbrowser/llm/openrouter/chat.py
@@ -1,0 +1,205 @@
+"""OpenRouter chat model wrapper for multi-provider gateway."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Type, TypeVar
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class ChatOpenRouter(BaseChatModel):
+    """
+    LangChain-compatible wrapper for OpenRouter API.
+    OpenRouter provides access to multiple LLM providers through a single API.
+    Uses OpenAI-compatible format.
+    """
+
+    model_name: str = Field(default="anthropic/claude-3.5-sonnet", alias="model")
+    temperature: float = Field(default=0.0)
+    max_tokens: int = Field(default=4096)
+    api_key: Optional[str] = Field(default=None)
+    timeout: float = Field(default=120.0)
+    site_url: Optional[str] = Field(default=None)
+    site_name: Optional[str] = Field(default=None)
+
+    _client: Any = PrivateAttr(default=None)
+    _bound_tools: List[Any] = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._bound_tools = []
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize OpenRouter client using OpenAI SDK."""
+        try:
+            from openai import AsyncOpenAI
+        except ImportError:
+            raise ImportError("Please install openai: pip install openai")
+
+        api_key = self.api_key or os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY not set")
+
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=OPENROUTER_BASE_URL,
+            timeout=self.timeout,
+        )
+
+    @property
+    def _llm_type(self) -> str:
+        return "openrouter"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "temperature": self.temperature}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        raise NotImplementedError("Use ainvoke for async generation")
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Async generation with OpenRouter API."""
+        openai_messages = self._convert_messages(messages)
+
+        extra_headers = {}
+        if self.site_url:
+            extra_headers["HTTP-Referer"] = self.site_url
+        if self.site_name:
+            extra_headers["X-Title"] = self.site_name
+
+        request_params = {
+            "model": self.model_name,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": openai_messages,
+        }
+
+        if self._bound_tools:
+            request_params["tools"] = self._bound_tools
+
+        if stop:
+            request_params["stop"] = stop
+
+        if extra_headers:
+            request_params["extra_headers"] = extra_headers
+
+        response = await self._client.chat.completions.create(**request_params)
+
+        choice = response.choices[0]
+        content = choice.message.content or ""
+        tool_calls = []
+
+        if choice.message.tool_calls:
+            for tc in choice.message.tool_calls:
+                tool_calls.append({
+                    "id": tc.id,
+                    "name": tc.function.name,
+                    "args": tc.function.arguments,
+                })
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _convert_messages(self, messages: List[BaseMessage]) -> List[dict]:
+        """Convert LangChain messages to OpenAI format."""
+        result = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                result.append({"role": "system", "content": msg.content})
+            elif isinstance(msg, HumanMessage):
+                content = msg.content
+                if isinstance(content, list):
+                    openai_content = []
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                openai_content.append({"type": "text", "text": item["text"]})
+                            elif item.get("type") == "image_url":
+                                openai_content.append(item)
+                        else:
+                            openai_content.append({"type": "text", "text": str(item)})
+                    result.append({"role": "user", "content": openai_content})
+                else:
+                    result.append({"role": "user", "content": content})
+            elif isinstance(msg, AIMessage):
+                result.append({"role": "assistant", "content": msg.content})
+        return result
+
+    def bind_tools(self, tools: List[Any], **kwargs: Any) -> ChatOpenRouter:
+        """Bind tools for function calling."""
+        new_instance = ChatOpenRouter(
+            model=self.model_name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            api_key=self.api_key,
+            site_url=self.site_url,
+            site_name=self.site_name,
+        )
+        new_instance._bound_tools = self._convert_tools(tools)
+        return new_instance
+
+    def _convert_tools(self, tools: List[Any]) -> List[dict]:
+        """Convert tools to OpenAI format."""
+        openai_tools = []
+        for tool in tools:
+            if hasattr(tool, "name") and hasattr(tool, "description"):
+                schema = {}
+                if hasattr(tool, "args_schema"):
+                    schema = tool.args_schema.model_json_schema()
+                openai_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": schema,
+                    },
+                })
+            elif isinstance(tool, dict):
+                openai_tools.append(tool)
+        return openai_tools
+
+    def with_structured_output(
+        self,
+        schema: Type[T],
+        **kwargs: Any,
+    ) -> ChatOpenRouter:
+        """Configure for structured output."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": schema.__name__,
+                "description": f"Output structured data as {schema.__name__}",
+                "parameters": schema.model_json_schema(),
+            },
+        }
+        return self.bind_tools([tool])
+

--- a/src/openbrowser/llm/openrouter/serializer.py
+++ b/src/openbrowser/llm/openrouter/serializer.py
@@ -1,0 +1,59 @@
+"""OpenRouter message serializer.
+
+OpenRouter uses OpenAI-compatible API format.
+"""
+
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.llm.openai.serializer import OpenAIMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class OpenRouterMessageSerializer(OpenAIMessageSerializer):
+    """Serializer for converting messages to OpenRouter format.
+    
+    OpenRouter uses OpenAI-compatible format and routes to various models.
+    Some models may have different capabilities for function calling and images.
+    """
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to OpenRouter function calling format.
+        
+        Note: Function calling support varies by model on OpenRouter.
+        """
+        schema = output_format.model_json_schema()
+        
+        # Remove $defs and resolve references
+        if '$defs' in schema:
+            defs = schema.pop('$defs')
+            schema = self._resolve_refs(schema, defs)
+        
+        return {
+            "type": "function",
+            "function": {
+                "name": output_format.__name__,
+                "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+                "parameters": schema,
+            }
+        }
+
+    def get_provider_preferences(self) -> dict[str, Any]:
+        """Get OpenRouter-specific provider preferences.
+        
+        Can be used to specify provider routing preferences.
+        """
+        return {
+            "allow_fallbacks": True,
+            "require_parameters": False,
+        }
+
+
+# Singleton instance
+openrouter_serializer = OpenRouterMessageSerializer()
+

--- a/src/openbrowser/llm/serializer.py
+++ b/src/openbrowser/llm/serializer.py
@@ -1,0 +1,172 @@
+"""Base serializer for LLM message handling."""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from src.openbrowser.agent.views import (
+    AssistantMessage,
+    BaseMessage,
+    ContentPartImageParam,
+    ContentPartRefusalParam,
+    ContentPartTextParam,
+    SystemMessage,
+    ToolCall,
+    UserMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+class BaseMessageSerializer(ABC):
+    """Base class for LLM message serializers.
+    
+    Each LLM provider has different message formats. This base class defines
+    the interface for serializing messages to provider-specific formats.
+    """
+
+    @abstractmethod
+    def serialize(self, message: BaseMessage) -> dict[str, Any]:
+        """Serialize a single message to provider-specific format.
+        
+        Args:
+            message: Message to serialize
+            
+        Returns:
+            Provider-specific message dict
+        """
+        pass
+
+    def serialize_messages(self, messages: list[BaseMessage]) -> list[dict[str, Any]]:
+        """Serialize a list of messages.
+        
+        Args:
+            messages: Messages to serialize
+            
+        Returns:
+            List of provider-specific message dicts
+        """
+        return [self.serialize(m) for m in messages]
+
+    def serialize_tool_schema(self, output_format: type[T]) -> dict[str, Any]:
+        """Serialize a Pydantic model to a tool/function schema.
+        
+        Args:
+            output_format: Pydantic model class
+            
+        Returns:
+            Tool schema dict
+        """
+        schema = output_format.model_json_schema()
+        return {
+            "type": "function",
+            "function": {
+                "name": output_format.__name__,
+                "description": output_format.__doc__ or f"Generate {output_format.__name__}",
+                "parameters": schema,
+            }
+        }
+
+    @staticmethod
+    def serialize_content_part_text(part: ContentPartTextParam) -> dict[str, Any]:
+        """Serialize a text content part."""
+        return {"type": "text", "text": part.text}
+
+    @staticmethod
+    def serialize_content_part_image(part: ContentPartImageParam) -> dict[str, Any]:
+        """Serialize an image content part."""
+        return {
+            "type": "image_url",
+            "image_url": {
+                "url": part.image_url.url,
+                "detail": part.image_url.detail,
+            }
+        }
+
+    @staticmethod
+    def serialize_content_part_refusal(part: ContentPartRefusalParam) -> dict[str, Any]:
+        """Serialize a refusal content part."""
+        return {"type": "refusal", "refusal": part.refusal}
+
+    def serialize_user_content(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartImageParam],
+    ) -> str | list[dict[str, Any]]:
+        """Serialize content for user messages."""
+        if isinstance(content, str):
+            return content
+
+        parts = []
+        for part in content:
+            if part.type == 'text':
+                parts.append(self.serialize_content_part_text(part))
+            elif part.type == 'image_url':
+                parts.append(self.serialize_content_part_image(part))
+        return parts
+
+    def serialize_system_content(
+        self,
+        content: str | list[ContentPartTextParam],
+    ) -> str | list[dict[str, Any]]:
+        """Serialize content for system messages."""
+        if isinstance(content, str):
+            return content
+
+        parts = []
+        for part in content:
+            if part.type == 'text':
+                parts.append(self.serialize_content_part_text(part))
+        return parts
+
+    def serialize_assistant_content(
+        self,
+        content: str | list[ContentPartTextParam | ContentPartRefusalParam] | None,
+    ) -> str | list[dict[str, Any]] | None:
+        """Serialize content for assistant messages."""
+        if content is None:
+            return None
+        if isinstance(content, str):
+            return content
+
+        parts = []
+        for part in content:
+            if part.type == 'text':
+                parts.append(self.serialize_content_part_text(part))
+            elif part.type == 'refusal':
+                parts.append(self.serialize_content_part_refusal(part))
+        return parts
+
+    def serialize_tool_call(self, tool_call: ToolCall) -> dict[str, Any]:
+        """Serialize a tool call."""
+        return {
+            "id": tool_call.id,
+            "type": "function",
+            "function": {
+                "name": tool_call.function.name,
+                "arguments": tool_call.function.arguments,
+            }
+        }
+
+    def parse_tool_call_response(
+        self,
+        response: dict[str, Any],
+        output_format: type[T],
+    ) -> T:
+        """Parse a tool call response into a Pydantic model.
+        
+        Args:
+            response: Raw response from the LLM
+            output_format: Expected Pydantic model class
+            
+        Returns:
+            Parsed Pydantic model instance
+        """
+        # This is a base implementation that can be overridden
+        # by provider-specific serializers
+        raise NotImplementedError("Subclasses must implement parse_tool_call_response")
+


### PR DESCRIPTION
This pull request adds support for Anthropic Claude and AWS Bedrock (Claude) large language models to the codebase, including both model wrappers and message serialization utilities. The integration is designed to be compatible with LangChain and supports advanced features such as tool calling and structured outputs. The most important changes are grouped as follows:

**Anthropic Claude LLM Integration:**

- Added `ChatAnthropic` class, a LangChain-compatible async wrapper for Anthropic Claude models, supporting tool calling, structured outputs, and multimodal input. (`src/openbrowser/llm/anthropic/chat.py`)
- Created module initialization for Anthropic LLM integration, exposing `ChatAnthropic`. (`src/openbrowser/llm/anthropic/__init__.py`)

**AWS Bedrock Claude LLM Integration:**

- Added `ChatAWSBedrock` class, an async LangChain-compatible wrapper for Claude models via AWS Bedrock, including support for tool calling and structured outputs. (`src/openbrowser/llm/aws/chat.py`)
- Created module initialization for AWS Bedrock LLM integration, exposing `ChatAWSBedrock`. (`src/openbrowser/llm/aws/__init__.py`)

**Message Serialization:**

- Implemented `AnthropicMessageSerializer` for converting internal message formats to Anthropic's required format, handling system/user/assistant messages, multimodal content, tool calls, and structured output schemas. Also includes utilities for parsing responses and resolving schema references. (`src/openbrowser/llm/anthropic/serializer.py`)Adds multi-provider LLM wrappers and per-provider serializers. Keeps provider code isolated and testable; reviewers should validate structured output compatibility and graceful fallbacks for missing credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified LLM provider layer with per-provider chat wrappers and message serializers, covering Anthropic, OpenAI/Azure, Groq, OpenRouter, Google, AWS Bedrock, Ollama, Cerebras, DeepSeek, and OCI. Standardizes message formats and errors, and isolates provider logic for easier testing.

- New Features
  - Chat wrappers: Anthropic, AWS Bedrock, Azure OpenAI, Groq, OpenRouter, Google (serializer), Ollama, Cerebras, DeepSeek, OCI, and browser-use.
  - Per-provider serializers with OpenAI-compatible reuse where possible; dedicated formats for Anthropic, Google, Bedrock, and Ollama.
  - Base message serializer and common chat base; unified exceptions for provider, rate-limit, and auth errors.
  - Structured output support via Pydantic schemas where providers allow; safe fallbacks when unsupported.

- Migration
  - No breaking changes. Configure provider API keys via env vars; missing credentials fail gracefully.
  - Please validate structured output parity per provider and confirm fallbacks behave as expected.

<sup>Written for commit af3260a68f02525279364ad0b42fdb6dd387e0c5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 11 new LLM providers: Anthropic Claude, AWS Bedrock, Azure OpenAI, Browser-Use, Cerebras, DeepSeek, Google Gemini, Groq, OCI GenAI, Ollama, and OpenRouter.
  * Enabled tool/function calling and structured output capabilities across all supported providers.
  * Added multimodal message support for text and image content in compatible providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->