### PR TITLE
feat(screenshots,tokens): add screenshot service and token tracking models

### DIFF
--- a/src/openbrowser/screenshots/__init__.py
+++ b/src/openbrowser/screenshots/__init__.py
@@ -1,0 +1,6 @@
+"""Screenshot management module."""
+
+from .service import ScreenshotService
+
+__all__ = ["ScreenshotService"]
+

--- a/src/openbrowser/screenshots/service.py
+++ b/src/openbrowser/screenshots/service.py
@@ -1,0 +1,183 @@
+"""Screenshot service for storage and management."""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from src.openbrowser.browser.session import BrowserSession, CDPSession
+
+logger = logging.getLogger(__name__)
+
+
+class ScreenshotService:
+    """
+    Service for managing screenshots during agent execution.
+    Handles capture, storage, and retrieval of screenshots.
+    """
+
+    def __init__(
+        self,
+        save_path: str | Path | None = None,
+        format: str = "png",
+        quality: int = 90,
+    ):
+        """
+        Initialize screenshot service.
+
+        Args:
+            save_path: Directory to save screenshots (None for in-memory only)
+            format: Image format (png or jpeg)
+            quality: JPEG quality (1-100)
+        """
+        self.save_path = Path(save_path) if save_path else None
+        self.format = format
+        self.quality = quality
+        self._screenshots: list[str] = []  # Base64 encoded screenshots
+        self._step_counter = 0
+
+        if self.save_path:
+            self.save_path.mkdir(parents=True, exist_ok=True)
+
+    async def take_screenshot(
+        self,
+        cdp_session: CDPSession,
+        step_number: int | None = None,
+        save: bool = True,
+    ) -> str:
+        """
+        Take a screenshot of the current page.
+
+        Args:
+            cdp_session: CDP session to use
+            step_number: Optional step number for naming
+            save: Whether to save to disk
+
+        Returns:
+            Base64-encoded screenshot data
+        """
+        try:
+            result = await cdp_session.cdp_client.send.Page.captureScreenshot(
+                params={
+                    "format": self.format,
+                    "quality": self.quality if self.format == "jpeg" else None,
+                },
+                session_id=cdp_session.session_id,
+            )
+
+            screenshot_b64 = result.get("data", "")
+
+            if not screenshot_b64:
+                logger.warning("Empty screenshot data received")
+                return ""
+
+            # Store in memory
+            self._screenshots.append(screenshot_b64)
+
+            # Save to disk if configured
+            if save and self.save_path:
+                step = step_number if step_number is not None else self._step_counter
+                self._step_counter += 1
+                file_path = self.save_path / f"step_{step:04d}.{self.format}"
+                self._save_to_file(screenshot_b64, file_path)
+                logger.debug(f"Screenshot saved to {file_path}")
+
+            return screenshot_b64
+
+        except Exception as e:
+            logger.error(f"Failed to take screenshot: {e}")
+            return ""
+
+    def _save_to_file(self, screenshot_b64: str, file_path: Path) -> None:
+        """Save base64 screenshot to file."""
+        try:
+            image_data = base64.b64decode(screenshot_b64)
+            with open(file_path, "wb") as f:
+                f.write(image_data)
+        except Exception as e:
+            logger.error(f"Failed to save screenshot to {file_path}: {e}")
+
+    def add_screenshot(self, screenshot_b64: str) -> None:
+        """Add a screenshot to the collection."""
+        self._screenshots.append(screenshot_b64)
+
+    def get_screenshots(self) -> list[str]:
+        """Get all collected screenshots."""
+        return self._screenshots.copy()
+
+    def get_latest(self) -> str | None:
+        """Get the latest screenshot."""
+        return self._screenshots[-1] if self._screenshots else None
+
+    def get_by_step(self, step: int) -> str | None:
+        """Get screenshot by step number."""
+        if 0 <= step < len(self._screenshots):
+            return self._screenshots[step]
+        return None
+
+    def count(self) -> int:
+        """Get the number of screenshots."""
+        return len(self._screenshots)
+
+    def clear(self) -> None:
+        """Clear all screenshots from memory."""
+        self._screenshots.clear()
+        self._step_counter = 0
+
+    def get_screenshot_paths(self) -> list[Path]:
+        """Get paths to all saved screenshots."""
+        if not self.save_path:
+            return []
+
+        paths = sorted(self.save_path.glob(f"*.{self.format}"))
+        return paths
+
+    @staticmethod
+    def decode_to_bytes(screenshot_b64: str) -> bytes:
+        """Decode base64 screenshot to bytes."""
+        return base64.b64decode(screenshot_b64)
+
+    @staticmethod
+    def encode_from_bytes(image_bytes: bytes) -> str:
+        """Encode bytes to base64 string."""
+        return base64.b64encode(image_bytes).decode("utf-8")
+
+    def resize_screenshot(
+        self,
+        screenshot_b64: str,
+        width: int,
+        height: int,
+    ) -> str:
+        """
+        Resize a screenshot.
+
+        Args:
+            screenshot_b64: Base64-encoded screenshot
+            width: Target width
+            height: Target height
+
+        Returns:
+            Resized base64-encoded screenshot
+        """
+        try:
+            from PIL import Image
+
+            image_data = base64.b64decode(screenshot_b64)
+            image = Image.open(io.BytesIO(image_data))
+            resized = image.resize((width, height), Image.Resampling.LANCZOS)
+
+            buffer = io.BytesIO()
+            resized.save(buffer, format=self.format.upper())
+            return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+        except ImportError:
+            logger.warning("PIL not installed, cannot resize screenshot")
+            return screenshot_b64
+        except Exception as e:
+            logger.error(f"Failed to resize screenshot: {e}")
+            return screenshot_b64
+

