### PR TITLE
refactor(config,cli): add flexible config loader and signal handler utilities

### DIFF
--- a/src/openbrowser/cli.py
+++ b/src/openbrowser/cli.py
@@ -1,0 +1,208 @@
+"""CLI module for OpenBrowser."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    import click
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+except ImportError:
+    raise ImportError("Please install CLI dependencies: pip install click rich")
+
+from src.openbrowser.agent import BrowserAgent
+from src.openbrowser.agent.views import AgentSettings
+from src.openbrowser.browser.session import BrowserSession
+from src.openbrowser.browser.profile import BrowserProfile
+from src.openbrowser.llm import get_llm_by_name
+
+console = Console()
+
+
+@click.group()
+@click.version_option(version="0.1.0", prog_name="openbrowser")
+def cli():
+    """OpenBrowser - AI-powered browser automation."""
+    pass
+
+
+@cli.command()
+@click.argument("task")
+@click.option("--provider", "-p", default="openai", help="LLM provider (openai, anthropic, google, groq, ollama, openrouter, aws, azure)")
+@click.option("--model", "-m", default=None, help="Model name (uses provider default if not specified)")
+@click.option("--headless/--no-headless", default=True, help="Run browser in headless mode")
+@click.option("--max-steps", default=10, help="Maximum number of steps")
+@click.option("--vision/--no-vision", default=True, help="Use vision capabilities")
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
+@click.option("--save-gif", type=str, default=None, help="Save execution as GIF to specified path")
+def run(
+    task: str,
+    provider: str,
+    model: Optional[str],
+    headless: bool,
+    max_steps: int,
+    vision: bool,
+    verbose: bool,
+    save_gif: Optional[str],
+):
+    """Run a browser automation task."""
+    # Configure logging
+    log_level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+    console.print(Panel.fit(
+        f"[bold blue]OpenBrowser[/bold blue]\n"
+        f"Task: {task}\n"
+        f"Provider: {provider}\n"
+        f"Headless: {headless}",
+        title="Starting Agent",
+    ))
+
+    async def execute():
+        browser_profile = BrowserProfile(headless=headless)
+        browser_session = BrowserSession(browser_profile=browser_profile)
+
+        try:
+            await browser_session.start()
+
+            settings = AgentSettings(
+                use_vision=vision,
+                max_actions_per_step=4,
+            )
+
+            agent = BrowserAgent(
+                browser_session=browser_session,
+                llm_provider=provider,
+                llm_model=model or _get_default_model(provider),
+                max_steps=max_steps,
+                settings=settings,
+                task=task,
+            )
+
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                console=console,
+            ) as progress:
+                progress.add_task(description="Running agent...", total=None)
+                result = await agent.run(task)
+
+            # Display results
+            console.print()
+            if result.get("is_done"):
+                console.print(Panel.fit(
+                    f"[green]Task completed successfully![/green]\n\n"
+                    f"Steps: {result.get('total_steps', 0)}\n"
+                    f"Result: {result.get('final_result', 'N/A')[:200]}",
+                    title="Results",
+                ))
+            else:
+                console.print(Panel.fit(
+                    f"[yellow]Task did not complete[/yellow]\n\n"
+                    f"Steps: {result.get('total_steps', 0)}\n"
+                    f"Errors: {result.get('errors', [])}",
+                    title="Results",
+                ))
+
+            # Save GIF if requested
+            if save_gif:
+                try:
+                    from src.openbrowser.agent.gif import create_gif_from_screenshots
+                    screenshots = result.get("screenshots", [])
+                    if screenshots:
+                        gif_path = create_gif_from_screenshots(screenshots, save_gif)
+                        console.print(f"[green]GIF saved to: {gif_path}[/green]")
+                    else:
+                        console.print("[yellow]No screenshots available for GIF[/yellow]")
+                except Exception as e:
+                    console.print(f"[red]Failed to save GIF: {e}[/red]")
+
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+            raise
+        finally:
+            await browser_session.stop()
+
+    asyncio.run(execute())
+
+
+@cli.command()
+def init():
+    """Initialize OpenBrowser configuration."""
+    console.print("[blue]Initializing OpenBrowser configuration...[/blue]")
+
+    # Check for environment variables
+    import os
+
+    providers_status = []
+    providers = [
+        ("OPENAI_API_KEY", "OpenAI"),
+        ("ANTHROPIC_API_KEY", "Anthropic"),
+        ("GOOGLE_API_KEY", "Google"),
+        ("GROQ_API_KEY", "Groq"),
+        ("OPENROUTER_API_KEY", "OpenRouter"),
+        ("AZURE_OPENAI_API_KEY", "Azure OpenAI"),
+    ]
+
+    for env_var, provider_name in providers:
+        if os.environ.get(env_var):
+            providers_status.append(f"[green]{provider_name}: Configured[/green]")
+        else:
+            providers_status.append(f"[yellow]{provider_name}: Not configured ({env_var})[/yellow]")
+
+    console.print(Panel.fit(
+        "\n".join(providers_status),
+        title="LLM Providers",
+    ))
+
+
+@cli.command()
+def models():
+    """List available models for each provider."""
+    models_info = {
+        "OpenAI": ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"],
+        "Anthropic": ["claude-sonnet-4-20250514", "claude-3-5-sonnet-20241022", "claude-3-opus-20240229"],
+        "Google": ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"],
+        "Groq": ["llama-3.3-70b-versatile", "llama-3.1-70b-versatile", "mixtral-8x7b-32768"],
+        "Ollama": ["llama3.2", "mistral", "codellama"],
+        "OpenRouter": ["anthropic/claude-3.5-sonnet", "openai/gpt-4o", "google/gemini-pro"],
+        "AWS Bedrock": ["anthropic.claude-3-5-sonnet-20241022-v2:0"],
+        "Azure OpenAI": ["gpt-4o", "gpt-4-turbo"],
+    }
+
+    for provider, model_list in models_info.items():
+        console.print(f"[bold]{provider}[/bold]")
+        for model in model_list:
+            console.print(f"  - {model}")
+        console.print()
+
+
+def _get_default_model(provider: str) -> str:
+    """Get default model for a provider."""
+    defaults = {
+        "openai": "gpt-4o",
+        "anthropic": "claude-sonnet-4-20250514",
+        "google": "gemini-2.0-flash",
+        "groq": "llama-3.3-70b-versatile",
+        "ollama": "llama3.2",
+        "openrouter": "anthropic/claude-3.5-sonnet",
+        "aws": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "azure": "gpt-4o",
+    }
+    return defaults.get(provider.lower(), "gpt-4o")
+
+
+def main():
+    """Main entry point for CLI."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/openbrowser/config.py
+++ b/src/openbrowser/config.py
@@ -1,0 +1,536 @@
+"""Configuration system for openbrowser with automatic migration support."""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from functools import cache
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+try:
+    import psutil
+    HAS_PSUTIL = True
+except ImportError:
+    psutil = None  # type: ignore
+    HAS_PSUTIL = False
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def is_running_in_docker() -> bool:
+    """Detect if we are running in a docker container.
+    
+    Used for optimizing chrome launch flags (dev shm usage, gpu settings, etc.)
+    """
+    try:
+        if Path('/.dockerenv').exists():
+            return True
+        cgroup_path = Path('/proc/1/cgroup')
+        if cgroup_path.exists() and 'docker' in cgroup_path.read_text().lower():
+            return True
+    except Exception:
+        pass
+
+    if HAS_PSUTIL:
+        try:
+            # if init proc (PID 1) looks like uvicorn/python/uv/etc. then we're in Docker
+            # if init proc (PID 1) looks like bash/systemd/init/etc. then we're probably NOT in Docker
+            init_cmd = ' '.join(psutil.Process(1).cmdline())
+            if ('py' in init_cmd) or ('uv' in init_cmd) or ('app' in init_cmd):
+                return True
+        except Exception:
+            pass
+
+        try:
+            # if less than 10 total running procs, then we're almost certainly in a container
+            if len(psutil.pids()) < 10:
+                return True
+        except Exception:
+            pass
+
+    return False
+
+
+class EnvConfig(BaseSettings):
+    """Environment variable configuration using pydantic-settings."""
+
+    model_config = SettingsConfigDict(
+        env_file='.env',
+        env_file_encoding='utf-8',
+        case_sensitive=True,
+        extra='allow'
+    )
+
+    # Logging and telemetry
+    OPENBROWSER_LOGGING_LEVEL: str = Field(default='info')
+    CDP_LOGGING_LEVEL: str = Field(default='WARNING')
+    OPENBROWSER_DEBUG_LOG_FILE: str | None = Field(default=None)
+    OPENBROWSER_INFO_LOG_FILE: str | None = Field(default=None)
+    ANONYMIZED_TELEMETRY: bool = Field(default=True)
+
+    # Path configuration
+    XDG_CACHE_HOME: str = Field(default='~/.cache')
+    XDG_CONFIG_HOME: str = Field(default='~/.config')
+    OPENBROWSER_CONFIG_DIR: str | None = Field(default=None)
+
+    # LLM API keys
+    OPENAI_API_KEY: str = Field(default='')
+    ANTHROPIC_API_KEY: str = Field(default='')
+    GOOGLE_API_KEY: str = Field(default='')
+    GROQ_API_KEY: str = Field(default='')
+    DEEPSEEK_API_KEY: str = Field(default='')
+    OPENROUTER_API_KEY: str = Field(default='')
+    AZURE_OPENAI_ENDPOINT: str = Field(default='')
+    AZURE_OPENAI_KEY: str = Field(default='')
+    AWS_ACCESS_KEY_ID: str = Field(default='')
+    AWS_SECRET_ACCESS_KEY: str = Field(default='')
+    AWS_REGION: str = Field(default='us-east-1')
+    OCI_API_KEY: str = Field(default='')
+    CEREBRAS_API_KEY: str = Field(default='')
+    SKIP_LLM_API_KEY_VERIFICATION: bool = Field(default=False)
+    DEFAULT_LLM: str = Field(default='')
+
+    # Runtime hints
+    IN_DOCKER: bool | None = Field(default=None)
+    WIN_FONT_DIR: str = Field(default='C:\\Windows\\Fonts')
+
+    # MCP-specific env vars
+    OPENBROWSER_CONFIG_PATH: str | None = Field(default=None)
+    OPENBROWSER_HEADLESS: bool | None = Field(default=None)
+    OPENBROWSER_ALLOWED_DOMAINS: str | None = Field(default=None)
+    OPENBROWSER_LLM_MODEL: str | None = Field(default=None)
+
+    # Proxy env vars
+    OPENBROWSER_PROXY_URL: str | None = Field(default=None)
+    OPENBROWSER_NO_PROXY: str | None = Field(default=None)
+    OPENBROWSER_PROXY_USERNAME: str | None = Field(default=None)
+    OPENBROWSER_PROXY_PASSWORD: str | None = Field(default=None)
+
+
+class DBStyleEntry(BaseModel):
+    """Database-style entry with UUID and metadata."""
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    default: bool = Field(default=False)
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class BrowserProfileEntry(DBStyleEntry):
+    """Browser profile configuration entry."""
+
+    model_config = ConfigDict(extra='allow')
+
+    # Common browser profile fields
+    headless: bool | None = None
+    user_data_dir: str | None = None
+    allowed_domains: list[str] | None = None
+    downloads_path: str | None = None
+    disable_security: bool | None = None
+    window_width: int | None = None
+    window_height: int | None = None
+    proxy: dict[str, Any] | None = None
+
+
+class LLMEntry(DBStyleEntry):
+    """LLM configuration entry."""
+
+    provider: str | None = None
+    api_key: str | None = None
+    model: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+    base_url: str | None = None
+
+
+class AgentEntry(DBStyleEntry):
+    """Agent configuration entry."""
+
+    max_steps: int | None = None
+    use_vision: bool | None = None
+    system_prompt: str | None = None
+    llm: str | None = None  # Reference to LLM entry ID
+    browser_profile: str | None = None  # Reference to browser profile entry ID
+
+
+class ConfigJSON(BaseModel):
+    """Configuration file format."""
+
+    browser_profiles: dict[str, BrowserProfileEntry] = Field(default_factory=dict)
+    llms: dict[str, LLMEntry] = Field(default_factory=dict)
+    agents: dict[str, AgentEntry] = Field(default_factory=dict)
+
+
+def create_default_config() -> ConfigJSON:
+    """Create a fresh default configuration."""
+    logger.debug('Creating fresh default config.json')
+
+    new_config = ConfigJSON()
+
+    # Generate default IDs
+    profile_id = str(uuid4())
+    llm_id = str(uuid4())
+    agent_id = str(uuid4())
+
+    # Create default browser profile entry
+    new_config.browser_profiles[profile_id] = BrowserProfileEntry(
+        id=profile_id,
+        default=True,
+        headless=False,
+        user_data_dir=None
+    )
+
+    # Create default LLM entry
+    new_config.llms[llm_id] = LLMEntry(
+        id=llm_id,
+        default=True,
+        provider='openai',
+        model='gpt-4o-mini',
+        api_key=None  # Will be read from env
+    )
+
+    # Create default agent entry
+    new_config.agents[agent_id] = AgentEntry(
+        id=agent_id,
+        default=True,
+        llm=llm_id,
+        browser_profile=profile_id
+    )
+
+    return new_config
+
+
+def load_and_migrate_config(config_path: Path) -> ConfigJSON:
+    """Load config.json or create fresh one if old format detected."""
+    if not config_path.exists():
+        # Create fresh config with defaults
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        new_config = create_default_config()
+        with open(config_path, 'w') as f:
+            json.dump(new_config.model_dump(), f, indent=2)
+        return new_config
+
+    try:
+        with open(config_path) as f:
+            data = json.load(f)
+
+        # Check if it's already in expected format
+        if all(key in data for key in ['browser_profiles', 'llms', 'agents']):
+            # Check if values are DB-style entries (have UUIDs as keys)
+            if data.get('browser_profiles') and all(
+                isinstance(v, dict) and 'id' in v for v in data['browser_profiles'].values()
+            ):
+                return ConfigJSON(**data)
+
+        # Old format detected - delete it and create fresh config
+        logger.debug(f'Old config format detected at {config_path}, creating fresh config')
+        new_config = create_default_config()
+
+        # Overwrite with new config
+        with open(config_path, 'w') as f:
+            json.dump(new_config.model_dump(), f, indent=2)
+
+        logger.debug(f'Created fresh config.json at {config_path}')
+        return new_config
+
+    except Exception as e:
+        logger.error(f'Failed to load config from {config_path}: {e}, creating fresh config')
+        # On any error, create fresh config
+        new_config = create_default_config()
+        try:
+            with open(config_path, 'w') as f:
+                json.dump(new_config.model_dump(), f, indent=2)
+        except Exception as write_error:
+            logger.error(f'Failed to write fresh config: {write_error}')
+        return new_config
+
+
+class Config:
+    """Configuration class that merges environment and file config.
+
+    Re-reads environment variables on every access for flexibility.
+    """
+
+    _instance: 'Config | None' = None
+    _dirs_created: bool = False
+
+    def __new__(cls) -> 'Config':
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @property
+    def LOGGING_LEVEL(self) -> str:
+        return os.getenv('OPENBROWSER_LOGGING_LEVEL', 'info').lower()
+
+    @property
+    def ANONYMIZED_TELEMETRY(self) -> bool:
+        return os.getenv('ANONYMIZED_TELEMETRY', 'true').lower()[:1] in 'ty1'
+
+    @property
+    def XDG_CACHE_HOME(self) -> Path:
+        return Path(os.getenv('XDG_CACHE_HOME', '~/.cache')).expanduser().resolve()
+
+    @property
+    def XDG_CONFIG_HOME(self) -> Path:
+        return Path(os.getenv('XDG_CONFIG_HOME', '~/.config')).expanduser().resolve()
+
+    @property
+    def CONFIG_DIR(self) -> Path:
+        path = Path(
+            os.getenv('OPENBROWSER_CONFIG_DIR', str(self.XDG_CONFIG_HOME / 'openbrowser'))
+        ).expanduser().resolve()
+        self._ensure_dirs()
+        return path
+
+    @property
+    def CONFIG_FILE(self) -> Path:
+        return self.CONFIG_DIR / 'config.json'
+
+    @property
+    def PROFILES_DIR(self) -> Path:
+        path = self.CONFIG_DIR / 'profiles'
+        self._ensure_dirs()
+        return path
+
+    @property
+    def DEFAULT_USER_DATA_DIR(self) -> Path:
+        return self.PROFILES_DIR / 'default'
+
+    @property
+    def EXTENSIONS_DIR(self) -> Path:
+        path = self.CONFIG_DIR / 'extensions'
+        self._ensure_dirs()
+        return path
+
+    def _ensure_dirs(self) -> None:
+        """Create directories if they don't exist (only once)"""
+        if not self._dirs_created:
+            config_dir = Path(
+                os.getenv('OPENBROWSER_CONFIG_DIR', str(self.XDG_CONFIG_HOME / 'openbrowser'))
+            ).expanduser().resolve()
+            config_dir.mkdir(parents=True, exist_ok=True)
+            (config_dir / 'profiles').mkdir(parents=True, exist_ok=True)
+            (config_dir / 'extensions').mkdir(parents=True, exist_ok=True)
+            Config._dirs_created = True
+
+    # LLM API key configuration
+    @property
+    def OPENAI_API_KEY(self) -> str:
+        return os.getenv('OPENAI_API_KEY', '')
+
+    @property
+    def ANTHROPIC_API_KEY(self) -> str:
+        return os.getenv('ANTHROPIC_API_KEY', '')
+
+    @property
+    def GOOGLE_API_KEY(self) -> str:
+        return os.getenv('GOOGLE_API_KEY', '')
+
+    @property
+    def GROQ_API_KEY(self) -> str:
+        return os.getenv('GROQ_API_KEY', '')
+
+    @property
+    def DEEPSEEK_API_KEY(self) -> str:
+        return os.getenv('DEEPSEEK_API_KEY', '')
+
+    @property
+    def OPENROUTER_API_KEY(self) -> str:
+        return os.getenv('OPENROUTER_API_KEY', '')
+
+    @property
+    def AZURE_OPENAI_ENDPOINT(self) -> str:
+        return os.getenv('AZURE_OPENAI_ENDPOINT', '')
+
+    @property
+    def AZURE_OPENAI_KEY(self) -> str:
+        return os.getenv('AZURE_OPENAI_KEY', '')
+
+    @property
+    def AWS_ACCESS_KEY_ID(self) -> str:
+        return os.getenv('AWS_ACCESS_KEY_ID', '')
+
+    @property
+    def AWS_SECRET_ACCESS_KEY(self) -> str:
+        return os.getenv('AWS_SECRET_ACCESS_KEY', '')
+
+    @property
+    def AWS_REGION(self) -> str:
+        return os.getenv('AWS_REGION', 'us-east-1')
+
+    @property
+    def OCI_API_KEY(self) -> str:
+        return os.getenv('OCI_API_KEY', '')
+
+    @property
+    def CEREBRAS_API_KEY(self) -> str:
+        return os.getenv('CEREBRAS_API_KEY', '')
+
+    @property
+    def SKIP_LLM_API_KEY_VERIFICATION(self) -> bool:
+        return os.getenv('SKIP_LLM_API_KEY_VERIFICATION', 'false').lower()[:1] in 'ty1'
+
+    @property
+    def DEFAULT_LLM(self) -> str:
+        return os.getenv('DEFAULT_LLM', '')
+
+    # Runtime hints
+    @property
+    def IN_DOCKER(self) -> bool:
+        return os.getenv('IN_DOCKER', 'false').lower()[:1] in 'ty1' or is_running_in_docker()
+
+    @property
+    def WIN_FONT_DIR(self) -> str:
+        return os.getenv('WIN_FONT_DIR', 'C:\\Windows\\Fonts')
+
+    def _get_config_path(self) -> Path:
+        """Get config path from env config."""
+        env_config = EnvConfig()
+        if env_config.OPENBROWSER_CONFIG_PATH:
+            return Path(env_config.OPENBROWSER_CONFIG_PATH).expanduser()
+        elif env_config.OPENBROWSER_CONFIG_DIR:
+            return Path(env_config.OPENBROWSER_CONFIG_DIR).expanduser() / 'config.json'
+        else:
+            xdg_config = Path(env_config.XDG_CONFIG_HOME).expanduser()
+            return xdg_config / 'openbrowser' / 'config.json'
+
+    def _get_db_config(self) -> ConfigJSON:
+        """Load and migrate config.json."""
+        config_path = self._get_config_path()
+        return load_and_migrate_config(config_path)
+
+    def get_default_profile(self) -> dict[str, Any]:
+        """Get the default browser profile configuration."""
+        db_config = self._get_db_config()
+        for profile in db_config.browser_profiles.values():
+            if profile.default:
+                return profile.model_dump(exclude_none=True)
+
+        # Return first profile if no default
+        if db_config.browser_profiles:
+            return next(iter(db_config.browser_profiles.values())).model_dump(exclude_none=True)
+
+        return {}
+
+    def get_default_llm(self) -> dict[str, Any]:
+        """Get the default LLM configuration."""
+        db_config = self._get_db_config()
+        for llm in db_config.llms.values():
+            if llm.default:
+                return llm.model_dump(exclude_none=True)
+
+        # Return first LLM if no default
+        if db_config.llms:
+            return next(iter(db_config.llms.values())).model_dump(exclude_none=True)
+
+        return {}
+
+    def get_default_agent(self) -> dict[str, Any]:
+        """Get the default agent configuration."""
+        db_config = self._get_db_config()
+        for agent in db_config.agents.values():
+            if agent.default:
+                return agent.model_dump(exclude_none=True)
+
+        # Return first agent if no default
+        if db_config.agents:
+            return next(iter(db_config.agents.values())).model_dump(exclude_none=True)
+
+        return {}
+
+    def load_config(self) -> dict[str, Any]:
+        """Load configuration with env var overrides."""
+        config = {
+            'browser_profile': self.get_default_profile(),
+            'llm': self.get_default_llm(),
+            'agent': self.get_default_agent(),
+        }
+
+        # Fresh env config for overrides
+        env_config = EnvConfig()
+
+        # Apply MCP-specific env var overrides
+        if env_config.OPENBROWSER_HEADLESS is not None:
+            config['browser_profile']['headless'] = env_config.OPENBROWSER_HEADLESS
+
+        if env_config.OPENBROWSER_ALLOWED_DOMAINS:
+            domains = [d.strip() for d in env_config.OPENBROWSER_ALLOWED_DOMAINS.split(',') if d.strip()]
+            config['browser_profile']['allowed_domains'] = domains
+
+        # Proxy settings
+        proxy_dict: dict[str, Any] = {}
+        if env_config.OPENBROWSER_PROXY_URL:
+            proxy_dict['server'] = env_config.OPENBROWSER_PROXY_URL
+        if env_config.OPENBROWSER_NO_PROXY:
+            proxy_dict['bypass'] = ','.join(
+                [d.strip() for d in env_config.OPENBROWSER_NO_PROXY.split(',') if d.strip()]
+            )
+        if env_config.OPENBROWSER_PROXY_USERNAME:
+            proxy_dict['username'] = env_config.OPENBROWSER_PROXY_USERNAME
+        if env_config.OPENBROWSER_PROXY_PASSWORD:
+            proxy_dict['password'] = env_config.OPENBROWSER_PROXY_PASSWORD
+        if proxy_dict:
+            config.setdefault('browser_profile', {})
+            config['browser_profile']['proxy'] = proxy_dict
+
+        # LLM API key overrides
+        if env_config.OPENAI_API_KEY:
+            config['llm']['api_key'] = env_config.OPENAI_API_KEY
+
+        if env_config.OPENBROWSER_LLM_MODEL:
+            config['llm']['model'] = env_config.OPENBROWSER_LLM_MODEL
+
+        return config
+
+
+# Create singleton instance
+CONFIG = Config()
+
+
+# Helper functions
+def load_openbrowser_config() -> dict[str, Any]:
+    """Load openbrowser configuration."""
+    return CONFIG.load_config()
+
+
+def get_default_profile(config: dict[str, Any]) -> dict[str, Any]:
+    """Get default browser profile from config dict."""
+    return config.get('browser_profile', {})
+
+
+def get_default_llm(config: dict[str, Any]) -> dict[str, Any]:
+    """Get default LLM config from config dict."""
+    return config.get('llm', {})
+
+
+def get_api_key_for_provider(provider: str) -> str:
+    """Get API key for a specific LLM provider."""
+    provider_lower = provider.lower()
+    
+    if provider_lower == 'openai':
+        return CONFIG.OPENAI_API_KEY
+    elif provider_lower in ('anthropic', 'claude'):
+        return CONFIG.ANTHROPIC_API_KEY
+    elif provider_lower == 'google':
+        return CONFIG.GOOGLE_API_KEY
+    elif provider_lower == 'groq':
+        return CONFIG.GROQ_API_KEY
+    elif provider_lower == 'deepseek':
+        return CONFIG.DEEPSEEK_API_KEY
+    elif provider_lower == 'openrouter':
+        return CONFIG.OPENROUTER_API_KEY
+    elif provider_lower in ('azure', 'azure_openai'):
+        return CONFIG.AZURE_OPENAI_KEY
+    elif provider_lower == 'oci':
+        return CONFIG.OCI_API_KEY
+    elif provider_lower == 'cerebras':
+        return CONFIG.CEREBRAS_API_KEY
+    else:
+        return ''
+

