### PR TITLE
chore(gitignore): exclude cloned formfactory repo from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ CSC490/A1/a1.pdf
 CSC490/A1/high_level_architecture.pdf
 
 !docker-compose.dev.yml
-!docker-compose.yml
+!docker-compose.ymldata/formfactory/


### PR DESCRIPTION
The formfactory directory is a separate git repository cloned from formfactory-ai/formfactory and should not be embedded in this repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated .gitignore to ignore the cloned formfactory repository at data/formfactory/ so it isn’t tracked in this repo. This prevents committing a nested git repo and keeps the history clean.

<sup>Written for commit 0f08c097731a9fedb1a843fe06d19feca13dc582. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git tracking configuration to include a new directory in version control while removing a previous file exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->