### PR TITLE
fix: rename torch_dtype to dtype in AutoModelForCausalLM.from_pretrai…

### DIFF
--- a/infra/training/serving/export_gguf.py
+++ b/infra/training/serving/export_gguf.py
@@ -41,7 +41,7 @@ def merge_lora_adapter(adapter_path: str, output_dir: Path):
     logger.info(f"Loading base model: {BASE_MODEL_NAME}")
     model = AutoModelForCausalLM.from_pretrained(
         BASE_MODEL_NAME,
-        torch_dtype=torch.float16,
+        dtype=torch.float16,
         device_map="cpu",
     )
 


### PR DESCRIPTION
This pull request makes a minor update to the `merge_lora_adapter` function in `export_gguf.py`, changing the argument passed to the model loading function from `torch_dtype` to `dtype` for consistency or compatibility.…ned call

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the parameter from torch_dtype to dtype when loading the base model in export_gguf. This matches the current Transformers API and prevents dtype-related errors during LoRA merge and GGUF export.

<sup>Written for commit 564d4a2acb25523e652e2113b89bed7da5ba45f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal model loading parameters for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->