--- a/src/openbrowser/utils/__init__.py
+++ b/src/openbrowser/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Utility modules for openbrowser."""
+
+from src.openbrowser.utils.signal_handler import SignalHandler, AsyncSignalHandler
+
+__all__ = [
+    "SignalHandler",
+    "AsyncSignalHandler",
+]
+

--- a/src/openbrowser/utils/signal_handler.py
+++ b/src/openbrowser/utils/signal_handler.py
@@ -1,0 +1,221 @@
+"""Signal handler for pause/resume/stop functionality.
+
+Provides graceful handling of SIGINT (Ctrl+C) for agent operations,
+allowing users to pause, resume, or stop the agent.
+"""
+
+import asyncio
+import logging
+import signal
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SignalHandler:
+    """Handle SIGINT for pause/resume/stop functionality.
+    
+    On first SIGINT:
+        - If running: pauses the agent
+        - If paused: resumes the agent
+    
+    On second SIGINT (while paused):
+        - Exits the agent
+    
+    Args:
+        loop: Event loop to schedule callbacks on
+        pause_callback: Called when agent should pause
+        resume_callback: Called when agent should resume
+        custom_exit_callback: Optional callback before exit
+        exit_on_second_int: Whether to exit on second SIGINT
+    """
+    
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop | None = None,
+        pause_callback: Callable[[], None] | None = None,
+        resume_callback: Callable[[], None] | None = None,
+        custom_exit_callback: Callable[[], None] | None = None,
+        exit_on_second_int: bool = True,
+    ):
+        self._loop = loop
+        self._pause_callback = pause_callback
+        self._resume_callback = resume_callback
+        self._custom_exit_callback = custom_exit_callback
+        self._exit_on_second_int = exit_on_second_int
+        self._sigint_count = 0
+        self._is_paused = False
+        self._original_handler: Any = None
+        self._registered = False
+    
+    def register(self) -> None:
+        """Register the signal handler."""
+        if self._registered:
+            return
+        
+        self._original_handler = signal.signal(signal.SIGINT, self._handle_sigint)
+        self._registered = True
+        logger.debug("Signal handler registered")
+    
+    def unregister(self) -> None:
+        """Unregister the signal handler and restore the original."""
+        if not self._registered:
+            return
+        
+        if self._original_handler is not None:
+            signal.signal(signal.SIGINT, self._original_handler)
+        else:
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
+        
+        self._registered = False
+        logger.debug("Signal handler unregistered")
+    
+    def _handle_sigint(self, signum: int, frame: Any) -> None:
+        """Handle SIGINT signal."""
+        self._sigint_count += 1
+        
+        if self._sigint_count == 1:
+            if self._is_paused:
+                # Resume
+                logger.info("Resuming agent...")
+                self._is_paused = False
+                if self._resume_callback:
+                    self._schedule_callback(self._resume_callback)
+            else:
+                # Pause
+                logger.info("Pausing agent... Press Ctrl+C again to stop.")
+                self._is_paused = True
+                if self._pause_callback:
+                    self._schedule_callback(self._pause_callback)
+        
+        elif self._sigint_count >= 2 and self._exit_on_second_int:
+            logger.info("Stopping agent...")
+            if self._custom_exit_callback:
+                self._schedule_callback(self._custom_exit_callback)
+            else:
+                # Restore default handler and re-raise
+                self.unregister()
+                raise KeyboardInterrupt
+    
+    def _schedule_callback(self, callback: Callable[[], None]) -> None:
+        """Schedule a callback on the event loop."""
+        if self._loop:
+            self._loop.call_soon_threadsafe(callback)
+        else:
+            callback()
+    
+    def reset(self) -> None:
+        """Reset the interrupt count."""
+        self._sigint_count = 0
+        self._is_paused = False
+    
+    @property
+    def is_paused(self) -> bool:
+        """Check if the agent is currently paused."""
+        return self._is_paused
+    
+    @property
+    def interrupt_count(self) -> int:
+        """Get the number of interrupts received."""
+        return self._sigint_count
+    
+    def __enter__(self) -> 'SignalHandler':
+        """Context manager entry."""
+        self.register()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Context manager exit."""
+        self.unregister()
+
+
+class AsyncSignalHandler:
+    """Async-aware signal handler for pause/resume/stop.
+    
+    Provides async callbacks and integrates better with asyncio.
+    """
+    
+    def __init__(
+        self,
+        pause_callback: Callable[[], Any] | None = None,
+        resume_callback: Callable[[], Any] | None = None,
+        stop_callback: Callable[[], Any] | None = None,
+    ):
+        self._pause_callback = pause_callback
+        self._resume_callback = resume_callback
+        self._stop_callback = stop_callback
+        self._pause_event = asyncio.Event()
+        self._stop_event = asyncio.Event()
+        self._is_paused = False
+        self._handler: SignalHandler | None = None
+    
+    def start(self) -> None:
+        """Start handling signals."""
+        loop = asyncio.get_event_loop()
+        self._handler = SignalHandler(
+            loop=loop,
+            pause_callback=self._on_pause,
+            resume_callback=self._on_resume,
+            custom_exit_callback=self._on_stop,
+            exit_on_second_int=True,
+        )
+        self._handler.register()
+    
+    def stop(self) -> None:
+        """Stop handling signals."""
+        if self._handler:
+            self._handler.unregister()
+            self._handler = None
+    
+    def _on_pause(self) -> None:
+        """Called when pause is requested."""
+        self._is_paused = True
+        self._pause_event.clear()
+        if self._pause_callback:
+            if asyncio.iscoroutinefunction(self._pause_callback):
+                asyncio.create_task(self._pause_callback())
+            else:
+                self._pause_callback()
+    
+    def _on_resume(self) -> None:
+        """Called when resume is requested."""
+        self._is_paused = False
+        self._pause_event.set()
+        if self._resume_callback:
+            if asyncio.iscoroutinefunction(self._resume_callback):
+                asyncio.create_task(self._resume_callback())
+            else:
+                self._resume_callback()
+    
+    def _on_stop(self) -> None:
+        """Called when stop is requested."""
+        self._stop_event.set()
+        if self._stop_callback:
+            if asyncio.iscoroutinefunction(self._stop_callback):
+                asyncio.create_task(self._stop_callback())
+            else:
+                self._stop_callback()
+    
+    async def wait_if_paused(self) -> None:
+        """Wait if currently paused, return immediately otherwise."""
+        if self._is_paused:
+            await self._pause_event.wait()
+    
+    @property
+    def should_stop(self) -> bool:
+        """Check if stop has been requested."""
+        return self._stop_event.is_set()
+    
+    @property
+    def is_paused(self) -> bool:
+        """Check if currently paused."""
+        return self._is_paused
+    
+    def __enter__(self) -> 'AsyncSignalHandler':
+        self.start()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+