--- a/src/openbrowser/tokens/__init__.py
+++ b/src/openbrowser/tokens/__init__.py
@@ -1,0 +1,7 @@
+"""Token cost tracking module."""
+
+from .service import TokenCost
+from .views import TokenUsage, ModelPricing
+
+__all__ = ["TokenCost", "TokenUsage", "ModelPricing"]
+

--- a/src/openbrowser/tokens/service.py
+++ b/src/openbrowser/tokens/service.py
@@ -1,0 +1,148 @@
+"""Token cost tracking service."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from src.openbrowser.tokens.views import ModelPricing, TokenUsage, CumulativeTokenUsage
+
+logger = logging.getLogger(__name__)
+
+# Pricing data (as of late 2024 - update as needed)
+MODEL_PRICING: dict[str, ModelPricing] = {
+    # OpenAI
+    "gpt-4o": ModelPricing(provider="openai", model="gpt-4o", input_cost_per_1k=0.0025, output_cost_per_1k=0.01),
+    "gpt-4o-mini": ModelPricing(provider="openai", model="gpt-4o-mini", input_cost_per_1k=0.00015, output_cost_per_1k=0.0006),
+    "gpt-4-turbo": ModelPricing(provider="openai", model="gpt-4-turbo", input_cost_per_1k=0.01, output_cost_per_1k=0.03),
+    "gpt-3.5-turbo": ModelPricing(provider="openai", model="gpt-3.5-turbo", input_cost_per_1k=0.0005, output_cost_per_1k=0.0015),
+    "o3": ModelPricing(provider="openai", model="o3", input_cost_per_1k=0.01, output_cost_per_1k=0.04),
+
+    # Anthropic
+    "claude-3-opus-20240229": ModelPricing(provider="anthropic", model="claude-3-opus-20240229", input_cost_per_1k=0.015, output_cost_per_1k=0.075),
+    "claude-3-5-sonnet-20241022": ModelPricing(provider="anthropic", model="claude-3-5-sonnet-20241022", input_cost_per_1k=0.003, output_cost_per_1k=0.015),
+    "claude-sonnet-4-20250514": ModelPricing(provider="anthropic", model="claude-sonnet-4-20250514", input_cost_per_1k=0.003, output_cost_per_1k=0.015),
+
+    # Google
+    "gemini-2.0-flash": ModelPricing(provider="google", model="gemini-2.0-flash", input_cost_per_1k=0.000075, output_cost_per_1k=0.0003),
+    "gemini-1.5-pro": ModelPricing(provider="google", model="gemini-1.5-pro", input_cost_per_1k=0.00125, output_cost_per_1k=0.005),
+    "gemini-1.5-flash": ModelPricing(provider="google", model="gemini-1.5-flash", input_cost_per_1k=0.000075, output_cost_per_1k=0.0003),
+
+    # Groq
+    "llama-3.3-70b-versatile": ModelPricing(provider="groq", model="llama-3.3-70b-versatile", input_cost_per_1k=0.00059, output_cost_per_1k=0.00079),
+    "llama-3.1-70b-versatile": ModelPricing(provider="groq", model="llama-3.1-70b-versatile", input_cost_per_1k=0.00059, output_cost_per_1k=0.00079),
+    "mixtral-8x7b-32768": ModelPricing(provider="groq", model="mixtral-8x7b-32768", input_cost_per_1k=0.00024, output_cost_per_1k=0.00024),
+}
+
+
+class TokenCost:
+    """
+    Token cost tracking service.
+    Tracks usage and calculates costs for LLM API calls.
+    """
+
+    def __init__(self, model: str | None = None):
+        """
+        Initialize token cost tracker.
+
+        Args:
+            model: Model name for pricing lookup
+        """
+        self.model = model
+        self.cumulative = CumulativeTokenUsage()
+        self._pricing = self._get_pricing(model) if model else None
+
+    def _get_pricing(self, model: str) -> Optional[ModelPricing]:
+        """Get pricing for a model."""
+        # Try exact match first
+        if model in MODEL_PRICING:
+            return MODEL_PRICING[model]
+
+        # Try partial match
+        for key, pricing in MODEL_PRICING.items():
+            if key in model or model in key:
+                return pricing
+
+        logger.warning(f"No pricing found for model: {model}")
+        return None
+
+    def set_model(self, model: str) -> None:
+        """Set the current model for pricing."""
+        self.model = model
+        self._pricing = self._get_pricing(model)
+
+    def calculate_cost(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        image_count: int = 0,
+    ) -> TokenUsage:
+        """
+        Calculate cost for token usage.
+
+        Args:
+            input_tokens: Number of input tokens
+            output_tokens: Number of output tokens
+            image_count: Number of images processed
+
+        Returns:
+            TokenUsage with calculated costs
+        """
+        usage = TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+            image_count=image_count,
+        )
+
+        if self._pricing:
+            usage.input_cost = (input_tokens / 1000) * self._pricing.input_cost_per_1k
+            usage.output_cost = (output_tokens / 1000) * self._pricing.output_cost_per_1k
+            usage.image_cost = image_count * self._pricing.image_cost
+            usage.total_cost = usage.input_cost + usage.output_cost + usage.image_cost
+
+        # Add to cumulative
+        self.cumulative.add(usage)
+
+        return usage
+
+    def track(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        image_count: int = 0,
+    ) -> float:
+        """
+        Track token usage and return total cost.
+
+        Args:
+            input_tokens: Number of input tokens
+            output_tokens: Number of output tokens
+            image_count: Number of images processed
+
+        Returns:
+            Total cost in USD
+        """
+        usage = self.calculate_cost(input_tokens, output_tokens, image_count)
+        return usage.total_cost
+
+    def get_cumulative(self) -> CumulativeTokenUsage:
+        """Get cumulative usage across all calls."""
+        return self.cumulative
+
+    def reset(self) -> None:
+        """Reset cumulative usage."""
+        self.cumulative = CumulativeTokenUsage()
+
+    def get_summary(self) -> str:
+        """Get a summary of token usage and costs."""
+        return (
+            f"Token Usage Summary:\n"
+            f"  Calls: {self.cumulative.call_count}\n"
+            f"  Input tokens: {self.cumulative.total_input_tokens:,}\n"
+            f"  Output tokens: {self.cumulative.total_output_tokens:,}\n"
+            f"  Total tokens: {self.cumulative.total_tokens:,}\n"
+            f"  Images: {self.cumulative.total_images}\n"
+            f"  Total cost: ${self.cumulative.total_cost:.4f}"
+        )
+

--- a/src/openbrowser/tokens/views.py
+++ b/src/openbrowser/tokens/views.py
@@ -1,0 +1,51 @@
+"""Token cost tracking views and models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ModelPricing(BaseModel):
+    """Pricing information for a model."""
+
+    provider: str
+    model: str
+    input_cost_per_1k: float = Field(description="Cost per 1000 input tokens in USD")
+    output_cost_per_1k: float = Field(description="Cost per 1000 output tokens in USD")
+    image_cost: float = Field(default=0.0, description="Cost per image in USD")
+
+
+class TokenUsage(BaseModel):
+    """Token usage for a single LLM call."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    image_count: int = 0
+
+    # Calculated costs
+    input_cost: float = 0.0
+    output_cost: float = 0.0
+    image_cost: float = 0.0
+    total_cost: float = 0.0
+
+
+class CumulativeTokenUsage(BaseModel):
+    """Cumulative token usage across all LLM calls."""
+
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_tokens: int = 0
+    total_images: int = 0
+    total_cost: float = 0.0
+    call_count: int = 0
+
+    def add(self, usage: TokenUsage) -> None:
+        """Add usage from a single call."""
+        self.total_input_tokens += usage.input_tokens
+        self.total_output_tokens += usage.output_tokens
+        self.total_tokens += usage.total_tokens
+        self.total_images += usage.image_count
+        self.total_cost += usage.total_cost
+        self.call_count += 1
+


### PR DESCRIPTION
This pull request introduces two new modules to the codebase: a screenshot management service and a token cost tracking service. These modules add structured, reusable services for handling screenshots during browser automation and for tracking/costing LLM token usage, respectively. Both modules are organized with clear APIs and supporting data models.

**Screenshot management:**

* Added `ScreenshotService` in `src/openbrowser/screenshots/service.py` for capturing, storing (in memory and on disk), retrieving, and resizing screenshots, with support for step-based naming and optional JPEG/PNG formats.
* Exposed the screenshot service via the `src/openbrowser/screenshots/__init__.py` module initializer.

**Token cost tracking:**

* Introduced `TokenCost` service in `src/openbrowser/tokens/service.py` to track token usage and calculate costs for various LLM providers/models, supporting cumulative tracking and summary reporting.
* Defined supporting data models (`ModelPricing`, `TokenUsage`, `CumulativeTokenUsage`) in `src/openbrowser/tokens/views.py` for structured cost and usage representation, including extensible pricing support.
* Exposed the token cost tracking services and models via the `src/openbrowser/tokens/__init__.py` module initializer.Adds screenshot service and token tracking models per CHANGELOG and commit_plan.md. Does NOT modify browser-use/, cdp-use/, bubus/.