### PR TITLE
feat(code-use): add CodeAgent and notebook session

### DIFF
--- a/src/openbrowser/code_use/__init__.py
+++ b/src/openbrowser/code_use/__init__.py
@@ -1,0 +1,30 @@
+"""Code-use agent module - Jupyter notebook-like code execution for browser automation."""
+
+from src.openbrowser.code_use.service import CodeAgent
+from src.openbrowser.code_use.views import (
+    CellType,
+    CodeAgentHistory,
+    CodeAgentModelOutput,
+    CodeAgentResult,
+    CodeAgentState,
+    CodeAgentStepMetadata,
+    CodeCell,
+    ExecutionStatus,
+    NotebookExport,
+    NotebookSession,
+)
+
+__all__ = [
+    "CellType",
+    "CodeAgent",
+    "CodeAgentHistory",
+    "CodeAgentModelOutput",
+    "CodeAgentResult",
+    "CodeAgentState",
+    "CodeAgentStepMetadata",
+    "CodeCell",
+    "ExecutionStatus",
+    "NotebookExport",
+    "NotebookSession",
+]
+

--- a/src/openbrowser/code_use/formatting.py
+++ b/src/openbrowser/code_use/formatting.py
@@ -1,0 +1,162 @@
+"""Browser state formatting helpers for code-use agent."""
+
+import logging
+from typing import Any
+
+from src.openbrowser.browser.session import BrowserSession
+
+logger = logging.getLogger(__name__)
+
+
+async def format_browser_state_for_llm(
+    url: str,
+    title: str,
+    dom_html: str,
+    namespace: dict[str, Any],
+    browser_session: BrowserSession,
+    screenshot: str | None = None,
+    page_info: dict | None = None,
+) -> str:
+    """
+    Format browser state summary for LLM consumption in code-use mode.
+
+    Args:
+        url: Current page URL
+        title: Current page title
+        dom_html: DOM representation
+        namespace: The code execution namespace (for showing available variables)
+        browser_session: Browser session for additional checks
+        screenshot: Optional screenshot base64 string
+        page_info: Optional page scroll/size information
+
+    Returns:
+        Formatted browser state text for LLM
+    """
+    if dom_html == "":
+        dom_html = "Empty DOM tree (you might have to wait for the page to load)"
+
+    # Format with URL and title header
+    lines = ["## Browser State"]
+    lines.append(f"**URL:** {url}")
+    lines.append(f"**Title:** {title}")
+    lines.append("")
+
+    # Add page scroll info if available
+    if page_info:
+        pixels_above = page_info.get("pixels_above", 0)
+        pixels_below = page_info.get("pixels_below", 0)
+        viewport_height = page_info.get("viewport_height", 1)
+        page_height = page_info.get("page_height", 1)
+
+        pages_above = pixels_above / viewport_height if viewport_height > 0 else 0
+        pages_below = pixels_below / viewport_height if viewport_height > 0 else 0
+        total_pages = page_height / viewport_height if viewport_height > 0 else 0
+
+        scroll_info = f"**Page:** {pages_above:.1f} pages above, {pages_below:.1f} pages below"
+        if total_pages > 1.2:  # Only mention total if significantly > 1 page
+            scroll_info += f", {total_pages:.1f} total pages"
+        lines.append(scroll_info)
+        lines.append("")
+
+    # Add available variables and functions BEFORE DOM structure
+    skip_vars = {
+        "browser",
+        "file_system",
+        "np",
+        "pd",
+        "plt",
+        "numpy",
+        "pandas",
+        "matplotlib",
+        "requests",
+        "BeautifulSoup",
+        "bs4",
+        "pypdf",
+        "PdfReader",
+        "wait",
+    }
+
+    # Highlight code block variables separately from regular variables
+    code_block_vars = []
+    regular_vars = []
+    tracked_code_blocks = namespace.get("_code_block_vars", set())
+    for name in namespace.keys():
+        # Skip private vars and system objects/actions
+        if not name.startswith("_") and name not in skip_vars:
+            if name in tracked_code_blocks:
+                code_block_vars.append(name)
+            else:
+                regular_vars.append(name)
+
+    # Sort for consistent display
+    available_vars_sorted = sorted(regular_vars)
+    code_block_vars_sorted = sorted(code_block_vars)
+
+    # Build available line with code blocks and variables
+    parts = []
+    if code_block_vars_sorted:
+        # Show detailed info for code block variables
+        code_block_details = []
+        for var_name in code_block_vars_sorted:
+            value = namespace.get(var_name)
+            if value is not None:
+                type_name = type(value).__name__
+                value_str = str(value) if not isinstance(value, str) else value
+
+                # Check if it's a function
+                is_function = value_str.strip().startswith("(function") or value_str.strip().startswith("(async function")
+
+                if is_function:
+                    detail = f"{var_name}({type_name})"
+                else:
+                    first_20 = value_str[:20].replace("\n", "\\n").replace("\t", "\\t")
+                    last_20 = value_str[-20:].replace("\n", "\\n").replace("\t", "\\t") if len(value_str) > 20 else ""
+
+                    if last_20 and first_20 != last_20:
+                        detail = f'{var_name}({type_name}): "{first_20}...{last_20}"'
+                    else:
+                        detail = f'{var_name}({type_name}): "{first_20}"'
+                code_block_details.append(detail)
+
+        parts.append(f'**Code block variables:** {" | ".join(code_block_details)}')
+    if available_vars_sorted:
+        parts.append(f'**Variables:** {", ".join(available_vars_sorted)}')
+
+    lines.append(f'**Available:** {" | ".join(parts)}')
+    lines.append("")
+
+    # Add DOM structure
+    lines.append("**DOM Structure:**")
+
+    # Add scroll position hints for DOM
+    if page_info:
+        pixels_above = page_info.get("pixels_above", 0)
+        pixels_below = page_info.get("pixels_below", 0)
+        viewport_height = page_info.get("viewport_height", 1)
+
+        pages_above = pixels_above / viewport_height if viewport_height > 0 else 0
+        pages_below = pixels_below / viewport_height if viewport_height > 0 else 0
+
+        if pages_above > 0:
+            dom_html = f"... {pages_above:.1f} pages above \n{dom_html}"
+        else:
+            dom_html = "[Start of page]\n" + dom_html
+
+        if pages_below > 0:
+            dom_html += f"\n... {pages_below:.1f} pages below "
+        else:
+            dom_html += "\n[End of page]"
+
+    # Truncate DOM if too long and notify LLM
+    max_dom_length = 60000
+    if len(dom_html) > max_dom_length:
+        lines.append(dom_html[:max_dom_length])
+        lines.append(
+            f"\n[DOM truncated after {max_dom_length} characters. Full page contains {len(dom_html)} characters total. Use evaluate to explore more.]"
+        )
+    else:
+        lines.append(dom_html)
+
+    browser_state_text = "\n".join(lines)
+    return browser_state_text
+