### PR DESCRIPTION
This pull request introduces a new CLI interface for OpenBrowser and adds robust signal handling utilities to support pause, resume, and stop functionality for agent operations. The main themes are the addition of a user-friendly command-line interface and the implementation of flexible signal handling for graceful interruption and control of browser automation tasks.

**CLI Interface and User Experience:**

* Introduces a new `cli.py` module that provides a Click-based command-line interface for OpenBrowser, including commands to run automation tasks, initialize configuration, and list available LLM models. The CLI supports options for provider/model selection, headless mode, vision, verbosity, and GIF export, and uses Rich for enhanced terminal output.

**Signal Handling Utilities:**

* Adds a new `signal_handler.py` module implementing `SignalHandler` and `AsyncSignalHandler` classes, enabling agents to gracefully handle SIGINT (Ctrl+C) for pausing, resuming, or stopping operations, with support for both synchronous and asynchronous workflows.
* Exposes `SignalHandler` and `AsyncSignalHandler` via the `utils` package’s `__init__.py` for easy import throughout the codebase.Refactors config and CLI; adds signal handler utilities per commit_plan.md. Does NOT add or modify browser-use/, cdp-use/, bubus/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a flexible config system with env overrides and auto-migration, a new CLI for running agents, and signal handlers for pause/resume/stop. Improves setup, DX, and graceful shutdown.

- New Features
  - Config loader merges env vars with config.json and provides defaults for browser profile, LLM, and agent; uses XDG paths, auto-creates dirs, detects Docker, and supports proxy settings.
  - Helpers to fetch provider API keys and the default profile/LLM/agent.
  - New CLI (requires click, rich) with run/init/models commands, progress output, optional GIF export, and sensible provider/model defaults.
  - SignalHandler and AsyncSignalHandler for Ctrl+C pause/resume/stop with context manager and asyncio support.

- Migration
  - Old config.json is auto-replaced with the new schema on first run; back up if you need previous values.
  - Install CLI deps: pip install click rich, and set API keys via env (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY). Use OPENBROWSER_* env vars to override headless, allowed domains, proxy, and model.

<sup>Written for commit fb593f56a2019a1e7d43aa2e1071f137ea50e39f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

