### PR TITLE
Feat/more features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,3 @@ packages = ["src/openbrowser"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-asyncio_mode = "auto"

--- a/src/openbrowser/agent/prompts.py
+++ b/src/openbrowser/agent/prompts.py
@@ -48,7 +48,7 @@ class SystemPrompt:
             elif self.use_thinking:
                 template_filename = 'system_prompt.md'
             else:
-                template_filename = 'system_prompt.md'
+                template_filename = 'system_prompt_no_thinking.md'
 
             # Load from the same directory as this module
             with importlib.resources.files('src.openbrowser.agent').joinpath(template_filename).open('r', encoding='utf-8') as f:

--- a/src/openbrowser/agent/system_prompt_no_thinking.md
+++ b/src/openbrowser/agent/system_prompt_no_thinking.md
@@ -1,0 +1,140 @@
+You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
+<intro>
+You excel at following tasks:
+1. Navigating complex websites and extracting precise information
+2. Automating form submissions and interactive web actions
+3. Gathering and saving information 
+4. Using your filesystem effectively to decide what to keep in your context
+5. Operate effectively in an agent loop
+6. Efficiently performing diverse web tasks
+</intro>
+<language_settings>
+- Default working language: **English**
+- Always respond in the same language as the user request
+</language_settings>
+<input>
+At every step, your input will consist of: 
+1. <agent_history>: A chronological event stream including your previous actions and their results.
+2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
+3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
+5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
+</input>
+<agent_history>
+Agent history will be given as a list of step information as follows:
+<step_{{step_number}}>:
+Evaluation of Previous Step: Assessment of last action
+Memory: Your memory of this step
+Next Goal: Your goal for this step
+Action Results: Your actions and their results
+</step_{{step_number}}>
+and system messages wrapped in <sys> tag.
+</agent_history>
+<user_request>
+USER REQUEST: This is your ultimate objective and always remains visible.
+- This has the highest priority. Make the user happy.
+- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
+- If the task is open ended you can plan yourself how to get it done.
+</user_request>
+<browser_state>
+1. Browser State will be given as:
+Current URL: URL of the page you are currently viewing.
+Open Tabs: Open tabs with their ids.
+Interactive Elements: All interactive elements will be provided in format as [index]<type>text</type> where
+- index: Numeric identifier for interaction
+- type: HTML element type (button, input, etc.)
+- text: Element description
+Examples:
+[33]<div>User form</div>
+\t*[35]<button aria-label='Submit form'>Submit</button>
+Note that:
+- Only elements with numeric indexes in [] are interactive
+- (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
+- Elements tagged with a star `*[` are the new interactive elements that appeared on the website since the last step - if url has not changed. Your previous actions caused that change. Think if you need to interact with them, e.g. after input you might need to select the right option from the list.
+- Pure text elements without [] are not interactive.
+</browser_state>
+<browser_vision>
+If you used screenshot before, you will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
+Use screenshot if you are unsure or simply want more information.
+</browser_vision>
+<browser_rules>
+Strictly follow these rules while using the browser and navigating the web:
+- Only interact with elements that have a numeric [index] assigned.
+- Only use indexes that are explicitly provided.
+- If research is needed, open a **new tab** instead of reusing the current one.
+- If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
+- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- You can scroll by a specific number of pages using the pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
+- If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).
+- If expected elements are missing, try refreshing, scrolling, or navigating back.
+- If the page is not fully loaded, use the wait action.
+- You can call extract on specific pages to gather structured semantic information from the entire page, including parts not currently visible.
+- Call extract only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
+- Calling the extract tool is expensive! DO NOT query the same page with the same extract query multiple times. Make sure that you are on the page with relevant information based on the screenshot before calling this tool.
+- If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
+- If the action sequence was interrupted in previous step due to page changes, make sure to complete any remaining actions that were not executed. For example, if you tried to input text and click a search button but the click was not executed because the page changed, you should retry the click action in your next step.
+- If the <user_request> includes specific page information such as product type, rating, price, location, etc., try to apply filters to be more efficient.
+- The <user_request> is the ultimate goal. If the user specifies explicit steps, they have always the highest priority.
+- If you input into a field, you might need to press enter, click the search button, or select from dropdown for completion.
+- Don't login into a page if you don't have to. Don't login if you don't have the credentials. 
+- There are 2 types of tasks always first think which type of request you are dealing with:
+1. Very specific step by step instructions:
+- Follow them as very precise and don't skip steps. Try to complete everything as requested.
+2. Open ended tasks. Plan yourself, be creative in achieving them.
+- If you get stuck e.g. with logins or captcha in open-ended tasks you can re-evaluate the task and try alternative ways, e.g. sometimes accidentally login pops up, even though there some part of the page is accessible or you get some information via web search.
+- If you reach a PDF viewer, the file is automatically downloaded and you can see its path in <available_file_paths>. You can either read the file or scroll in the page to see more.
+</browser_rules>
+<file_system>
+- You have access to a persistent file system which you can use to track progress, store results, and manage long tasks.
+- Your file system is initialized with a `todo.md`: Use this to keep a checklist for known subtasks. Use `replace_file` tool to update markers in `todo.md` as first action whenever you complete an item. This file should guide your step-by-step execution when you have a long running task.
+- If you are writing a `csv` file, make sure to use double quotes if cell elements contain commas.
+- If the file is too large, you are only given a preview of your file. Use `read_file` to see the full content if necessary.
+- If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You can only read or upload these files but you don't have write access.
+- If the task is really long, initialize a `results.md` file to accumulate your results.
+- DO NOT use the file system if the task is less than 10 steps!
+</file_system>
+<task_completion_rules>
+You must call the `done` action in one of two cases:
+- When you have fully completed the USER REQUEST.
+- When you reach the final allowed step (`max_steps`), even if the task is incomplete.
+- If it is ABSOLUTELY IMPOSSIBLE to continue.
+The `done` action is your opportunity to terminate and share your findings with the user.
+- Set `success` to `true` only if the full USER REQUEST has been completed with no missing components.
+- If any part of the request is missing, incomplete, or uncertain, set `success` to `false`.
+- You can use the `text` field of the `done` action to communicate your findings and `files_to_display` to send file attachments to the user, e.g. `["results.md"]`.
+- Put ALL the relevant information you found so far in the `text` field when you call `done` action.
+- Combine `text` and `files_to_display` to provide a coherent reply to the user and fulfill the USER REQUEST.
+- You are ONLY ALLOWED to call `done` as a single action. Don't call it together with other actions.
+- If the user asks for specified format, such as "return JSON with following structure", "return a list of format...", MAKE sure to use the right format in your answer.
+- If the user asks for a structured output, your `done` action's schema will be modified. Take this schema into account when solving the task!
+</task_completion_rules>
+<action_rules>
+- You are allowed to use a maximum of {max_actions} actions per step.
+If you are allowed multiple actions, you can specify multiple actions in the list to be executed sequentially (one after another).
+- If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
+</action_rules>
+<efficiency_guidelines>
+You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
+**Recommended Action Combinations:**
+- `input` + `click` -> Fill form field and submit/search in one step
+- `input` + `input` -> Fill multiple form fields
+- `click` + `click` -> Navigate through multi-step flows (when the page does not navigate between clicks)
+- `scroll` with pages 10 + `extract` -> Scroll to the bottom of the page to load more content before extracting structured data
+- File operations + browser actions 
+Do not try multiple different paths in one step. Always have one clear goal per step. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, e.g. 
+- do not use click and then navigate, because you would not see if the click was successful or not.
+- or do not use switch and switch together, because you would not see the state in between.
+- do not use input and then scroll, because you would not see if the input was successful or not.
+</efficiency_guidelines>
+<output>
+You must ALWAYS respond with a valid JSON in this exact format:
+{{
+  "evaluation_previous_goal": "One-sentence analysis of your last action. Clearly state success, failure, or uncertain.",
+  "memory": "1-3 sentences of specific memory of this step and overall progress. You should put here everything that will help you track progress in future steps. Like counting pages visited, items found, etc.",
+  "next_goal": "State the next immediate goal and action to achieve it, in one clear sentence.",
+  "action":[{{"navigate": {{ "url": "url_value"}}}}, // ... more actions in sequence]
+}}
+Action list should NEVER be empty.
+</output>

--- a/src/openbrowser/code_use/__init__.py
+++ b/src/openbrowser/code_use/__init__.py
@@ -1,5 +1,6 @@
 """Code-use agent module - Jupyter notebook-like code execution for browser automation."""
 
+from src.openbrowser.code_use.notebook_export import export_to_ipynb, session_to_python_script
 from src.openbrowser.code_use.service import CodeAgent
 from src.openbrowser.code_use.views import (
     CellType,
@@ -26,5 +27,7 @@ __all__ = [
     "ExecutionStatus",
     "NotebookExport",
     "NotebookSession",
+    "export_to_ipynb",
+    "session_to_python_script",
 ]
 

--- a/src/openbrowser/code_use/notebook_export.py
+++ b/src/openbrowser/code_use/notebook_export.py
@@ -1,0 +1,285 @@
+"""Export code-use session to Jupyter notebook format."""
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from .views import CellType, NotebookExport
+
+# Use TYPE_CHECKING to avoid circular imports
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .service import CodeAgent
+
+logger = logging.getLogger(__name__)
+
+
+def export_to_ipynb(agent: "CodeAgent", output_path: str | Path) -> Path:
+    """
+    Export a CodeAgent session to a Jupyter notebook (.ipynb) file.
+    Includes JavaScript code blocks that were stored in the namespace.
+
+    Args:
+        agent: The CodeAgent instance to export
+        output_path: Path where to save the notebook file
+
+    Returns:
+        Path to the saved notebook file
+
+    Example:
+        ```python
+        session = await agent.run()
+        notebook_path = export_to_ipynb(agent, 'my_automation.ipynb')
+        logger.info(f'Notebook saved to {notebook_path}')
+        ```
+    """
+    output_path = Path(output_path)
+
+    # Create notebook structure
+    notebook = NotebookExport(
+        metadata={
+            "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+            "language_info": {
+                "name": "python",
+                "version": "3.11.0",
+                "mimetype": "text/x-python",
+                "codemirror_mode": {"name": "ipython", "version": 3},
+                "pygments_lexer": "ipython3",
+                "nbconvert_exporter": "python",
+                "file_extension": ".py",
+            },
+        }
+    )
+
+    # Add setup cell at the beginning with proper type hints
+    setup_code = """import asyncio
+import json
+import logging
+from typing import Any
+from src.openbrowser.browser.session import BrowserSession
+from src.openbrowser.code_use.namespace import create_namespace
+
+# Initialize browser and namespace
+browser = BrowserSession()
+await browser.start()
+
+# Create namespace with all browser control functions
+namespace: dict[str, Any] = create_namespace(browser)
+
+# Import all functions into the current namespace
+globals().update(namespace)
+
+# Type hints for better IDE support (these are now available globally)
+# navigate, click, input, evaluate, search, extract, scroll, done, etc.
+
+logging.info("openbrowser environment initialized!")
+logging.info("Available functions: navigate, click, input, evaluate, search, extract, done, etc.")"""
+
+    setup_cell = {
+        "cell_type": "code",
+        "metadata": {},
+        "source": setup_code.split("\n"),
+        "execution_count": None,
+        "outputs": [],
+    }
+    notebook.cells.append(setup_cell)
+
+    # Add JavaScript code blocks as variables FIRST
+    if hasattr(agent, "namespace") and agent.namespace:
+        # Look for JavaScript variables in the namespace
+        code_block_vars = agent.namespace.get("_code_block_vars", set())
+
+        for var_name in sorted(code_block_vars):
+            var_value = agent.namespace.get(var_name)
+            if isinstance(var_value, str) and var_value.strip():
+                # Check if this looks like JavaScript code
+                # Look for common JS patterns
+                js_patterns = [
+                    r"function\s+\w+\s*\(",
+                    r"\(\s*function\s*\(\)",
+                    r"=>\s*{",
+                    r"document\.",
+                    r"Array\.from\(",
+                    r"\.querySelector",
+                    r"\.textContent",
+                    r"\.innerHTML",
+                    r"return\s+",
+                    r"console\.log",
+                    r"window\.",
+                    r"\.map\(",
+                    r"\.filter\(",
+                    r"\.forEach\(",
+                ]
+
+                is_js = any(re.search(pattern, var_value, re.IGNORECASE) for pattern in js_patterns)
+
+                if is_js:
+                    # Create a code cell with the JavaScript variable
+                    js_cell = {
+                        "cell_type": "code",
+                        "metadata": {},
+                        "source": [f"# JavaScript Code Block: {var_name}\n", f'{var_name} = """{var_value}"""'],
+                        "execution_count": None,
+                        "outputs": [],
+                    }
+                    notebook.cells.append(js_cell)
+
+    # Convert cells
+    python_cell_count = 0
+    for cell in agent.session.cells:
+        notebook_cell: dict = {
+            "cell_type": cell.cell_type.value,
+            "metadata": {},
+            "source": cell.source.splitlines(keepends=True),
+        }
+
+        if cell.cell_type == CellType.CODE:
+            python_cell_count += 1
+            notebook_cell["execution_count"] = cell.execution_count
+            notebook_cell["outputs"] = []
+
+            # Add output if available
+            if cell.output:
+                notebook_cell["outputs"].append(
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": cell.output.split("\n"),
+                    }
+                )
+
+            # Add error if available
+            if cell.error:
+                notebook_cell["outputs"].append(
+                    {
+                        "output_type": "error",
+                        "ename": "Error",
+                        "evalue": cell.error.split("\n")[0] if cell.error else "",
+                        "traceback": cell.error.split("\n") if cell.error else [],
+                    }
+                )
+
+            # Add browser state as a separate output
+            if cell.browser_state:
+                notebook_cell["outputs"].append(
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": [f"Browser State:\n{cell.browser_state}"],
+                    }
+                )
+
+        notebook.cells.append(notebook_cell)
+
+    # Write to file
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(notebook.model_dump(), f, indent=2, ensure_ascii=False)
+
+    logger.info(f"Exported notebook to {output_path}")
+    return output_path
+
+
+def session_to_python_script(agent: "CodeAgent") -> str:
+    """
+    Convert a CodeAgent session to a Python script.
+    Includes JavaScript code blocks that were stored in the namespace.
+
+    Args:
+        agent: The CodeAgent instance to convert
+
+    Returns:
+        Python script as a string
+
+    Example:
+        ```python
+        await agent.run()
+        script = session_to_python_script(agent)
+        logging.info(script)
+        ```
+    """
+    lines = []
+
+    lines.append("# Generated from openbrowser code-use session\n")
+    lines.append("import asyncio\n")
+    lines.append("import json\n")
+    lines.append("import logging\n")
+    lines.append("from src.openbrowser.browser.session import BrowserSession\n")
+    lines.append("from src.openbrowser.code_use.namespace import create_namespace\n\n")
+
+    lines.append("async def main():\n")
+    lines.append("\t# Initialize browser and namespace\n")
+    lines.append("\tbrowser = BrowserSession()\n")
+    lines.append("\tawait browser.start()\n\n")
+    lines.append("\t# Create namespace with all browser control functions\n")
+    lines.append("\tnamespace = create_namespace(browser)\n\n")
+    lines.append("\t# Extract functions from namespace for direct access\n")
+    lines.append('\tnavigate = namespace["navigate"]\n')
+    lines.append('\tclick = namespace["click"]\n')
+    lines.append('\tinput_text = namespace["input"]\n')
+    lines.append('\tevaluate = namespace["evaluate"]\n')
+    lines.append('\tsearch = namespace["search"]\n')
+    lines.append('\textract = namespace["extract"]\n')
+    lines.append('\tscroll = namespace["scroll"]\n')
+    lines.append('\tdone = namespace["done"]\n')
+    lines.append('\tgo_back = namespace["go_back"]\n')
+    lines.append('\twait = namespace["wait"]\n')
+    lines.append('\tscreenshot = namespace["screenshot"]\n')
+    lines.append('\tfind_text = namespace["find_text"]\n')
+    lines.append('\tswitch_tab = namespace["switch"]\n')
+    lines.append('\tclose_tab = namespace["close"]\n')
+    lines.append('\tdropdown_options = namespace["dropdown_options"]\n')
+    lines.append('\tselect_dropdown = namespace["select_dropdown"]\n')
+    lines.append('\tupload_file = namespace["upload_file"]\n')
+    lines.append('\tsend_keys = namespace["send_keys"]\n\n')
+
+    # Add JavaScript code blocks as variables FIRST
+    if hasattr(agent, "namespace") and agent.namespace:
+        code_block_vars = agent.namespace.get("_code_block_vars", set())
+
+        for var_name in sorted(code_block_vars):
+            var_value = agent.namespace.get(var_name)
+            if isinstance(var_value, str) and var_value.strip():
+                # Check if this looks like JavaScript code
+                js_patterns = [
+                    r"function\s+\w+\s*\(",
+                    r"\(\s*function\s*\(\)",
+                    r"=>\s*{",
+                    r"document\.",
+                    r"Array\.from\(",
+                    r"\.querySelector",
+                    r"\.textContent",
+                    r"\.innerHTML",
+                    r"return\s+",
+                    r"console\.log",
+                    r"window\.",
+                    r"\.map\(",
+                    r"\.filter\(",
+                    r"\.forEach\(",
+                ]
+
+                is_js = any(re.search(pattern, var_value, re.IGNORECASE) for pattern in js_patterns)
+
+                if is_js:
+                    lines.append(f"\t# JavaScript Code Block: {var_name}\n")
+                    lines.append(f'\t{var_name} = """{var_value}"""\n\n')
+
+    for i, cell in enumerate(agent.session.cells):
+        if cell.cell_type == CellType.CODE:
+            lines.append(f"\t# Cell {i + 1}\n")
+
+            # Indent each line of source
+            source_lines = cell.source.split("\n")
+            for line in source_lines:
+                if line.strip():  # Only add non-empty lines
+                    lines.append(f"\t{line}\n")
+
+            lines.append("\n")
+
+    lines.append("\tawait browser.stop()\n\n")
+    lines.append("if __name__ == '__main__':\n")
+    lines.append("\tasyncio.run(main())\n")
+
+    return "".join(lines)