--- a/src/openbrowser/code_use/namespace.py
+++ b/src/openbrowser/code_use/namespace.py
@@ -1,0 +1,359 @@
+"""Namespace initialization for code-use mode.
+
+This module creates a namespace with all browser tools available as functions,
+similar to a Jupyter notebook environment.
+"""
+
+import asyncio
+import csv
+import datetime
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from src.openbrowser.browser.session import BrowserSession
+from src.openbrowser.tools.actions import Tools
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_js_comments(js_code: str) -> str:
+    """
+    Remove JavaScript comments before CDP evaluation.
+    CDP's Runtime.evaluate doesn't handle comments in all contexts.
+
+    Args:
+        js_code: JavaScript code potentially containing comments
+
+    Returns:
+        JavaScript code with comments stripped
+    """
+    # Remove multi-line comments (/* ... */)
+    js_code = re.sub(r"/\*.*?\*/", "", js_code, flags=re.DOTALL)
+
+    # Remove single-line comments - only lines that START with // (after whitespace)
+    js_code = re.sub(r"^\s*//.*$", "", js_code, flags=re.MULTILINE)
+
+    return js_code
+
+
+class EvaluateError(Exception):
+    """Special exception raised by evaluate() to stop Python execution immediately."""
+
+    pass
+
+
+async def evaluate(code: str, browser_session: BrowserSession) -> Any:
+    """
+    Execute JavaScript code in the browser and return the result.
+
+    Args:
+        code: JavaScript code to execute (must be wrapped in IIFE)
+
+    Returns:
+        The result of the JavaScript execution
+
+    Raises:
+        EvaluateError: If JavaScript execution fails. This stops Python execution immediately.
+
+    Example:
+        result = await evaluate('''
+        (function(){
+            return Array.from(document.querySelectorAll('.product')).map(p => ({
+                name: p.querySelector('.name').textContent,
+                price: p.querySelector('.price').textContent
+            }))
+        })()
+        ''')
+    """
+    # Strip JavaScript comments before CDP evaluation
+    code = _strip_js_comments(code)
+
+    cdp_session = await browser_session.get_or_create_cdp_session()
+
+    try:
+        # Execute JavaScript with proper error handling
+        result = await cdp_session.cdp_client.send.Runtime.evaluate(
+            params={"expression": code, "returnByValue": True, "awaitPromise": True},
+            session_id=cdp_session.session_id,
+        )
+
+        # Check for JavaScript execution errors
+        if result.get("exceptionDetails"):
+            exception = result["exceptionDetails"]
+            error_text = exception.get("text", "Unknown error")
+
+            # Try to get more details from the exception
+            error_details = []
+            if "exception" in exception:
+                exc_obj = exception["exception"]
+                if "description" in exc_obj:
+                    error_details.append(exc_obj["description"])
+                elif "value" in exc_obj:
+                    error_details.append(str(exc_obj["value"]))
+
+            # Build comprehensive error message
+            error_msg = f"JavaScript execution error: {error_text}"
+            if error_details:
+                error_msg += f'\nDetails: {" | ".join(error_details)}'
+
+            raise EvaluateError(error_msg)
+
+        # Get the result data
+        result_data = result.get("result", {})
+
+        # Get the actual value
+        value = result_data.get("value")
+
+        # Return the value directly
+        if value is None:
+            return None if "value" in result_data else "undefined"
+        elif isinstance(value, (dict, list)):
+            # Complex objects - already deserialized by returnByValue
+            return value
+        else:
+            # Primitive values
+            return value
+
+    except EvaluateError:
+        # Re-raise EvaluateError as-is to stop Python execution
+        raise
+    except Exception as e:
+        # Wrap other exceptions in EvaluateError
+        raise EvaluateError(f"Failed to execute JavaScript: {type(e).__name__}: {e}") from e
+
+
+def create_namespace(
+    browser_session: BrowserSession,
+    tools: Tools | None = None,
+    sensitive_data: dict[str, str | dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """
+    Create a namespace with all browser tools available as functions.
+
+    This function creates a dictionary of functions that can be used to interact
+    with the browser, similar to a Jupyter notebook environment.
+
+    Args:
+        browser_session: The browser session to use
+        tools: Optional Tools instance (will create default if not provided)
+        sensitive_data: Optional sensitive data dictionary
+
+    Returns:
+        Dictionary containing all available functions and objects
+
+    Example:
+        namespace = create_namespace(browser_session)
+        await namespace['navigate'](url='https://google.com')
+        result = await namespace['evaluate']('document.title')
+    """
+    if tools is None:
+        tools = Tools(browser_session)
+
+    namespace: dict[str, Any] = {
+        # Core objects
+        "browser": browser_session,
+        # Standard library modules (always available)
+        "json": json,
+        "asyncio": asyncio,
+        "Path": Path,
+        "csv": csv,
+        "re": re,
+        "datetime": datetime,
+    }
+
+    # Track failed evaluate() calls to detect repeated failed approaches
+    if "_evaluate_failures" not in namespace:
+        namespace["_evaluate_failures"] = []
+
+    # Add custom evaluate function that returns values directly
+    async def evaluate_wrapper(
+        code: str | None = None, variables: dict[str, Any] | None = None, *_args: Any, **kwargs: Any
+    ) -> Any:
+        # Handle both positional and keyword argument styles
+        if code is None:
+            code = kwargs.get("code", kwargs.get("js_code", kwargs.get("expression", "")))
+        if variables is None:
+            variables = kwargs.get("variables")
+
+        if not code:
+            raise ValueError("No JavaScript code provided to evaluate()")
+
+        # Inject variables if provided
+        if variables:
+            vars_json = json.dumps(variables)
+            stripped = code.strip()
+
+            # Check if code is already a function expression expecting params
+            if re.match(r"\((?:async\s+)?function\s*\(\s*\w+\s*\)", stripped):
+                code = f"(function(){{ const params = {vars_json}; return {stripped}(params); }})()"
+            else:
+                # Not a parameterized function, inject params in scope
+                is_wrapped = (
+                    (stripped.startswith("(function()") and "})())" in stripped[-10:])
+                    or (stripped.startswith("(async function()") and "})())" in stripped[-10:])
+                    or (stripped.startswith("(() =>") and ")())" in stripped[-10:])
+                    or (stripped.startswith("(async () =>") and ")())" in stripped[-10:])
+                )
+                if is_wrapped:
+                    match = re.match(r"(\((?:async\s+)?function\s*\(\s*\)\s*\{)", stripped)
+                    if match:
+                        prefix = match.group(1)
+                        rest = stripped[len(prefix) :]
+                        code = f"{prefix} const params = {vars_json}; {rest}"
+                    else:
+                        code = f"(function(){{ const params = {vars_json}; return {stripped}; }})()"
+                else:
+                    code = f"(function(){{ const params = {vars_json}; {code} }})()"
+                    return await evaluate(code, browser_session)
+
+        # Auto-wrap in IIFE if not already wrapped (and no variables were injected)
+        if not variables:
+            stripped = code.strip()
+            is_wrapped = (
+                (stripped.startswith("(function()") and "})())" in stripped[-10:])
+                or (stripped.startswith("(async function()") and "})())" in stripped[-10:])
+                or (stripped.startswith("(() =>") and ")())" in stripped[-10:])
+                or (stripped.startswith("(async () =>") and ")())" in stripped[-10:])
+            )
+            if not is_wrapped:
+                code = f"(function(){{{code}}})()"
+
+        # Execute and track failures
+        try:
+            result = await evaluate(code, browser_session)
+
+            # Print result structure for debugging
+            if isinstance(result, list) and result and isinstance(result[0], dict):
+                result_preview = f"list of dicts - len={len(result)}, example 1:\n"
+                sample_result = result[0]
+                for key, value in list(sample_result.items())[:10]:
+                    value_str = str(value)[:10] if not isinstance(value, (int, float, bool, type(None))) else str(value)
+                    result_preview += f"  {key}: {value_str}...\n"
+                if len(sample_result) > 10:
+                    result_preview += f"  ... {len(sample_result) - 10} more keys"
+                print(result_preview)
+
+            elif isinstance(result, list):
+                if len(result) == 0:
+                    print("type=list, len=0")
+                else:
+                    result_preview = str(result)[:100]
+                    print(f"type=list, len={len(result)}, preview={result_preview}...")
+            elif isinstance(result, dict):
+                result_preview = f"type=dict, len={len(result)}, sample keys:\n"
+                for key, value in list(result.items())[:10]:
+                    value_str = str(value)[:10] if not isinstance(value, (int, float, bool, type(None))) else str(value)
+                    result_preview += f"  {key}: {value_str}...\n"
+                if len(result) > 10:
+                    result_preview += f"  ... {len(result) - 10} more keys"
+                print(result_preview)
+
+            else:
+                print(f"type={type(result).__name__}, value={repr(result)[:50]}")
+
+            return result
+        except Exception as e:
+            namespace["_evaluate_failures"].append({"error": str(e), "type": "exception"})
+            raise
+
+    namespace["evaluate"] = evaluate_wrapper
+
+    # Inject all tools as functions into the namespace
+    for action_name, action in tools.registry.registry.actions.items():
+        if action_name == "evaluate":
+            continue  # Skip - use custom evaluate that returns Python objects directly
+        param_model = action.param_model
+        action_function = action.function
+
+        # Create a closure to capture the current action_name, param_model, and action_function
+        def make_action_wrapper(act_name, par_model, act_func):
+            async def action_wrapper(*args, **kwargs):
+                # Convert positional args to kwargs based on param model fields
+                if args:
+                    field_names = list(par_model.model_fields.keys())
+                    for i, arg in enumerate(args):
+                        if i < len(field_names):
+                            kwargs[field_names[i]] = arg
+
+                # Create params from kwargs
+                try:
+                    params = par_model(**kwargs)
+                except Exception as e:
+                    raise ValueError(f"Invalid parameters for {act_name}: {e}") from e
+
+                # Special validation for done() - enforce minimal code cell
+                if act_name == "done":
+                    consecutive_failures = namespace.get("_consecutive_errors")
+                    if not consecutive_failures or consecutive_failures <= 3:
+                        # Check if there are multiple Python blocks in this response
+                        all_blocks = namespace.get("_all_code_blocks", {})
+                        python_blocks = [k for k in sorted(all_blocks.keys()) if k.startswith("python_")]
+
+                        if len(python_blocks) > 1:
+                            msg = (
+                                "done() should be the ONLY code block in the response.\n"
+                                "You have multiple Python blocks in this response."
+                            )
+                            print(msg)
+
+                # Build special context
+                special_context = {
+                    "browser_session": browser_session,
+                }
+
+                # Execute the action
+                result = await act_func(params=params, **special_context)
+
+                # For code-use mode, we want to return the result directly
+                if hasattr(result, "extracted_content"):
+                    # Special handling for done action
+                    if act_name == "done" and hasattr(result, "is_done") and result.is_done:
+                        namespace["_task_done"] = True
+                        if result.extracted_content:
+                            namespace["_task_result"] = result.extracted_content
+                        if hasattr(result, "success"):
+                            namespace["_task_success"] = result.success
+
+                    if result.extracted_content:
+                        return result.extracted_content
+                    if result.error:
+                        raise RuntimeError(result.error)
+                    return None
+                return result
+
+            return action_wrapper
+
+        # Rename 'input' to 'input_text' to avoid shadowing Python's built-in input()
+        namespace_action_name = "input_text" if action_name == "input" else action_name
+
+        # Add the wrapper to the namespace
+        namespace[namespace_action_name] = make_action_wrapper(action_name, param_model, action_function)
+
+    return namespace
+
+
+def get_namespace_documentation(namespace: dict[str, Any]) -> str:
+    """
+    Generate documentation for all available functions in the namespace.
+
+    Args:
+        namespace: The namespace dictionary
+
+    Returns:
+        Markdown-formatted documentation string
+    """
+    docs = ["# Available Functions\n"]
+
+    # Document each function
+    for name, obj in sorted(namespace.items()):
+        if callable(obj) and not name.startswith("_"):
+            # Get function signature and docstring
+            if hasattr(obj, "__doc__") and obj.__doc__:
+                docs.append(f"## {name}\n")
+                docs.append(f"{obj.__doc__}\n")
+
+    return "\n".join(docs)
+

--- a/src/openbrowser/code_use/service.py
+++ b/src/openbrowser/code_use/service.py
@@ -1,0 +1,865 @@
+"""Code-use agent service - Jupyter notebook-like code execution for browser automation."""
+
+import ast
+import asyncio
+import datetime
+import io
+import logging
+import re
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from src.openbrowser.browser.profile import BrowserProfile
+from src.openbrowser.browser.session import BrowserSession
+from src.openbrowser.tools.actions import CodeAgentTools, Tools
+
+from .formatting import format_browser_state_for_llm
+from .namespace import EvaluateError, create_namespace
+from .utils import detect_token_limit_issue, extract_code_blocks, extract_url_from_task, truncate_message_content
+from .views import (
+    CodeAgentHistory,
+    CodeAgentModelOutput,
+    CodeAgentResult,
+    CodeAgentState,
+    CodeAgentStepMetadata,
+    ExecutionStatus,
+    NotebookSession,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CodeAgent:
+    """
+    Agent that executes Python code in a notebook-like environment for browser automation.
+
+    This agent provides a Jupyter notebook-like interface where the LLM writes Python code
+    that gets executed in a persistent namespace with browser control functions available.
+    """
+
+    def __init__(
+        self,
+        task: str,
+        # Optional parameters
+        llm: Any | None = None,
+        browser_session: BrowserSession | None = None,
+        browser: BrowserSession | None = None,  # Alias for browser_session
+        tools: Tools | None = None,
+        controller: Tools | None = None,  # Alias for tools
+        # Agent settings
+        sensitive_data: dict[str, str | dict[str, str]] | None = None,
+        max_steps: int = 100,
+        max_failures: int = 8,
+        use_vision: bool = True,
+        **kwargs,
+    ):
+        """
+        Initialize the code-use agent.
+
+        Args:
+            task: The task description for the agent
+            llm: Optional LLM instance
+            browser_session: Optional browser session (will be created if not provided)
+            browser: Optional browser session (cleaner API)
+            tools: Optional Tools instance (will create default if not provided)
+            controller: Optional Tools instance
+            sensitive_data: Optional sensitive data dictionary
+            max_steps: Maximum number of execution steps
+            max_failures: Maximum consecutive errors before termination (default: 8)
+            use_vision: Whether to include screenshots in LLM messages (default: True)
+            **kwargs: Additional keyword arguments for compatibility (ignored)
+        """
+        # Log and ignore unknown kwargs for compatibility
+        if kwargs:
+            logger.debug(f"Ignoring additional kwargs for CodeAgent compatibility: {list(kwargs.keys())}")
+
+        if llm is None:
+            raise ValueError("llm parameter is required for CodeAgent")
+
+        # Handle browser vs browser_session parameter (browser takes precedence)
+        if browser and browser_session:
+            raise ValueError('Cannot specify both "browser" and "browser_session" parameters.')
+        browser_session = browser or browser_session
+
+        # Handle controller vs tools parameter (controller takes precedence)
+        if controller and tools:
+            raise ValueError('Cannot specify both "controller" and "tools" parameters.')
+        tools = controller or tools
+
+        # Store browser_profile for creating browser session if needed
+        self._browser_profile_for_init = BrowserProfile() if browser_session is None else None
+
+        self.task = task
+        self.llm = llm
+        self.browser_session = browser_session
+        self.tools = tools
+        self.sensitive_data = sensitive_data
+        self.max_steps = max_steps
+        self.max_failures = max_failures
+        self.use_vision = use_vision
+
+        self.session = NotebookSession()
+        self.namespace: dict[str, Any] = {}
+        self._llm_messages: list[dict[str, Any]] = []  # Internal LLM conversation history
+        self.complete_history: list[CodeAgentHistory] = []  # Type-safe history
+        self._last_browser_state_text: str | None = None
+        self._last_screenshot: str | None = None
+        self._consecutive_errors = 0
+        self._step_start_time = 0.0
+
+        # Initialize agent ID and directory
+        self.id = str(uuid4())
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        base_tmp = Path("/tmp")
+        self.agent_directory = base_tmp / f"browser_use_code_agent_{self.id}_{timestamp}"
+
+    async def run(self, max_steps: int | None = None) -> NotebookSession:
+        """
+        Run the agent to complete the task.
+
+        Args:
+            max_steps: Optional override for maximum number of steps
+
+        Returns:
+            The notebook session with all executed cells
+        """
+        # Use override if provided
+        steps_to_run = max_steps if max_steps is not None else self.max_steps
+        self.max_steps = steps_to_run
+
+        # Start browser if not provided
+        if self.browser_session is None:
+            assert self._browser_profile_for_init is not None
+            self.browser_session = BrowserSession(browser_profile=self._browser_profile_for_init)
+            await self.browser_session.start()
+
+        # Initialize tools if not provided
+        if self.tools is None:
+            self.tools = CodeAgentTools(self.browser_session)
+
+        # Create namespace with all tools
+        self.namespace = create_namespace(
+            browser_session=self.browser_session,
+            tools=self.tools,
+            sensitive_data=self.sensitive_data,
+        )
+
+        # Initialize conversation with task
+        self._llm_messages.append({"role": "user", "content": f"Task: {self.task}"})
+
+        # Extract URL from task and navigate if found
+        initial_url = extract_url_from_task(self.task)
+        if initial_url:
+            try:
+                logger.info(f"Extracted URL from task, navigating to: {initial_url}")
+                # Use the navigate action from namespace
+                await self.namespace["go_to_url"](initial_url)
+                # Wait for page load
+                await asyncio.sleep(2)
+
+                # Record this navigation as a cell in the notebook
+                nav_code = f"await go_to_url('{initial_url}')"
+                cell = self.session.add_cell(source=nav_code)
+                cell.status = ExecutionStatus.SUCCESS
+                cell.execution_count = self.session.increment_execution_count()
+                cell.output = f"Navigated to {initial_url}"
+
+            except Exception as e:
+                logger.warning(f"Failed to navigate to extracted URL {initial_url}: {e}")
+                # Record failed navigation as error cell
+                nav_code = f"await go_to_url('{initial_url}')"
+                cell = self.session.add_cell(source=nav_code)
+                cell.status = ExecutionStatus.ERROR
+                cell.execution_count = self.session.increment_execution_count()
+                cell.error = str(e)
+
+        # Get initial browser state before first LLM call
+        if self.browser_session:
+            try:
+                browser_state_text, screenshot = await self._get_browser_state()
+                self._last_browser_state_text = browser_state_text
+                self._last_screenshot = screenshot
+            except Exception as e:
+                logger.warning(f"Failed to get initial browser state: {e}")
+
+        # Main execution loop
+        for step in range(self.max_steps):
+            logger.info(f"\n\n\nStep {step + 1}/{self.max_steps}")
+
+            # Start timing this step
+            self._step_start_time = datetime.datetime.now().timestamp()
+
+            # Check if we're approaching the step limit or error limit
+            steps_remaining = self.max_steps - step - 1
+            errors_remaining = self.max_failures - self._consecutive_errors
+
+            should_warn = (
+                steps_remaining <= 1  # Last step or next to last
+                or errors_remaining <= 1  # One more error will terminate
+                or (steps_remaining <= 2 and self._consecutive_errors >= 2)
+            )
+
+            if should_warn:
+                warning_message = (
+                    f"\n\n⚠️ CRITICAL WARNING: You are approaching execution limits!\n"
+                    f"- Steps remaining: {steps_remaining + 1}\n"
+                    f"- Consecutive errors: {self._consecutive_errors}/{self.max_failures}\n\n"
+                    f"YOU MUST call done() in your NEXT response, even if the task is incomplete:\n"
+                    f"- Set success=False if you couldn't complete the task\n"
+                    f"- Return EVERYTHING you found so far (partial data is better than nothing)\n"
+                    f"Without done(), the user will receive NOTHING."
+                )
+                self._llm_messages.append({"role": "user", "content": warning_message})
+
+            try:
+                # Fetch fresh browser state right before LLM call
+                if not self._last_browser_state_text and self.browser_session:
+                    try:
+                        logger.debug("Fetching browser state before LLM call...")
+                        browser_state_text, screenshot = await self._get_browser_state()
+                        self._last_browser_state_text = browser_state_text
+                        self._last_screenshot = screenshot
+                    except Exception as e:
+                        logger.warning(f"Failed to get browser state before LLM call: {e}")
+
+                # Get code from LLM
+                try:
+                    code, full_llm_response = await self._get_code_from_llm()
+                except Exception as llm_error:
+                    self._consecutive_errors += 1
+                    logger.warning(
+                        f"LLM call failed (consecutive errors: {self._consecutive_errors}/{self.max_failures}): {llm_error}"
+                    )
+
+                    if self._consecutive_errors >= self.max_failures:
+                        logger.error(f"Terminating: {self.max_failures} consecutive LLM failures")
+                        break
+
+                    await asyncio.sleep(1)
+                    continue
+
+                if not code or code.strip() == "":
+                    # If task is already done, empty code is fine
+                    if self._is_task_done():
+                        logger.info("Task already marked as done, LLM provided explanation without code")
+                        await self._add_step_to_complete_history(
+                            model_output_code="",
+                            full_llm_response=full_llm_response,
+                            output=full_llm_response,
+                            error=None,
+                            screenshot_path=await self._capture_screenshot(step + 1),
+                        )
+                        break
+
+                    logger.warning("LLM returned empty code")
+                    self._consecutive_errors += 1
+
+                    if self.browser_session:
+                        try:
+                            browser_state_text, screenshot = await self._get_browser_state()
+                            self._last_browser_state_text = browser_state_text
+                            self._last_screenshot = screenshot
+                        except Exception as e:
+                            logger.warning(f"Failed to get new browser state: {e}")
+                    continue
+
+                # Execute code blocks sequentially
+                all_blocks = self.namespace.get("_all_code_blocks", {})
+                python_blocks = [k for k in sorted(all_blocks.keys()) if k.startswith("python_")]
+
+                if len(python_blocks) > 1:
+                    output = None
+                    error = None
+
+                    for i, block_key in enumerate(python_blocks):
+                        logger.info(f"Executing Python block {i + 1}/{len(python_blocks)}")
+                        block_code = all_blocks[block_key]
+                        block_output, block_error, _ = await self._execute_code(block_code)
+
+                        if block_output:
+                            output = (output or "") + block_output
+                        if block_error:
+                            error = block_error
+                            break
+                else:
+                    output, error, _ = await self._execute_code(code)
+
+                # Track consecutive errors
+                if error:
+                    self._consecutive_errors += 1
+                    logger.warning(f"Consecutive errors: {self._consecutive_errors}/{self.max_failures}")
+
+                    if self._consecutive_errors >= self.max_failures:
+                        logger.error(f"Terminating: {self.max_failures} consecutive errors reached.")
+                        await self._add_step_to_complete_history(
+                            model_output_code=code,
+                            full_llm_response=f"[Terminated after {self.max_failures} consecutive errors]",
+                            output=None,
+                            error=f"Auto-terminated: {self.max_failures} consecutive errors without progress",
+                            screenshot_path=None,
+                        )
+                        break
+                else:
+                    self._consecutive_errors = 0
+
+                # Check if task is done
+                if self._is_task_done():
+                    final_result: str | None = self.namespace.get("_task_result")
+                    if final_result:
+                        output = final_result
+
+                if output:
+                    if self._is_task_done():
+                        logger.info(f"✓ Task completed - Final output from done():\n{output[:300] if len(output) > 300 else output}")
+                    else:
+                        logger.info(f"Code output:\n{output}")
+
+                # Take screenshot for tracking
+                screenshot_path = await self._capture_screenshot(step + 1)
+
+                # Add step to complete_history
+                await self._add_step_to_complete_history(
+                    model_output_code=code,
+                    full_llm_response=full_llm_response,
+                    output=output,
+                    error=error,
+                    screenshot_path=screenshot_path,
+                )
+
+                # Check if task is done
+                if self._is_task_done():
+                    final_result: str | None = self.namespace.get("_task_result", output)
+                    logger.info("Task completed successfully")
+                    if final_result:
+                        logger.info(f"Final result: {final_result}")
+                    break
+
+                # Add result to LLM messages for next iteration
+                result_message = self._format_execution_result(code, output, error, current_step=step + 1)
+                truncated_result = truncate_message_content(result_message)
+                self._llm_messages.append({"role": "user", "content": truncated_result})
+
+            except Exception as e:
+                logger.error(f"Error in step {step + 1}: {e}")
+                traceback.print_exc()
+                break
+        else:
+            logger.warning(f"Maximum steps ({self.max_steps}) reached without task completion")
+
+        # Log final summary if task was completed
+        if self._is_task_done():
+            logger.info("\n" + "=" * 60)
+            logger.info("TASK COMPLETED SUCCESSFULLY")
+            logger.info("=" * 60)
+            final_result: str | None = self.namespace.get("_task_result")
+            if final_result:
+                logger.info(f"\nFinal Output:\n{final_result}")
+            logger.info("=" * 60 + "\n")
+
+        # Close browser
+        await self.close()
+
+        return self.session
+
+    async def _get_code_from_llm(self) -> tuple[str, str]:
+        """Get Python code from the LLM.
+
+        Returns:
+            Tuple of (extracted_code, full_llm_response)
+        """
+        # Prepare messages for this request
+        messages_to_send = self._llm_messages.copy()
+
+        if self._last_browser_state_text:
+            if self.use_vision and self._last_screenshot:
+                # Build content with text + screenshot
+                content = [
+                    {"type": "text", "text": self._last_browser_state_text},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{self._last_screenshot}"},
+                    },
+                ]
+                messages_to_send.append({"role": "user", "content": content})
+            else:
+                messages_to_send.append({"role": "user", "content": self._last_browser_state_text})
+
+            # Clear browser state after including it
+            self._last_browser_state_text = None
+            self._last_screenshot = None
+
+        # Call LLM with message history
+        response = await self.llm.ainvoke(messages_to_send)
+
+        # Handle different response types
+        if hasattr(response, "content"):
+            full_response = response.content
+        elif isinstance(response, str):
+            full_response = response
+        else:
+            full_response = str(response)
+
+        logger.info(f"LLM Response:\n{full_response}")
+
+        # Check for token limit issues
+        max_tokens = getattr(self.llm, "max_tokens", None)
+        completion_tokens = None
+        stop_reason = None
+
+        if hasattr(response, "usage") and response.usage:
+            completion_tokens = getattr(response.usage, "completion_tokens", None)
+        if hasattr(response, "stop_reason"):
+            stop_reason = response.stop_reason
+
+        is_problematic, issue_message = detect_token_limit_issue(
+            completion=full_response,
+            completion_tokens=completion_tokens,
+            max_tokens=max_tokens,
+            stop_reason=stop_reason,
+        )
+
+        if is_problematic:
+            logger.warning(f"Token limit issue detected: {issue_message}")
+            recovery_prompt = (
+                f"Your previous response hit a token limit or became repetitive: {issue_message}\n\n"
+                "Please write a SHORT plan (2 sentences) for what to do next, then execute ONE simple action."
+            )
+            self._llm_messages.append({"role": "user", "content": recovery_prompt})
+            return "", f"[Token limit error: {issue_message}]"
+
+        # Extract code blocks from response
+        code_blocks = extract_code_blocks(full_response)
+
+        # Inject non-python blocks into namespace as variables
+        if "_code_block_vars" not in self.namespace:
+            self.namespace["_code_block_vars"] = set()
+
+        for block_type, block_content in code_blocks.items():
+            if not block_type.startswith("python"):
+                self.namespace[block_type] = block_content
+                self.namespace["_code_block_vars"].add(block_type)
+                print(f"→ Code block variable: {block_type} (str, {len(block_content)} chars)")
+                logger.debug(f"Injected {block_type} block into namespace ({len(block_content)} chars)")
+
+        # Store all code blocks for sequential execution
+        self.namespace["_all_code_blocks"] = code_blocks
+
+        # Get Python code if it exists
+        code = code_blocks.get("python", full_response)
+
+        # Add to LLM messages
+        truncated_completion = truncate_message_content(full_response)
+        self._llm_messages.append({"role": "assistant", "content": truncated_completion})
+
+        return code, full_response
+
+    async def _execute_code(self, code: str) -> tuple[str | None, str | None, str | None]:
+        """
+        Execute Python code in the namespace.
+
+        Args:
+            code: The Python code to execute
+
+        Returns:
+            Tuple of (output, error, browser_state)
+        """
+        # Create new cell
+        cell = self.session.add_cell(source=code)
+        cell.status = ExecutionStatus.RUNNING
+        cell.execution_count = self.session.increment_execution_count()
+
+        output = None
+        error = None
+
+        try:
+            # Capture output
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+
+            try:
+                # Add asyncio to namespace if not already there
+                if "asyncio" not in self.namespace:
+                    self.namespace["asyncio"] = asyncio
+
+                # Store the current code in namespace for done() validation
+                self.namespace["_current_cell_code"] = code
+                self.namespace["_consecutive_errors"] = self._consecutive_errors
+
+                # Check if code contains await expressions
+                try:
+                    tree = ast.parse(code, mode="exec")
+                    has_await = any(isinstance(node, (ast.Await, ast.AsyncWith, ast.AsyncFor)) for node in ast.walk(tree))
+                except SyntaxError:
+                    has_await = False
+
+                if has_await:
+                    # Wrap in async function
+                    try:
+                        assigned_names = set()
+                        user_global_names = set()
+
+                        for node in ast.walk(tree):
+                            if isinstance(node, ast.Assign):
+                                for target in node.targets:
+                                    if isinstance(target, ast.Name):
+                                        assigned_names.add(target.id)
+                            elif isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Name):
+                                assigned_names.add(node.target.id)
+                            elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)):
+                                if hasattr(node, "target") and isinstance(node.target, ast.Name):
+                                    assigned_names.add(node.target.id)
+                            elif isinstance(node, ast.Global):
+                                user_global_names.update(node.names)
+
+                        # Pre-define globals that don't exist yet
+                        for name in user_global_names:
+                            if name not in self.namespace:
+                                self.namespace[name] = None
+
+                        existing_vars = {name for name in (assigned_names | user_global_names) if name in self.namespace}
+                    except Exception:
+                        existing_vars = set()
+
+                    global_decl = ""
+                    has_global_decl = False
+                    if existing_vars:
+                        vars_str = ", ".join(sorted(existing_vars))
+                        global_decl = f"    global {vars_str}\n"
+                        has_global_decl = True
+
+                    indented_code = "\n".join("    " + line if line.strip() else line for line in code.split("\n"))
+                    wrapped_code = f"""async def __code_exec__():
+{global_decl}{indented_code}
+    return locals()
+
+__code_exec_coro__ = __code_exec__()
+"""
+                    self.namespace["_has_global_decl"] = has_global_decl
+
+                    compiled_code = compile(wrapped_code, "<code>", "exec")
+                    exec(compiled_code, self.namespace, self.namespace)
+
+                    coro = self.namespace.get("__code_exec_coro__")
+                    if coro:
+                        result_locals = await coro
+                        if result_locals:
+                            for key, value in result_locals.items():
+                                if not key.startswith("_"):
+                                    self.namespace[key] = value
+
+                        self.namespace.pop("__code_exec_coro__", None)
+                        self.namespace.pop("__code_exec__", None)
+                else:
+                    # Execute directly at module level
+                    compiled_code = compile(code, "<code>", "exec")
+                    exec(compiled_code, self.namespace, self.namespace)
+
+                # Get output
+                output_value = sys.stdout.getvalue()
+                if output_value:
+                    output = output_value
+
+            finally:
+                sys.stdout = old_stdout
+
+            # Wait for page to stabilize
+            await asyncio.sleep(0.5)
+
+            cell.status = ExecutionStatus.SUCCESS
+            cell.output = output
+            cell.browser_state = None
+
+        except EvaluateError as e:
+            error = str(e)
+            cell.status = ExecutionStatus.ERROR
+            cell.error = error
+            logger.error(f"Code execution error: {error}")
+            await asyncio.sleep(1)
+            return output, error, None
+
+        except SyntaxError as e:
+            error_msg = e.msg if e.msg else str(e)
+            error = f"{type(e).__name__}: {error_msg}"
+
+            if e.text:
+                error += f"\n{e.text}"
+            elif e.lineno and code:
+                lines = code.split("\n")
+                if 0 < e.lineno <= len(lines):
+                    error += f"\n{lines[e.lineno - 1]}"
+
+            cell.status = ExecutionStatus.ERROR
+            cell.error = error
+            logger.error(f"Code execution error: {error}")
+            await asyncio.sleep(1)
+
+        except Exception as e:
+            error_str = str(e)
+            error = f"{type(e).__name__}: {error_str}" if error_str else f"{type(e).__name__} occurred"
+
+            cell.status = ExecutionStatus.ERROR
+            cell.error = error
+            logger.error(f"Code execution error: {error}")
+            await asyncio.sleep(1)
+
+        return output, error, None
+
+    async def _get_browser_state(self) -> tuple[str, str | None]:
+        """Get the current browser state as text.
+
+        Returns:
+            Tuple of (browser_state_text, screenshot_base64)
+        """
+        if not self.browser_session:
+            return "Browser state not available", None
+
+        try:
+            # Get current page info
+            cdp_session = await self.browser_session.get_or_create_cdp_session()
+            client = cdp_session.cdp_client
+            session_id = cdp_session.session_id
+
+            # Get URL
+            result = await client.send.Runtime.evaluate(
+                params={"expression": "window.location.href", "returnByValue": True},
+                session_id=session_id,
+            )
+            url = result.get("result", {}).get("value", "")
+
+            # Get title
+            result = await client.send.Runtime.evaluate(
+                params={"expression": "document.title", "returnByValue": True},
+                session_id=session_id,
+            )
+            title = result.get("result", {}).get("value", "")
+
+            # Get DOM representation (simplified)
+            result = await client.send.Runtime.evaluate(
+                params={
+                    "expression": """
+                    (function() {
+                        function getElements(el, depth) {
+                            if (depth > 5) return '';
+                            var result = '';
+                            for (var child of el.children) {
+                                var tag = child.tagName.toLowerCase();
+                                var text = child.textContent?.trim()?.slice(0, 50) || '';
+                                if (['script', 'style', 'noscript'].includes(tag)) continue;
+                                result += '  '.repeat(depth) + '<' + tag + '>' + (text ? ' ' + text : '') + '\\n';
+                                result += getElements(child, depth + 1);
+                            }
+                            return result;
+                        }
+                        return getElements(document.body, 0);
+                    })()
+                    """,
+                    "returnByValue": True,
+                },
+                session_id=session_id,
+            )
+            dom_html = result.get("result", {}).get("value", "")
+
+            # Take screenshot if vision enabled
+            screenshot = None
+            if self.use_vision:
+                try:
+                    result = await client.send.Page.captureScreenshot(
+                        params={"format": "jpeg", "quality": 70},
+                        session_id=session_id,
+                    )
+                    screenshot = result.get("data")
+                except Exception as e:
+                    logger.debug(f"Failed to capture screenshot: {e}")
+
+            # Format browser state
+            browser_state_text = await format_browser_state_for_llm(
+                url=url,
+                title=title,
+                dom_html=dom_html,
+                namespace=self.namespace,
+                browser_session=self.browser_session,
+                screenshot=screenshot,
+            )
+
+            return browser_state_text, screenshot
+
+        except Exception as e:
+            logger.error(f"Failed to get browser state: {e}")
+            return f"Error getting browser state: {e}", None
+
+    def _format_execution_result(self, code: str, output: str | None, error: str | None, current_step: int | None = None) -> str:
+        """Format the execution result for the LLM."""
+        result = []
+
+        if current_step is not None:
+            progress_header = f"Step {current_step}/{self.max_steps} executed"
+            if error and self._consecutive_errors > 0:
+                progress_header += f" | Consecutive failures: {self._consecutive_errors}/{self.max_failures}"
+            result.append(progress_header)
+
+        if error:
+            result.append(f"Error: {error}")
+
+        if output:
+            if len(output) > 10000:
+                output = output[:9950] + "\n[Truncated after 10000 characters]"
+            result.append(f"Output: {output}")
+        if len(result) == 0:
+            result.append("Executed")
+        return "\n".join(result)
+
+    def _is_task_done(self) -> bool:
+        """Check if the task is marked as done in the namespace."""
+        return self.namespace.get("_task_done", False)
+
+    async def _capture_screenshot(self, step_number: int) -> str | None:
+        """Capture and store screenshot for tracking."""
+        if not self.browser_session:
+            return None
+
+        try:
+            cdp_session = await self.browser_session.get_or_create_cdp_session()
+            client = cdp_session.cdp_client
+            session_id = cdp_session.session_id
+
+            result = await client.send.Page.captureScreenshot(
+                params={"format": "jpeg", "quality": 70},
+                session_id=session_id,
+            )
+            screenshot_data = result.get("data")
+            if screenshot_data:
+                # Ensure directory exists
+                self.agent_directory.mkdir(parents=True, exist_ok=True)
+                screenshot_path = self.agent_directory / f"step_{step_number}.jpg"
+
+                import base64
+
+                with open(screenshot_path, "wb") as f:
+                    f.write(base64.b64decode(screenshot_data))
+
+                return str(screenshot_path)
+        except Exception as e:
+            logger.warning(f"Failed to capture screenshot for step {step_number}: {e}")
+            return None
+
+    async def _add_step_to_complete_history(
+        self,
+        model_output_code: str,
+        full_llm_response: str,
+        output: str | None,
+        error: str | None,
+        screenshot_path: str | None,
+    ) -> None:
+        """Add a step to complete_history using type-safe models."""
+        # Get current browser URL and title for state
+        url: str | None = None
+        title: str | None = None
+        if self.browser_session:
+            try:
+                cdp_session = await self.browser_session.get_or_create_cdp_session()
+                result = await cdp_session.cdp_client.send.Runtime.evaluate(
+                    params={"expression": "window.location.href", "returnByValue": True},
+                    session_id=cdp_session.session_id,
+                )
+                url = result.get("result", {}).get("value")
+                result = await cdp_session.cdp_client.send.Runtime.evaluate(
+                    params={"expression": "document.title", "returnByValue": True},
+                    session_id=cdp_session.session_id,
+                )
+                title = result.get("result", {}).get("value")
+            except Exception as e:
+                logger.debug(f"Failed to get browser URL/title for history: {e}")
+
+        # Check if this is a done result
+        is_done = self._is_task_done()
+
+        # Get self-reported success from done() call if task is done
+        self_reported_success: bool | None = None
+        if is_done:
+            task_success = self.namespace.get("_task_success")
+            self_reported_success = task_success if isinstance(task_success, bool) else None
+
+        # Create result entry
+        result_entry = CodeAgentResult(
+            extracted_content=output if output else None,
+            error=error if error else None,
+            is_done=is_done,
+            success=self_reported_success,
+        )
+
+        # Create state entry
+        state_entry = CodeAgentState(url=url, title=title, screenshot_path=screenshot_path)
+
+        # Create metadata entry
+        step_end_time = datetime.datetime.now().timestamp()
+        metadata_entry = CodeAgentStepMetadata(
+            input_tokens=None,
+            output_tokens=None,
+            step_start_time=self._step_start_time,
+            step_end_time=step_end_time,
+        )
+
+        # Create model output entry
+        model_output_entry: CodeAgentModelOutput | None = None
+        if model_output_code or full_llm_response:
+            model_output_entry = CodeAgentModelOutput(
+                model_output=model_output_code if model_output_code else "",
+                full_response=full_llm_response if full_llm_response else "",
+            )
+
+        # Create history entry
+        history_entry = CodeAgentHistory(
+            model_output=model_output_entry,
+            result=[result_entry],
+            state=state_entry,
+            metadata=metadata_entry,
+            screenshot_path=screenshot_path,
+        )
+
+        self.complete_history.append(history_entry)
+
+    def screenshot_paths(self, n_last: int | None = None) -> list[str | None]:
+        """Get screenshot paths from complete_history.
+
+        Args:
+            n_last: Optional number of last screenshots to return
+
+        Returns:
+            List of screenshot file paths
+        """
+        paths = [step.screenshot_path for step in self.complete_history]
+
+        if n_last is not None:
+            return paths[-n_last:] if len(paths) > n_last else paths
+
+        return paths
+
+    @property
+    def history(self) -> Any:
+        """Compatibility property - returns complete_history."""
+
+        class MockAgentHistoryList:
+            def __init__(self, complete_history: list[CodeAgentHistory]):
+                self.history = complete_history
+
+        return MockAgentHistoryList(self.complete_history)
+
+    async def close(self) -> None:
+        """Close the browser session."""
+        if self.browser_session:
+            try:
+                await self.browser_session.stop()
+            except Exception as e:
+                logger.warning(f"Error closing browser session: {e}")
+
+    async def __aenter__(self) -> "CodeAgent":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Async context manager exit."""
+        await self.close()
+

--- a/src/openbrowser/code_use/utils.py
+++ b/src/openbrowser/code_use/utils.py
@@ -1,0 +1,149 @@
+"""Utility functions for code-use agent."""
+
+import re
+
+
+def truncate_message_content(content: str, max_length: int = 10000) -> str:
+    """Truncate message content to max_length characters for history."""
+    if len(content) <= max_length:
+        return content
+    # Truncate and add marker
+    return content[:max_length] + f"\n\n[... truncated {len(content) - max_length} characters for history]"
+
+
+def detect_token_limit_issue(
+    completion: str,
+    completion_tokens: int | None,
+    max_tokens: int | None,
+    stop_reason: str | None,
+) -> tuple[bool, str | None]:
+    """
+    Detect if the LLM response hit token limits or is repetitive garbage.
+
+    Returns: (is_problematic, error_message)
+    """
+    # Check 1: Stop reason indicates max_tokens
+    if stop_reason == "max_tokens":
+        return True, f"Response terminated due to max_tokens limit (stop_reason: {stop_reason})"
+
+    # Check 2: Used 90%+ of max_tokens (if we have both values)
+    if completion_tokens is not None and max_tokens is not None and max_tokens > 0:
+        usage_ratio = completion_tokens / max_tokens
+        if usage_ratio >= 0.9:
+            return True, f"Response used {usage_ratio:.1%} of max_tokens ({completion_tokens}/{max_tokens})"
+
+    # Check 3: Last 6 characters repeat 40+ times (repetitive garbage)
+    if len(completion) >= 6:
+        last_6 = completion[-6:]
+        repetition_count = completion.count(last_6)
+        if repetition_count >= 40:
+            return True, f'Repetitive output detected: last 6 chars "{last_6}" appears {repetition_count} times'
+
+    return False, None
+
+
+def extract_url_from_task(task: str) -> str | None:
+    """Extract URL from task string using naive pattern matching."""
+    # Remove email addresses from task before looking for URLs
+    task_without_emails = re.sub(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", "", task)
+
+    # Look for common URL patterns
+    patterns = [
+        r"https?://[^\s<>\"']+",  # Full URLs with http/https
+        r"(?:www\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(?:/[^\s<>\"']*)?",  # Domain names
+    ]
+
+    found_urls = []
+    for pattern in patterns:
+        matches = re.finditer(pattern, task_without_emails)
+        for match in matches:
+            url = match.group(0)
+
+            # Remove trailing punctuation that's not part of URLs
+            url = re.sub(r"[.,;:!?()\[\]]+$", "", url)
+            # Add https:// if missing
+            if not url.startswith(("http://", "https://")):
+                url = "https://" + url
+            found_urls.append(url)
+
+    unique_urls = list(set(found_urls))
+    # If multiple URLs found, skip auto-navigation to avoid ambiguity
+    if len(unique_urls) > 1:
+        return None
+
+    # If exactly one URL found, return it
+    if len(unique_urls) == 1:
+        return unique_urls[0]
+
+    return None
+
+
+def extract_code_blocks(text: str) -> dict[str, str]:
+    """Extract all code blocks from markdown response.
+
+    Supports:
+    - ```python, ```js, ```javascript, ```bash, ```markdown, ```md
+    - Named blocks: ```js variable_name → saved as 'variable_name' in namespace
+    - Nested blocks: Use 4+ backticks for outer block when inner content has 3 backticks
+
+    Returns dict mapping block_name -> content
+
+    Note: Python blocks are NO LONGER COMBINED. Each python block executes separately
+    to allow sequential execution with JS/bash blocks in between.
+    """
+    # Pattern to match code blocks with language identifier and optional variable name
+    pattern = r"(`{3,})(\w+)(?:\s+(\w+))?\n(.*?)\1(?:\n|$)"
+    matches = re.findall(pattern, text, re.DOTALL)
+
+    blocks: dict[str, str] = {}
+    python_block_counter = 0
+
+    for backticks, lang, var_name, content in matches:
+        lang = lang.lower()
+
+        # Normalize language names
+        if lang in ("javascript", "js"):
+            lang_normalized = "js"
+        elif lang in ("markdown", "md"):
+            lang_normalized = "markdown"
+        elif lang in ("sh", "shell"):
+            lang_normalized = "bash"
+        elif lang == "python":
+            lang_normalized = "python"
+        else:
+            # Unknown language, skip
+            continue
+
+        # Only process supported types
+        if lang_normalized in ("python", "js", "bash", "markdown"):
+            content = content.rstrip()  # Only strip trailing whitespace
+            if content:
+                # Determine the key to use
+                if var_name:
+                    # Named block - use the variable name
+                    block_key = var_name
+                    blocks[block_key] = content
+                elif lang_normalized == "python":
+                    # Unnamed Python blocks - give each a unique key
+                    block_key = f"python_{python_block_counter}"
+                    blocks[block_key] = content
+                    python_block_counter += 1
+                else:
+                    # Other unnamed blocks - keep last one only
+                    blocks[lang_normalized] = content
+
+    # If we have multiple python blocks, mark the first one as 'python' for backward compat
+    if python_block_counter > 0:
+        blocks["python"] = blocks["python_0"]
+
+    # Fallback: if no python block but there's generic ``` block, treat as python
+    if python_block_counter == 0 and "python" not in blocks:
+        generic_pattern = r"```\n(.*?)```"
+        generic_matches = re.findall(generic_pattern, text, re.DOTALL)
+        if generic_matches:
+            combined = "\n\n".join(m.strip() for m in generic_matches if m.strip())
+            if combined:
+                blocks["python"] = combined
+
+    return blocks
+

