### PR TITLE
feat(observability): add observability decorators and telemetry service for product events

### DIFF
--- a/src/openbrowser/observability.py
+++ b/src/openbrowser/observability.py
@@ -1,0 +1,204 @@
+"""
+Observability module for openbrowser.
+
+This module provides observability decorators that optionally integrate with lmnr (Laminar) for tracing.
+If lmnr is not installed, it provides no-op wrappers that accept the same parameters.
+
+Features:
+- Optional lmnr integration - works with or without lmnr installed
+- Debug mode support - observe_debug only traces when in debug mode
+- Full parameter compatibility with lmnr observe decorator
+- No-op fallbacks when lmnr is unavailable
+"""
+
+import asyncio
+import logging
+import os
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Literal, TypeVar, cast
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Type definitions
+F = TypeVar('F', bound=Callable[..., Any])
+
+
+def _is_debug_mode() -> bool:
+    """Check if we're in debug mode based on environment variables or logging level."""
+    lmnr_debug_mode = os.getenv('LMNR_LOGGING_LEVEL', '').lower()
+    if lmnr_debug_mode == 'debug':
+        return True
+    
+    openbrowser_debug = os.getenv('OPENBROWSER_DEBUG', '').lower()
+    if openbrowser_debug in ('1', 'true', 'yes', 'on'):
+        return True
+    
+    # Check root logger level
+    if logging.root.level <= logging.DEBUG:
+        return True
+    
+    return False
+
+
+# Try to import lmnr observe
+_LMNR_AVAILABLE = False
+_lmnr_observe = None
+
+try:
+    from lmnr import observe as _lmnr_observe  # type: ignore
+
+    if os.environ.get('OPENBROWSER_VERBOSE_OBSERVABILITY', 'false').lower() == 'true':
+        logger.debug('Lmnr is available for observability')
+    _LMNR_AVAILABLE = True
+except ImportError:
+    if os.environ.get('OPENBROWSER_VERBOSE_OBSERVABILITY', 'false').lower() == 'true':
+        logger.debug('Lmnr is not available for observability')
+    _LMNR_AVAILABLE = False
+
+
+def _create_no_op_decorator(
+    name: str | None = None,
+    ignore_input: bool = False,
+    ignore_output: bool = False,
+    metadata: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> Callable[[F], F]:
+    """Create a no-op decorator that accepts all lmnr observe parameters but does nothing."""
+
+    def decorator(func: F) -> F:
+        if asyncio.iscoroutinefunction(func):
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await func(*args, **kwargs)
+            return cast(F, async_wrapper)
+        else:
+            @wraps(func)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+            return cast(F, sync_wrapper)
+
+    return decorator
+
+
+def observe(
+    name: str | None = None,
+    ignore_input: bool = False,
+    ignore_output: bool = False,
+    metadata: dict[str, Any] | None = None,
+    span_type: Literal['DEFAULT', 'LLM', 'TOOL'] = 'DEFAULT',
+    **kwargs: Any,
+) -> Callable[[F], F]:
+    """
+    Observability decorator that traces function execution when lmnr is available.
+
+    This decorator will use lmnr's observe decorator if lmnr is installed,
+    otherwise it will be a no-op that accepts the same parameters.
+
+    Args:
+        name: Name of the span/trace
+        ignore_input: Whether to ignore function input parameters in tracing
+        ignore_output: Whether to ignore function output in tracing
+        metadata: Additional metadata to attach to the span
+        span_type: Type of span (DEFAULT, LLM, TOOL)
+        **kwargs: Additional parameters passed to lmnr observe
+
+    Returns:
+        Decorated function that may be traced depending on lmnr availability
+
+    Example:
+        @observe(name="my_function", metadata={"version": "1.0"})
+        def my_function(param1, param2):
+            return param1 + param2
+    """
+    observe_kwargs = {
+        'name': name,
+        'ignore_input': ignore_input,
+        'ignore_output': ignore_output,
+        'metadata': metadata,
+        'span_type': span_type,
+        'tags': ['observe'],
+        **kwargs,
+    }
+
+    if _LMNR_AVAILABLE and _lmnr_observe:
+        return cast(Callable[[F], F], _lmnr_observe(**observe_kwargs))
+    else:
+        return _create_no_op_decorator(**observe_kwargs)
+
+
+def observe_debug(
+    name: str | None = None,
+    ignore_input: bool = False,
+    ignore_output: bool = False,
+    metadata: dict[str, Any] | None = None,
+    span_type: Literal['DEFAULT', 'LLM', 'TOOL'] = 'DEFAULT',
+    **kwargs: Any,
+) -> Callable[[F], F]:
+    """
+    Debug-only observability decorator that only traces when in debug mode.
+
+    This decorator will use lmnr's observe decorator if both lmnr is installed
+    AND we're in debug mode, otherwise it will be a no-op.
+
+    Debug mode is determined by:
+    - LMNR_LOGGING_LEVEL environment variable set to debug
+    - OPENBROWSER_DEBUG environment variable set to 1/true/yes/on
+    - Root logging level set to DEBUG or lower
+
+    Args:
+        name: Name of the span/trace
+        ignore_input: Whether to ignore function input parameters in tracing
+        ignore_output: Whether to ignore function output in tracing
+        metadata: Additional metadata to attach to the span
+        span_type: Type of span (DEFAULT, LLM, TOOL)
+        **kwargs: Additional parameters passed to lmnr observe
+
+    Returns:
+        Decorated function that may be traced only in debug mode
+
+    Example:
+        @observe_debug(ignore_input=True, ignore_output=True, name="debug_function")
+        def debug_function(param1, param2):
+            return param1 + param2
+    """
+    observe_kwargs = {
+        'name': name,
+        'ignore_input': ignore_input,
+        'ignore_output': ignore_output,
+        'metadata': metadata,
+        'span_type': span_type,
+        'tags': ['observe_debug'],
+        **kwargs,
+    }
+
+    if _LMNR_AVAILABLE and _lmnr_observe and _is_debug_mode():
+        return cast(Callable[[F], F], _lmnr_observe(**observe_kwargs))
+    else:
+        return _create_no_op_decorator(**observe_kwargs)
+
+
+# Convenience functions for checking availability and debug status
+def is_lmnr_available() -> bool:
+    """Check if lmnr is available for tracing."""
+    return _LMNR_AVAILABLE
+
+
+def is_debug_mode() -> bool:
+    """Check if we're currently in debug mode."""
+    return _is_debug_mode()
+
+
+def get_observability_status() -> dict[str, bool]:
+    """Get the current status of observability features."""
+    return {
+        'lmnr_available': _LMNR_AVAILABLE,
+        'debug_mode': _is_debug_mode(),
+        'observe_active': _LMNR_AVAILABLE,
+        'observe_debug_active': _LMNR_AVAILABLE and _is_debug_mode(),
+    }
+

--- a/src/openbrowser/telemetry/__init__.py
+++ b/src/openbrowser/telemetry/__init__.py
@@ -1,0 +1,7 @@
+"""Telemetry module for tracking agent performance."""
+
+from .service import ProductTelemetry
+from .views import AgentTelemetryEvent
+
+__all__ = ["ProductTelemetry", "AgentTelemetryEvent"]
+

--- a/src/openbrowser/telemetry/service.py
+++ b/src/openbrowser/telemetry/service.py
@@ -1,0 +1,175 @@
+"""Telemetry service for tracking agent performance."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Optional
+
+from src.openbrowser.telemetry.views import AgentTelemetryEvent, StepTelemetryEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ProductTelemetry:
+    """
+    Telemetry service for tracking agent runs and performance.
+    Uses PostHog for analytics when available.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        enabled: bool | None = None,
+    ):
+        """
+        Initialize telemetry service.
+
+        Args:
+            api_key: PostHog API key (or POSTHOG_API_KEY env var)
+            enabled: Whether telemetry is enabled (or OPENBROWSER_TELEMETRY_ENABLED env var)
+        """
+        self._enabled = enabled if enabled is not None else self._is_enabled()
+        self._api_key = api_key or os.environ.get("POSTHOG_API_KEY")
+        self._posthog = None
+        self._user_id = self._get_user_id()
+
+        if self._enabled and self._api_key:
+            self._init_posthog()
+
+    def _is_enabled(self) -> bool:
+        """Check if telemetry is enabled via environment variable."""
+        env_value = os.environ.get("OPENBROWSER_TELEMETRY_ENABLED", "true").lower()
+        return env_value not in ("false", "0", "no", "off")
+
+    def _get_user_id(self) -> str:
+        """Get or generate a unique user ID."""
+        # Try to get from environment or generate a new one
+        user_id = os.environ.get("OPENBROWSER_USER_ID")
+        if not user_id:
+            user_id = str(uuid.uuid4())
+        return user_id
+
+    def _init_posthog(self) -> None:
+        """Initialize PostHog client."""
+        try:
+            import posthog
+
+            posthog.project_api_key = self._api_key
+            posthog.host = "https://app.posthog.com"
+            self._posthog = posthog
+            logger.debug("PostHog telemetry initialized")
+        except ImportError:
+            logger.debug("PostHog not installed, telemetry disabled")
+            self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        """Check if telemetry is enabled."""
+        return self._enabled and self._posthog is not None
+
+    def track_agent_run(self, event: AgentTelemetryEvent) -> None:
+        """
+        Track an agent run event.
+
+        Args:
+            event: Agent telemetry event to track
+        """
+        if not self.enabled:
+            return
+
+        try:
+            self._posthog.capture(
+                distinct_id=self._user_id,
+                event="agent_run",
+                properties={
+                    "run_id": event.run_id,
+                    "task_length": len(event.task),
+                    "total_steps": event.total_steps,
+                    "total_duration_seconds": event.total_duration_seconds,
+                    "is_successful": event.is_successful,
+                    "is_done": event.is_done,
+                    "total_errors": event.total_errors,
+                    "llm_provider": event.llm_provider,
+                    "llm_model": event.llm_model,
+                    "total_llm_calls": event.total_llm_calls,
+                    "total_input_tokens": event.total_input_tokens,
+                    "total_output_tokens": event.total_output_tokens,
+                    "total_cost": event.total_cost,
+                    "total_actions": event.total_actions,
+                    "action_summary": event.action_summary,
+                    "browser_headless": event.browser_headless,
+                    "use_vision": event.use_vision,
+                    "version": event.version,
+                },
+            )
+            logger.debug(f"Tracked agent run: {event.run_id}")
+        except Exception as e:
+            logger.warning(f"Failed to track agent run: {e}")
+
+    def track_step(self, event: StepTelemetryEvent) -> None:
+        """
+        Track an individual step event.
+
+        Args:
+            event: Step telemetry event to track
+        """
+        if not self.enabled:
+            return
+
+        try:
+            self._posthog.capture(
+                distinct_id=self._user_id,
+                event="agent_step",
+                properties={
+                    "run_id": event.run_id,
+                    "step_number": event.step_number,
+                    "action_name": event.action_name,
+                    "duration_seconds": event.duration_seconds,
+                    "is_successful": event.is_successful,
+                    "has_error": event.error is not None,
+                },
+            )
+        except Exception as e:
+            logger.warning(f"Failed to track step: {e}")
+
+    def track_error(self, run_id: str, error: str) -> None:
+        """
+        Track an error event.
+
+        Args:
+            run_id: Run identifier
+            error: Error message
+        """
+        if not self.enabled:
+            return
+
+        try:
+            self._posthog.capture(
+                distinct_id=self._user_id,
+                event="agent_error",
+                properties={
+                    "run_id": run_id,
+                    "error": error[:500],  # Truncate long errors
+                },
+            )
+        except Exception as e:
+            logger.warning(f"Failed to track error: {e}")
+
+    def flush(self) -> None:
+        """Flush pending events."""
+        if self._posthog:
+            try:
+                self._posthog.flush()
+            except Exception as e:
+                logger.warning(f"Failed to flush telemetry: {e}")
+
+    def shutdown(self) -> None:
+        """Shutdown telemetry service."""
+        if self._posthog:
+            try:
+                self._posthog.shutdown()
+            except Exception as e:
+                logger.warning(f"Failed to shutdown telemetry: {e}")
+