### PR DESCRIPTION
This pull request adds support for exporting code-use agent sessions to Jupyter notebook (`.ipynb`) and Python script formats, and updates prompt template handling for agents without "thinking" mode. It also makes a minor test configuration change. The most important changes are grouped below.

**Code-use Agent Export Functionality:**

* Added a new module `notebook_export.py` that provides two functions: `export_to_ipynb` for exporting a `CodeAgent` session to a Jupyter notebook, and `session_to_python_script` for exporting to a standalone Python script. These exports include both Python and JavaScript code blocks, as well as relevant browser state and outputs.
* Updated `src/openbrowser/code_use/__init__.py` to import and expose `export_to_ipynb` and `session_to_python_script` as part of the public API. [[1]](diffhunk://#diff-673ccd0c4157f15a9472478ec29d5567e34ab1e22d0fedc80408b1da7340661eR3) [[2]](diffhunk://#diff-673ccd0c4157f15a9472478ec29d5567e34ab1e22d0fedc80408b1da7340661eR30-R31)

**Prompt Template Handling:**

* Changed the prompt template logic in `src/openbrowser/agent/prompts.py` so that when `use_thinking` is `False`, the agent loads `system_prompt_no_thinking.md` instead of the default prompt.
* Added the new prompt template file `system_prompt_no_thinking.md`, which provides detailed instructions and rules for agent operation without "thinking" mode.

**Testing and Configuration:**

* Removed `asyncio_mode = "auto"` from the pytest configuration in `pyproject.toml`, likely to avoid conflicts or enforce explicit asyncio handling in tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add export of code-use sessions to Jupyter notebooks and Python scripts, and switch agent prompts to a no-thinking template when use_thinking is false. Also removes a pytest asyncio setting.

- **New Features**
  - Added export_to_ipynb and session_to_python_script to export CodeAgent sessions.
  - Exports include JS code blocks, browser state, outputs, and are exposed via the public API.

- **Refactors**
  - Agents without thinking mode now load system_prompt_no_thinking.md.
  - Removed asyncio_mode = "auto" from pytest config.

<sup>Written for commit 080560d667a663543806781bf7d1af93db0049fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions can now be exported to Jupyter notebooks, preserving code cells, execution outputs, browser states, and JavaScript code blocks.
  * Agent sessions can be converted to standalone Python scripts with all code blocks and browser automation initialization logic included.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->