--- a/src/openbrowser/code_use/views.py
+++ b/src/openbrowser/code_use/views.py
@@ -1,0 +1,171 @@
+"""Data models for code-use mode."""
+
+import base64
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CellType(str, Enum):
+    """Type of notebook cell."""
+
+    CODE = "code"
+    MARKDOWN = "markdown"
+
+
+class ExecutionStatus(str, Enum):
+    """Execution status of a cell."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    ERROR = "error"
+
+
+class CodeCell(BaseModel):
+    """Represents a code cell in the notebook-like execution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    cell_type: CellType = CellType.CODE
+    source: str = Field(description="The code to execute")
+    output: str | None = Field(default=None, description="The output of the code execution")
+    execution_count: int | None = Field(default=None, description="The execution count")
+    status: ExecutionStatus = Field(default=ExecutionStatus.PENDING)
+    error: str | None = Field(default=None, description="Error message if execution failed")
+    browser_state: str | None = Field(default=None, description="Browser state after execution")
+
+
+class NotebookSession(BaseModel):
+    """Represents a notebook-like session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    cells: list[CodeCell] = Field(default_factory=list)
+    current_execution_count: int = Field(default=0)
+    namespace: dict[str, Any] = Field(default_factory=dict, description="Current namespace state")
+
+    def add_cell(self, source: str) -> CodeCell:
+        """Add a new code cell to the session."""
+        cell = CodeCell(source=source)
+        self.cells.append(cell)
+        return cell
+
+    def get_cell(self, cell_id: str) -> CodeCell | None:
+        """Get a cell by ID."""
+        for cell in self.cells:
+            if cell.id == cell_id:
+                return cell
+        return None
+
+    def get_latest_cell(self) -> CodeCell | None:
+        """Get the most recently added cell."""
+        if self.cells:
+            return self.cells[-1]
+        return None
+
+    def increment_execution_count(self) -> int:
+        """Increment and return the execution count."""
+        self.current_execution_count += 1
+        return self.current_execution_count
+
+
+class NotebookExport(BaseModel):
+    """Export format for Jupyter notebook."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    nbformat: int = Field(default=4)
+    nbformat_minor: int = Field(default=5)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    cells: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class CodeAgentModelOutput(BaseModel):
+    """Model output for CodeAgent - contains the code and full LLM response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_output: str = Field(description="The extracted code from the LLM response")
+    full_response: str = Field(description="The complete LLM response including any text/reasoning")
+
+
+class CodeAgentResult(BaseModel):
+    """Result of executing a code cell in CodeAgent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    extracted_content: str | None = Field(default=None, description="Output from code execution")
+    error: str | None = Field(default=None, description="Error message if execution failed")
+    is_done: bool = Field(default=False, description="Whether task is marked as done")
+    success: bool | None = Field(default=None, description="Self-reported success from done() call")
+
+
+class CodeAgentState(BaseModel):
+    """State information for a CodeAgent step."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    url: str | None = Field(default=None, description="Current page URL")
+    title: str | None = Field(default=None, description="Current page title")
+    screenshot_path: str | None = Field(default=None, description="Path to screenshot file")
+
+    def get_screenshot(self) -> str | None:
+        """Load screenshot from disk and return as base64 string."""
+        if not self.screenshot_path:
+            return None
+
+        path_obj = Path(self.screenshot_path)
+        if not path_obj.exists():
+            return None
+
+        try:
+            with open(path_obj, "rb") as f:
+                screenshot_data = f.read()
+            return base64.b64encode(screenshot_data).decode("utf-8")
+        except Exception:
+            return None
+
+
+class CodeAgentStepMetadata(BaseModel):
+    """Metadata for a single CodeAgent step including timing and token information."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_tokens: int | None = Field(default=None, description="Number of input tokens used")
+    output_tokens: int | None = Field(default=None, description="Number of output tokens used")
+    step_start_time: float = Field(description="Step start timestamp (Unix time)")
+    step_end_time: float = Field(description="Step end timestamp (Unix time)")
+
+    @property
+    def duration_seconds(self) -> float:
+        """Calculate step duration in seconds."""
+        return self.step_end_time - self.step_start_time
+
+
+class CodeAgentHistory(BaseModel):
+    """History item for CodeAgent actions."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    model_output: CodeAgentModelOutput | None = Field(default=None, description="LLM output for this step")
+    result: list[CodeAgentResult] = Field(default_factory=list, description="Results from code execution")
+    state: CodeAgentState = Field(description="Browser state at this step")
+    metadata: CodeAgentStepMetadata | None = Field(default=None, description="Step timing and token metadata")
+    screenshot_path: str | None = Field(default=None, description="Legacy field for screenshot path")
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        """Custom serialization for CodeAgentHistory."""
+        return {
+            "model_output": self.model_output.model_dump() if self.model_output else None,
+            "result": [r.model_dump() for r in self.result],
+            "state": self.state.model_dump(),
+            "metadata": self.metadata.model_dump() if self.metadata else None,
+            "screenshot_path": self.screenshot_path,
+        }
+


### PR DESCRIPTION
This pull request introduces new modules and utilities for the code-use agent, supporting Jupyter notebook-like code execution for browser automation. The most significant changes include implementing a robust namespace initialization for interactive browser sessions, formatting helpers for LLM consumption, and utility functions for code block extraction and token limit detection.

**Code-use agent infrastructure:**

* Added `src/openbrowser/code_use/__init__.py` to define public API exports for the code-use agent, centralizing imports and available types.
* Implemented `create_namespace` in `src/openbrowser/code_use/namespace.py` to initialize a dynamic Python namespace with browser tools and custom `evaluate` logic, enabling seamless code execution and interaction similar to Jupyter notebooks.

**Formatting and utility functions:**

* Added `format_browser_state_for_llm` in `src/openbrowser/code_use/formatting.py` to generate detailed, context-rich browser state summaries for LLM prompts, including DOM, available variables, and scroll info.
* Introduced utility functions in `src/openbrowser/code_use/utils.py` for truncating message content, detecting token limit issues in LLM responses, extracting URLs from tasks, and parsing code blocks from markdown responses.

**Documentation and error handling:**

* Provided dynamic documentation generation for available namespace functions via `get_namespace_documentation`, and improved error handling for browser code evaluation and tool execution.This pull request introduces several new modules and utilities to support a "code-use agent" for browser automation, providing a Jupyter notebook-like environment for interactive code execution and browser control. The main changes include the addition of code execution namespace management, browser state formatting for LLM consumption, and utility functions for code extraction and token limit handling.

**Code-use agent infrastructure:**

* Added `src/openbrowser/code_use/namespace.py` to create and manage a Python namespace with browser tools and a custom `evaluate` function for executing JavaScript in the browser. This includes error handling, variable injection, and documentation generation for the interactive environment.
* Added `src/openbrowser/code_use/__init__.py` to expose key types, classes, and functions for the code-use agent module, enabling easier imports and module usage.

**Browser state formatting and LLM integration:**

* Added `src/openbrowser/code_use/formatting.py` with an async function to format the browser state (URL, title, DOM, variables, screenshots, page info) into a structured text summary for LLM input, including scroll position and variable details.

**Utility functions for agent operation:**

* Added `src/openbrowser/code_use/utils.py` with helpers for truncating message content, detecting LLM token limit issues, extracting URLs from tasks, and robustly extracting code blocks from markdown responses for sequential execution.Implements CodeAgent (notebook-like code execution), NotebookSession state models, namespace helpers, and formatting utilities for code-use mode. Reviewers: check execution sandboxing and namespace safety.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CodeAgent for notebook-like code execution to automate the browser, with a persistent namespace and typed step history. Includes browser state formatting, JS execution via CDP, screenshot capture, and safeguards for errors and token limits.

- **New Features**
  - CodeAgent run loop with step limits, consecutive error protection, and finalization via done().
  - Persistent namespace with browser Tools and a custom evaluate() that runs JS (CDP), strips comments, injects variables, and returns Python values.
  - Multiple code blocks support: extracts markdown fenced blocks, executes python blocks sequentially, and injects non-python blocks as named variables.
  - Browser state formatter: URL, title, scroll hints, DOM truncation, and available variables; optional vision screenshots in prompts.
  - Typed history models (result, state, metadata) with screenshot paths and session cells for notebook-style tracking.
  - Token-limit and repetitive-output detection with concise recovery prompts; safe output truncation for message history.

- **Migration**
  - Import from openbrowser.code_use and instantiate CodeAgent(task, llm, browser_session?).
  - Call await agent.run(); use done(success=?, result=?) to finish and return outputs.
  - Use evaluate(code, variables?) for JS; it auto-wraps IIFEs and returns Python-native results.
  - The action name input is exposed as input_text to avoid shadowing Python’s input().

<sup>Written for commit be4ed9ce107a13bc937d15a1acdc85aea1a076bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