--- a/src/openbrowser/telemetry/views.py
+++ b/src/openbrowser/telemetry/views.py
@@ -1,0 +1,55 @@
+"""Telemetry views and event models."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentTelemetryEvent(BaseModel):
+    """Telemetry event for agent runs."""
+
+    # Run identification
+    run_id: str = Field(description="Unique identifier for this run")
+    task: str = Field(description="The task description")
+
+    # Run metrics
+    total_steps: int = Field(default=0, description="Total number of steps taken")
+    total_duration_seconds: float = Field(default=0.0, description="Total duration in seconds")
+    is_successful: Optional[bool] = Field(default=None, description="Whether the task was successful")
+    is_done: bool = Field(default=False, description="Whether the task completed")
+
+    # Error tracking
+    total_errors: int = Field(default=0, description="Total number of errors encountered")
+    last_error: Optional[str] = Field(default=None, description="Last error message")
+
+    # LLM metrics
+    llm_provider: str = Field(default="unknown", description="LLM provider used")
+    llm_model: str = Field(default="unknown", description="LLM model used")
+    total_llm_calls: int = Field(default=0, description="Total LLM API calls")
+    total_input_tokens: int = Field(default=0, description="Total input tokens")
+    total_output_tokens: int = Field(default=0, description="Total output tokens")
+    total_cost: float = Field(default=0.0, description="Estimated total cost in USD")
+
+    # Actions
+    total_actions: int = Field(default=0, description="Total actions executed")
+    action_summary: dict[str, int] = Field(default_factory=dict, description="Count of each action type")
+
+    # Metadata
+    browser_headless: bool = Field(default=True, description="Whether browser was in headless mode")
+    use_vision: bool = Field(default=True, description="Whether vision was enabled")
+    version: str = Field(default="0.1.0", description="OpenBrowser version")
+
+
+class StepTelemetryEvent(BaseModel):
+    """Telemetry event for individual steps."""
+
+    run_id: str
+    step_number: int
+    action_name: str
+    action_params: dict
+    duration_seconds: float
+    is_successful: bool
+    error: Optional[str] = None
+


### PR DESCRIPTION
This pull request introduces a new observability and telemetry system for the `openbrowser` project. It adds optional integration with the `lmnr` tracing library, as well as a structured telemetry service for tracking agent performance using PostHog analytics. The implementation ensures graceful fallback when dependencies are missing and provides clear interfaces for event tracking and observability status.

**Observability Integration:**

- Added a new `observability.py` module that provides decorators (`observe`, `observe_debug`) for function tracing, with optional integration with the `lmnr` library. If `lmnr` is not installed, the decorators act as no-ops but maintain full parameter compatibility. Debug-only tracing is supported, and convenience methods are included for checking observability status.

**Telemetry Service:**

- Introduced a new telemetry service in `telemetry/service.py` (`ProductTelemetry`) that tracks agent runs, steps, and errors. The service uses PostHog for analytics when available, supports environment-based configuration, and includes robust error handling and lifecycle management (flush and shutdown).
- Added event model definitions in `telemetry/views.py` for agent and step telemetry events using Pydantic for validation and structure.
- Created a telemetry module initializer in `telemetry/__init__.py` to expose the main service and event types.Implements observability and telemetry modules per CHANGELOG and commit_plan.md. Includes observability decorators and a telemetry service; does NOT include or modify browser-use/, cdp-use/, bubus/ directories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add observability decorators and a ProductTelemetry service to capture agent runs and steps. Optional lmnr tracing and PostHog analytics with safe no-op fallbacks.

- **New Features**
  - observe and observe_debug decorators with lmnr-compatible params; fall back to no-op when lmnr is missing; observe_debug only active in debug mode.
  - Status helpers: is_lmnr_available, is_debug_mode, get_observability_status.
  - ProductTelemetry with PostHog integration: tracks agent_run, agent_step, agent_error; includes flush and shutdown; user ID generation and enable flag via env.
  - Pydantic models: AgentTelemetryEvent and StepTelemetryEvent; telemetry module exports ProductTelemetry and AgentTelemetryEvent.

- **Migration**
  - Set POSTHOG_API_KEY to enable analytics; otherwise telemetry stays disabled.
  - OPENBROWSER_TELEMETRY_ENABLED defaults to true; set to false/0/off to disable.
  - Optional OPENBROWSER_USER_ID to persist identity across runs.
  - Debug-only tracing via LMNR_LOGGING_LEVEL=debug or OPENBROWSER_DEBUG=1 for observe_debug.

<sup>Written for commit 6a03854c6341d13b8f4818aa76bdbd8854ce49dd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

