### PR TITLE
support for controlling the user's current browser via a Chrome extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,19 @@ CSC490/A1/a1.pdf
 CSC490/A1/high_level_architecture.pdf
 
 !docker-compose.dev.yml
-!docker-compose.ymldata/formfactory/
+!docker-compose.yml
+data/formfactory/
+
+# Extension build artifacts and secrets
+*.pem
+*.crx
+
+# Runtime data
+openbrowser_agent_data/
+backend/openbrowser_agent_data/
+data/processed/
+results/
+feature-store-ui/
+
+# Drawio diagrams
+*.drawio

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,8 @@ data/formfactory/
 # Runtime data
 openbrowser_agent_data/
 backend/openbrowser_agent_data/
-data/processed/
+data/processed/*
+!data/processed/*.jsonl
 results/
 feature-store-ui/
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     
     # CORS settings
     CORS_ORIGINS: list[str] = Field(
-        default=["http://localhost:3000", "https://openbrowser.me", "https://www.openbrowser.me"],
+        default=["http://localhost:3000", "http://localhost:3001", "https://openbrowser.me", "https://www.openbrowser.me"],
         description="Allowed CORS origins"
     )
     

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.api import projects, tasks
 from app.core.config import settings
 from app.models.schemas import AvailableModelsResponse, LLMModel
 from app.websocket.handler import handle_websocket
+from app.websocket.extension_handler import handle_extension_websocket
 
 # Configure logging
 logging.basicConfig(
@@ -106,6 +107,21 @@ async def websocket_endpoint(websocket: WebSocket):
     """WebSocket endpoint for real-time agent communication."""
     client_id = str(uuid4())
     await handle_websocket(websocket, client_id)
+
+
+# Extension routes must be registered before the dynamic /ws/{client_id} route
+# to prevent "extension" from being captured as a client_id
+@app.websocket("/ws/extension")
+async def extension_websocket_endpoint(websocket: WebSocket):
+    """WebSocket endpoint for Chrome extension connections."""
+    extension_id = str(uuid4())
+    await handle_extension_websocket(websocket, extension_id)
+
+
+@app.websocket("/ws/extension/{extension_id}")
+async def extension_websocket_endpoint_with_id(websocket: WebSocket, extension_id: str):
+    """WebSocket endpoint for Chrome extension with specific ID."""
+    await handle_extension_websocket(websocket, extension_id)
 
 
 @app.websocket("/ws/{client_id}")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -39,6 +39,7 @@ class CreateTaskRequest(BaseModel):
     use_vision: bool = Field(default=True, description="Enable vision/screenshots")
     llm_model: str | None = Field(default=None, description="LLM model to use")
     project_id: str | None = Field(default=None, description="Project to associate task with")
+    use_current_browser: bool = Field(default=False, description="Use current browser via Chrome extension")
 
 
 class CreateProjectRequest(BaseModel):
@@ -152,6 +153,7 @@ class WSMessageType(str, Enum):
     TASK_CANCELLED = "task_cancelled"
     LOG = "log"  # Backend terminal log messages
     VNC_INFO = "vnc_info"  # VNC connection information
+    EXTENSION_STATUS = "extension_status"  # Chrome extension connection status
 
 
 class WSMessage(BaseModel):
@@ -169,6 +171,7 @@ class WSStartTaskData(BaseModel):
     max_steps: int = 50
     use_vision: bool = True
     llm_model: str | None = None
+    use_current_browser: bool = False
 
 
 class WSStepUpdateData(BaseModel):

--- a/backend/app/services/cdp_bridge.py
+++ b/backend/app/services/cdp_bridge.py
@@ -1,0 +1,402 @@
+"""CDP Bridge - local WebSocket server that bridges CDPClient to Chrome extension."""
+
+import asyncio
+import json
+import logging
+import socket
+from typing import Any
+
+import websockets
+from websockets.server import WebSocketServerProtocol
+
+logger = logging.getLogger(__name__)
+
+
+def _find_free_port() -> int:
+    """Find a free port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+class CDPBridge:
+    """Creates a local WebSocket server that acts as a CDP endpoint.
+
+    BrowserSession.connect() connects to this bridge, and all CDP traffic
+    is relayed through the Chrome extension's chrome.debugger API.
+    """
+
+    def __init__(self, extension_id: str):
+        self.extension_id = extension_id
+        self._port: int | None = None
+        self._server: Any = None
+        self._cdp_client_ws: WebSocketServerProtocol | None = None
+        self._session_map: dict[str, str] = {}  # sessionId -> targetId
+        self._reverse_session_map: dict[str, str] = {}  # targetId -> sessionId
+        self._pending_responses: dict[int, asyncio.Future] = {}  # command id -> future
+        self._running = False
+        self._connected_event = asyncio.Event()
+        self._attached_tab_id: int | None = None
+        self._attached_tab_url: str = "about:blank"
+
+    @property
+    def cdp_url(self) -> str:
+        """Get the WebSocket URL for this bridge."""
+        if self._port is None:
+            raise RuntimeError("Bridge not started")
+        return f"ws://localhost:{self._port}"
+
+    async def start(self) -> str:
+        """Start the local WebSocket server and return the CDP URL."""
+        from app.websocket.extension_handler import extension_manager
+
+        self._port = _find_free_port()
+        self._running = True
+
+        # Register callback for extension messages
+        extension_manager.register_message_callback(
+            self.extension_id, self._on_extension_message
+        )
+
+        # Start WebSocket server
+        self._server = await websockets.serve(
+            self._handle_cdp_client,
+            "localhost",
+            self._port,
+            # Allow any origin since this is local only
+            origins=None,
+        )
+
+        logger.info(f"CDP Bridge started on port {self._port} for extension {self.extension_id}")
+        return self.cdp_url
+
+    async def stop(self):
+        """Stop the bridge and clean up."""
+        self._running = False
+
+        from app.websocket.extension_handler import extension_manager
+        extension_manager.unregister_message_callback(self.extension_id)
+
+        if self._cdp_client_ws:
+            try:
+                await self._cdp_client_ws.close()
+            except Exception:
+                pass
+            self._cdp_client_ws = None
+
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        # Cancel pending responses
+        for future in self._pending_responses.values():
+            if not future.done():
+                future.cancel()
+        self._pending_responses.clear()
+        self._session_map.clear()
+        self._reverse_session_map.clear()
+
+        logger.info(f"CDP Bridge stopped for extension {self.extension_id}")
+
+    async def _handle_cdp_client(self, websocket: WebSocketServerProtocol):
+        """Handle incoming WebSocket connection from CDPClient."""
+        self._cdp_client_ws = websocket
+        self._connected_event.set()
+        logger.info("CDPClient connected to CDP Bridge")
+
+        try:
+            async for raw_message in websocket:
+                if not self._running:
+                    break
+
+                try:
+                    message = json.loads(raw_message)
+                    await self._on_cdp_client_message(message)
+                except json.JSONDecodeError:
+                    logger.warning(f"Invalid JSON from CDPClient: {raw_message[:100]}")
+                except Exception as e:
+                    logger.error(f"Error handling CDPClient message: {e}")
+
+        except websockets.exceptions.ConnectionClosed:
+            logger.info("CDPClient disconnected from CDP Bridge")
+        finally:
+            self._cdp_client_ws = None
+            self._connected_event.clear()
+
+    async def _on_cdp_client_message(self, message: dict[str, Any]):
+        """Handle a CDP message from CDPClient and relay to extension."""
+        from app.websocket.extension_handler import extension_manager
+
+        msg_id = message.get("id")
+        method = message.get("method", "")
+        params = message.get("params", {})
+        session_id = message.get("sessionId")
+
+        logger.info(f"CDP <- CDPClient: id={msg_id} method={method} sessionId={str(session_id)[:8] if session_id else None}")
+
+        # Intercept Target.setAutoAttach: respond locally since chrome.debugger
+        # handles target attachment differently.
+        if method == "Target.setAutoAttach":
+            await self._send_to_cdp_client({"id": msg_id, "result": {}})
+            return
+
+        # Intercept Browser-domain commands: chrome.debugger doesn't support
+        # the Browser domain at all. Return appropriate responses immediately
+        # to prevent watchdog timeouts.
+        if method.startswith("Browser."):
+            # Browser.getVersion -> return synthetic info
+            if method == "Browser.getVersion":
+                await self._send_to_cdp_client({
+                    "id": msg_id,
+                    "result": {
+                        "protocolVersion": "1.3",
+                        "product": "Chrome (via extension)",
+                        "revision": "unknown",
+                        "userAgent": "",
+                        "jsVersion": "",
+                    },
+                })
+                return
+            # All other Browser.* commands -> return error immediately
+            error_msg = f"'{method}' is not available through chrome.debugger extension bridge"
+            logger.info(f"CDP Bridge intercepted unsupported: {method}")
+            cdp_response: dict[str, Any] = {
+                "id": msg_id,
+                "error": {"code": -32601, "message": error_msg},
+            }
+            if session_id:
+                cdp_response["sessionId"] = session_id
+            elif self._attached_tab_id is not None:
+                tab_target = f"tab-{self._attached_tab_id}"
+                synthetic_session = self._reverse_session_map.get(tab_target)
+                if synthetic_session:
+                    cdp_response["sessionId"] = synthetic_session
+            await self._send_to_cdp_client(cdp_response)
+            return
+
+        # Intercept Target.getTargetInfo: chrome.debugger returns "Not allowed"
+        # for this method. Return synthetic target info for our tab.
+        if method == "Target.getTargetInfo" and not session_id:
+            requested_target = params.get("targetId", "")
+            target_id = f"tab-{self._attached_tab_id}" if self._attached_tab_id else "tab-0"
+            synthetic_response = {
+                "id": msg_id,
+                "result": {
+                    "targetInfo": {
+                        "targetId": requested_target or target_id,
+                        "type": "page",
+                        "title": "",
+                        "url": self._attached_tab_url,
+                        "attached": True,
+                        "browserContextId": "default",
+                    }
+                },
+            }
+            await self._send_to_cdp_client(synthetic_response)
+            return
+
+        # Intercept Target.getTargets: chrome.debugger doesn't return the tab
+        # itself as a target, so we synthesize a response including it.
+        if method == "Target.getTargets" and not session_id:
+            target_id = f"tab-{self._attached_tab_id}" if self._attached_tab_id else "tab-0"
+            synthetic_response = {
+                "id": msg_id,
+                "result": {
+                    "targetInfos": [
+                        {
+                            "targetId": target_id,
+                            "type": "page",
+                            "title": "",
+                            "url": self._attached_tab_url,
+                            "attached": True,
+                            "browserContextId": "default",
+                        }
+                    ]
+                },
+            }
+            await self._send_to_cdp_client(synthetic_response)
+            return
+
+        # Intercept Target.attachToTarget for the synthetic tab target:
+        # Generate a fake sessionId and map it, since chrome.debugger
+        # is already attached to this tab.
+        if method == "Target.attachToTarget" and not session_id:
+            requested_target = params.get("targetId", "")
+            if requested_target.startswith("tab-"):
+                import uuid
+                fake_session_id = str(uuid.uuid4())
+                self._session_map[fake_session_id] = requested_target
+                self._reverse_session_map[requested_target] = fake_session_id
+                synthetic_response = {
+                    "id": msg_id,
+                    "result": {"sessionId": fake_session_id},
+                }
+                await self._send_to_cdp_client(synthetic_response)
+                # Also send a synthetic attachedToTarget event
+                attached_event = {
+                    "method": "Target.attachedToTarget",
+                    "params": {
+                        "sessionId": fake_session_id,
+                        "targetInfo": {
+                            "targetId": requested_target,
+                            "type": "page",
+                            "title": "",
+                            "url": self._attached_tab_url,
+                            "attached": True,
+                            "browserContextId": "default",
+                        },
+                        "waitingForDebugger": False,
+                    },
+                }
+                await self._send_to_cdp_client(attached_event)
+                return
+
+        # Build extension command
+        ext_command: dict[str, Any] = {
+            "type": "cdp_command",
+            "id": msg_id,
+            "method": method,
+            "params": params,
+        }
+
+        # Map sessionId to targetId for the extension.
+        # If the sessionId maps to our synthetic tab target (tab-*),
+        # strip it so the extension uses its activeTabId.
+        if session_id:
+            target_id = self._session_map.get(session_id)
+            if target_id and target_id.startswith("tab-"):
+                # Synthetic session for the main tab -- don't send sessionId
+                # to the extension; it will use activeTabId.
+                pass
+            elif target_id:
+                ext_command["sessionId"] = session_id
+                ext_command["targetId"] = target_id
+            else:
+                ext_command["sessionId"] = session_id
+
+        # Send to extension
+        await extension_manager.send_command(self.extension_id, ext_command)
+
+    async def _on_extension_message(self, message: dict[str, Any]):
+        """Handle a message from the extension (CDP response or event)."""
+        msg_type = message.get("type", "")
+
+        if msg_type == "cdp_response":
+            await self._handle_cdp_response(message)
+        elif msg_type == "cdp_event":
+            await self._handle_cdp_event(message)
+        elif msg_type == "tab_attached":
+            self._attached_tab_id = message.get("tabId")
+            logger.info(f"Tab attached: tabId={self._attached_tab_id}")
+        elif msg_type == "debugger_detached":
+            logger.warning(f"Debugger detached: {message.get('reason')}")
+
+    async def _handle_cdp_response(self, message: dict[str, Any]):
+        """Handle a CDP response from the extension."""
+        msg_id = message.get("id")
+        result = message.get("result")
+        error = message.get("error")
+        session_id = message.get("sessionId")
+
+        # Log response summary for debugging
+        result_summary = str(result)[:200] if result else "None"
+        logger.info(f"CDP <- Extension: id={msg_id} error={error} result={result_summary}")
+
+        # Track current tab URL from navigation history responses
+        if result and isinstance(result, dict) and "entries" in result and "currentIndex" in result:
+            try:
+                entries = result["entries"]
+                current_idx = result["currentIndex"]
+                if 0 <= current_idx < len(entries):
+                    self._attached_tab_url = entries[current_idx].get("url", self._attached_tab_url)
+            except (IndexError, TypeError):
+                pass
+
+        # Track sessionId -> targetId from Target.attachToTarget responses
+        if result and isinstance(result, dict) and "sessionId" in result:
+            new_session_id = result["sessionId"]
+            # The original command had params with targetId
+            original_target_id = message.get("originalTargetId")
+            if original_target_id:
+                self._session_map[new_session_id] = original_target_id
+                self._reverse_session_map[original_target_id] = new_session_id
+                logger.info(
+                    f"Session mapping: {new_session_id[:8]}... -> {original_target_id[:8]}..."
+                )
+
+        # Forward to CDPClient
+        cdp_response: dict[str, Any] = {"id": msg_id}
+        if error:
+            cdp_response["error"] = {"message": error} if isinstance(error, str) else error
+        else:
+            cdp_response["result"] = result or {}
+
+        # If extension didn't include sessionId but the command was for the
+        # main tab (synthetic session), add the synthetic sessionId back.
+        if session_id:
+            cdp_response["sessionId"] = session_id
+        elif self._attached_tab_id is not None:
+            # Find the synthetic session for the main tab
+            tab_target = f"tab-{self._attached_tab_id}"
+            synthetic_session = self._reverse_session_map.get(tab_target)
+            if synthetic_session:
+                cdp_response["sessionId"] = synthetic_session
+
+        await self._send_to_cdp_client(cdp_response)
+
+    async def _handle_cdp_event(self, message: dict[str, Any]):
+        """Handle a CDP event from the extension."""
+        method = message.get("method", "")
+        params = message.get("params", {})
+        session_id = message.get("sessionId")
+        target_id = message.get("targetId")
+
+        # Track new sessions from Target.attachedToTarget events
+        if method == "Target.attachedToTarget":
+            event_session_id = params.get("sessionId")
+            target_info = params.get("targetInfo", {})
+            event_target_id = target_info.get("targetId")
+            if event_session_id and event_target_id:
+                self._session_map[event_session_id] = event_target_id
+                self._reverse_session_map[event_target_id] = event_session_id
+                logger.info(
+                    f"Session mapping (event): {event_session_id[:8]}... -> {event_target_id[:8]}..."
+                )
+
+        # Clean up on detach
+        elif method == "Target.detachedFromTarget":
+            event_session_id = params.get("sessionId")
+            event_target_id = params.get("targetId")
+            if event_session_id and event_session_id in self._session_map:
+                del self._session_map[event_session_id]
+            if event_target_id and event_target_id in self._reverse_session_map:
+                del self._reverse_session_map[event_target_id]
+
+        # Resolve sessionId from targetId if needed
+        if not session_id and target_id:
+            session_id = self._reverse_session_map.get(target_id)
+
+        # If no sessionId resolved, use the synthetic session for the main tab
+        if not session_id and self._attached_tab_id is not None:
+            tab_target = f"tab-{self._attached_tab_id}"
+            session_id = self._reverse_session_map.get(tab_target)
+
+        # Forward to CDPClient as raw CDP event
+        cdp_event: dict[str, Any] = {
+            "method": method,
+            "params": params,
+        }
+        if session_id:
+            cdp_event["sessionId"] = session_id
+
+        await self._send_to_cdp_client(cdp_event)
+
+    async def _send_to_cdp_client(self, message: dict[str, Any]):
+        """Send a message to the connected CDPClient."""
+        if self._cdp_client_ws:
+            try:
+                await self._cdp_client_ws.send(json.dumps(message))
+            except Exception as e:
+                logger.error(f"Failed to send to CDPClient: {e}")

--- a/backend/app/websocket/extension_handler.py
+++ b/backend/app/websocket/extension_handler.py
@@ -1,0 +1,129 @@
+"""WebSocket handler for Chrome extension connections."""
+
+import asyncio
+import json
+import logging
+from typing import Any, Callable
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+
+class ExtensionConnectionManager:
+    """Manages WebSocket connections from Chrome extensions."""
+
+    def __init__(self):
+        self.active_extensions: dict[str, WebSocket] = {}
+        self._message_callbacks: dict[str, Callable] = {}  # extension_id -> callback for CDP bridge
+        self._lock = asyncio.Lock()
+
+    async def connect(self, websocket: WebSocket, extension_id: str):
+        """Accept a new extension WebSocket connection."""
+        await websocket.accept()
+        async with self._lock:
+            # Close existing connection if any
+            if extension_id in self.active_extensions:
+                try:
+                    await self.active_extensions[extension_id].close()
+                except Exception:
+                    pass
+            self.active_extensions[extension_id] = websocket
+        logger.info(f"Extension {extension_id} connected")
+
+    async def disconnect(self, extension_id: str):
+        """Remove an extension WebSocket connection."""
+        async with self._lock:
+            if extension_id in self.active_extensions:
+                del self.active_extensions[extension_id]
+            if extension_id in self._message_callbacks:
+                del self._message_callbacks[extension_id]
+        logger.info(f"Extension {extension_id} disconnected")
+
+    def is_connected(self, extension_id: str | None = None) -> bool:
+        """Check if any extension (or specific one) is connected."""
+        if extension_id:
+            return extension_id in self.active_extensions
+        return len(self.active_extensions) > 0
+
+    def get_any_extension_id(self) -> str | None:
+        """Get any connected extension ID."""
+        if self.active_extensions:
+            return next(iter(self.active_extensions))
+        return None
+
+    async def send_command(self, extension_id: str, command: dict[str, Any]) -> None:
+        """Send a command to a specific extension."""
+        websocket = self.active_extensions.get(extension_id)
+        if websocket:
+            try:
+                await websocket.send_json(command)
+            except Exception as e:
+                logger.error(f"Failed to send command to extension {extension_id}: {e}")
+                await self.disconnect(extension_id)
+
+    def register_message_callback(self, extension_id: str, callback: Callable):
+        """Register a callback for messages from a specific extension."""
+        self._message_callbacks[extension_id] = callback
+
+    def unregister_message_callback(self, extension_id: str):
+        """Unregister message callback for an extension."""
+        self._message_callbacks.pop(extension_id, None)
+
+    async def _handle_message(self, extension_id: str, message: dict[str, Any]):
+        """Route incoming extension message to registered callback."""
+        callback = self._message_callbacks.get(extension_id)
+        if callback:
+            if asyncio.iscoroutinefunction(callback):
+                await callback(message)
+            else:
+                callback(message)
+
+
+# Global extension manager
+extension_manager = ExtensionConnectionManager()
+
+
+async def handle_extension_websocket(websocket: WebSocket, extension_id: str):
+    """Handle WebSocket connection from a Chrome extension."""
+    await extension_manager.connect(websocket, extension_id)
+
+    # Import here to avoid circular imports
+    from app.websocket.handler import connection_manager as frontend_manager
+    from app.models.schemas import WSMessage, WSMessageType
+
+    # Notify all frontend clients that extension is connected
+    await frontend_manager.broadcast(
+        WSMessage(
+            type=WSMessageType.EXTENSION_STATUS,
+            data={"connected": True, "extension_id": extension_id},
+        )
+    )
+
+    try:
+        while True:
+            data = await websocket.receive_json()
+            msg_type = data.get("type", "")
+
+            if msg_type == "ping":
+                # Keepalive ping from extension
+                await websocket.send_json({"type": "pong"})
+            elif msg_type == "extension_connected":
+                logger.info(f"Extension {extension_id} reported connected: {data.get('info', {})}")
+            else:
+                # Route to CDP bridge callback
+                await extension_manager._handle_message(extension_id, data)
+
+    except WebSocketDisconnect:
+        logger.info(f"Extension {extension_id} disconnected")
+    except Exception as e:
+        logger.exception(f"Extension WebSocket error for {extension_id}: {e}")
+    finally:
+        await extension_manager.disconnect(extension_id)
+        # Notify frontend clients
+        await frontend_manager.broadcast(
+            WSMessage(
+                type=WSMessageType.EXTENSION_STATUS,
+                data={"connected": False, "extension_id": extension_id},
+            )
+        )

--- a/backend/app/websocket/handler.py
+++ b/backend/app/websocket/handler.py
@@ -118,7 +118,21 @@ connection_manager = ConnectionManager()
 async def handle_websocket(websocket: WebSocket, client_id: str):
     """Handle WebSocket connection for a client."""
     await connection_manager.connect(websocket, client_id)
-    
+
+    # Send current extension connection status on connect
+    try:
+        from app.websocket.extension_handler import extension_manager
+        ext_id = extension_manager.get_any_extension_id()
+        await connection_manager.send_message(
+            client_id,
+            WSMessage(
+                type=WSMessageType.EXTENSION_STATUS,
+                data={"connected": ext_id is not None, "extension_id": ext_id},
+            ),
+        )
+    except Exception:
+        pass
+
     try:
         while True:
             # Receive message from client
@@ -272,6 +286,7 @@ async def handle_start_task(client_id: str, message: WSMessage):
             max_steps=task_data.max_steps,
             use_vision=task_data.use_vision,
             llm_model=task_data.llm_model,
+            use_current_browser=task_data.use_current_browser,
             on_step_callback=on_step,
             on_output_callback=on_output,
             on_screenshot_callback=on_screenshot,

--- a/extension/background.js
+++ b/extension/background.js
@@ -520,12 +520,10 @@ chrome.runtime.onMessage.addListener(function (message, _sender, sendResponse) {
 });
 
 // ---------------------------------------------------------------------------
-// Startup: restore previous backend URL and reconnect
+// Startup: do NOT auto-connect from cached URL.
+//
+// The content script will detect an OpenBrowser frontend page and send the
+// correct backend URL via "set_backend_url" message.  Auto-connecting from
+// cache caused stale-URL issues (e.g. connecting to port 8000 when the
+// backend moved to 8001).
 // ---------------------------------------------------------------------------
-
-chrome.storage.local.get(["backendUrl"], function (data) {
-  if (data.backendUrl) {
-    console.log("[OpenBrowser] Restoring connection to", data.backendUrl);
-    connect(data.backendUrl);
-  }
-});

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,531 @@
+/**
+ * OpenBrowser Background Service Worker
+ *
+ * Maintains a WebSocket connection to the OpenBrowser backend and relays
+ * Chrome DevTools Protocol (CDP) commands between the backend and the
+ * browser via the chrome.debugger API.
+ *
+ * Key responsibilities:
+ *   - WebSocket lifecycle (connect, ping keepalive, reconnect)
+ *   - CDP command relay (backend -> chrome.debugger -> backend)
+ *   - CDP event forwarding (chrome.debugger events -> backend)
+ *   - Session/target ID mapping for multi-target debugging
+ *   - Tab attach/detach management
+ *
+ * NOTE: Uses async/await (Promise-based) chrome.debugger API for MV3
+ * compatibility. The callback-based API can silently drop results in
+ * service workers.
+ */
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+/** @type {WebSocket|null} */
+let ws = null;
+
+/** @type {string|null} */
+let backendUrl = null;
+
+/** @type {number|null} Current tab being debugged */
+let activeTabId = null;
+
+/** @type {boolean} Whether the debugger is attached to the active tab */
+let debuggerAttached = false;
+
+/** CDP sessionId -> targetId */
+const sessionToTarget = new Map();
+
+/** targetId -> CDP sessionId */
+const targetToSession = new Map();
+
+/** Ping interval handle */
+let pingInterval = null;
+
+/** Reconnect timer handle */
+let reconnectTimer = null;
+
+/** Reconnect delay in ms -- grows exponentially, capped at 30s */
+let reconnectDelay = 1000;
+
+const MAX_RECONNECT_DELAY = 30000;
+const PING_INTERVAL_MS = 25000;
+const CDP_PROTOCOL_VERSION = "1.3";
+
+// ---------------------------------------------------------------------------
+// Persistence helpers
+// ---------------------------------------------------------------------------
+
+function persistState() {
+  chrome.storage.local.set({
+    backendUrl: backendUrl,
+    connected: ws !== null && ws.readyState === WebSocket.OPEN,
+    activeTabId: activeTabId,
+    debuggerAttached: debuggerAttached,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket management
+// ---------------------------------------------------------------------------
+
+function connect(url) {
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    if (url === backendUrl) {
+      return; // already connected / connecting to same URL
+    }
+    ws.close();
+  }
+
+  backendUrl = url;
+  persistState();
+
+  try {
+    ws = new WebSocket(url);
+  } catch (err) {
+    console.error("[OpenBrowser] Failed to create WebSocket:", err);
+    scheduleReconnect();
+    return;
+  }
+
+  ws.onopen = function () {
+    console.log("[OpenBrowser] WebSocket connected to", url);
+    reconnectDelay = 1000; // reset backoff
+    persistState();
+    startPing();
+    sendBrowserInfo();
+  };
+
+  ws.onmessage = function (event) {
+    let msg;
+    try {
+      msg = JSON.parse(event.data);
+    } catch (err) {
+      console.error("[OpenBrowser] Invalid JSON from backend:", err);
+      return;
+    }
+    handleBackendMessage(msg);
+  };
+
+  ws.onclose = function (event) {
+    console.log("[OpenBrowser] WebSocket closed. Code:", event.code, "Reason:", event.reason);
+    cleanup();
+    scheduleReconnect();
+  };
+
+  ws.onerror = function (err) {
+    console.error("[OpenBrowser] WebSocket error:", err);
+    // onclose will fire after onerror, which triggers reconnect
+  };
+}
+
+function disconnect() {
+  clearReconnect();
+  if (ws) {
+    ws.close();
+  }
+  cleanup();
+}
+
+function cleanup() {
+  stopPing();
+  ws = null;
+  persistState();
+}
+
+function startPing() {
+  stopPing();
+  pingInterval = setInterval(function () {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      wsSend({ type: "ping" });
+    }
+  }, PING_INTERVAL_MS);
+}
+
+function stopPing() {
+  if (pingInterval !== null) {
+    clearInterval(pingInterval);
+    pingInterval = null;
+  }
+}
+
+function scheduleReconnect() {
+  clearReconnect();
+  if (!backendUrl) return;
+
+  console.log("[OpenBrowser] Reconnecting in", reconnectDelay, "ms");
+  reconnectTimer = setTimeout(function () {
+    connect(backendUrl);
+  }, reconnectDelay);
+
+  reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
+}
+
+function clearReconnect() {
+  if (reconnectTimer !== null) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
+function wsSend(obj) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(obj));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Send browser info on connect
+// ---------------------------------------------------------------------------
+
+async function sendBrowserInfo() {
+  try {
+    const tabs = await chrome.tabs.query({});
+    wsSend({
+      type: "extension_connected",
+      info: {
+        userAgent: navigator.userAgent,
+        tabCount: tabs ? tabs.length : 0,
+      },
+    });
+  } catch (err) {
+    console.error("[OpenBrowser] sendBrowserInfo error:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backend message handler
+// ---------------------------------------------------------------------------
+
+function handleBackendMessage(msg) {
+  switch (msg.type) {
+    case "cdp_command":
+      handleCdpCommand(msg);
+      break;
+    case "attach_tab":
+      handleAttachTab(msg);
+      break;
+    case "detach_tab":
+    case "detach_debugger":
+      handleDetachTab(msg);
+      break;
+    case "get_browser_info":
+      handleGetBrowserInfo(msg);
+      break;
+    case "pong":
+      // keepalive ack, nothing to do
+      break;
+    default:
+      console.warn("[OpenBrowser] Unknown message type from backend:", msg.type);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CDP command relay (async/await -- MV3 Promise-based API)
+// ---------------------------------------------------------------------------
+
+async function handleCdpCommand(msg) {
+  const { id, method, params, sessionId } = msg;
+
+  let target;
+  if (sessionId) {
+    const targetId = sessionToTarget.get(sessionId);
+    if (targetId) {
+      target = { targetId: targetId };
+    } else {
+      // Fallback: send on main tab
+      if (!activeTabId) {
+        wsSend({ type: "cdp_response", id: id, error: "No active tab and unknown sessionId" });
+        return;
+      }
+      target = { tabId: activeTabId };
+    }
+  } else {
+    if (!activeTabId) {
+      wsSend({ type: "cdp_response", id: id, error: "No active tab attached" });
+      return;
+    }
+    target = { tabId: activeTabId };
+  }
+
+  try {
+    // Use Promise-based API (MV3) instead of callback-based.
+    // The callback-based API can silently return undefined for results.
+    const result = await chrome.debugger.sendCommand(target, method, params || {});
+
+    // Track session <-> target mapping from Target.attachToTarget response
+    if (method === "Target.attachToTarget" && result && result.sessionId) {
+      const newTargetId = params && params.targetId ? params.targetId : null;
+      if (newTargetId) {
+        sessionToTarget.set(result.sessionId, newTargetId);
+        targetToSession.set(newTargetId, result.sessionId);
+
+        // Also attach chrome.debugger to the new target so we receive its events
+        try {
+          await chrome.debugger.attach({ targetId: newTargetId }, CDP_PROTOCOL_VERSION);
+        } catch (attachErr) {
+          // Target may already be attached -- not fatal
+          console.warn(
+            "[OpenBrowser] Could not attach debugger to target",
+            newTargetId,
+            attachErr.message
+          );
+        }
+      }
+    }
+
+    // Send response back. Ensure result is never undefined in JSON
+    // (JSON.stringify omits undefined values).
+    wsSend({
+      type: "cdp_response",
+      id: id,
+      result: result !== undefined && result !== null ? result : {},
+    });
+  } catch (err) {
+    console.error("[OpenBrowser] CDP command error:", method, err.message);
+    wsSend({
+      type: "cdp_response",
+      id: id,
+      error: err.message || String(err),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tab attach / detach (async/await)
+// ---------------------------------------------------------------------------
+
+async function handleAttachTab(msg) {
+  const requestedTabId = msg.tabId || null;
+
+  async function attachToTab(tabId) {
+    try {
+      await chrome.debugger.attach({ tabId: tabId }, CDP_PROTOCOL_VERSION);
+      activeTabId = tabId;
+      debuggerAttached = true;
+      persistState();
+
+      // Enable Runtime and Page domains so we receive events
+      try {
+        await chrome.debugger.sendCommand({ tabId: tabId }, "Runtime.enable", {});
+      } catch (e) {
+        console.warn("[OpenBrowser] Runtime.enable failed:", e.message);
+      }
+      try {
+        await chrome.debugger.sendCommand({ tabId: tabId }, "Page.enable", {});
+      } catch (e) {
+        console.warn("[OpenBrowser] Page.enable failed:", e.message);
+      }
+
+      wsSend({
+        type: "tab_attached",
+        tabId: tabId,
+        success: true,
+      });
+    } catch (err) {
+      wsSend({
+        type: "tab_attached",
+        tabId: tabId,
+        success: false,
+        error: err.message || String(err),
+      });
+    }
+  }
+
+  if (requestedTabId) {
+    await attachToTab(requestedTabId);
+  } else {
+    // Create a new tab with about:blank (avoids chrome://newtab which
+    // can cause debugger detachment) and attach
+    try {
+      const tab = await chrome.tabs.create({ active: true, url: "about:blank" });
+      if (!tab) {
+        wsSend({
+          type: "tab_attached",
+          tabId: null,
+          success: false,
+          error: "Failed to create tab",
+        });
+        return;
+      }
+      await attachToTab(tab.id);
+    } catch (err) {
+      wsSend({
+        type: "tab_attached",
+        tabId: null,
+        success: false,
+        error: err.message || String(err),
+      });
+    }
+  }
+}
+
+async function handleDetachTab(_msg) {
+  if (!activeTabId) {
+    return;
+  }
+
+  try {
+    await chrome.debugger.detach({ tabId: activeTabId });
+  } catch (err) {
+    console.warn("[OpenBrowser] Detach error:", err.message);
+  }
+  activeTabId = null;
+  debuggerAttached = false;
+  sessionToTarget.clear();
+  targetToSession.clear();
+  persistState();
+}
+
+// ---------------------------------------------------------------------------
+// Browser info
+// ---------------------------------------------------------------------------
+
+async function handleGetBrowserInfo(msg) {
+  try {
+    const tabs = await chrome.tabs.query({});
+    wsSend({
+      type: "browser_info",
+      id: msg.id || null,
+      info: {
+        userAgent: navigator.userAgent,
+        tabCount: tabs ? tabs.length : 0,
+        activeTabId: activeTabId,
+        debuggerAttached: debuggerAttached,
+      },
+    });
+  } catch (err) {
+    console.error("[OpenBrowser] handleGetBrowserInfo error:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// chrome.debugger event forwarding
+// ---------------------------------------------------------------------------
+
+chrome.debugger.onEvent.addListener(function (source, method, params) {
+  // Track Target.attachedToTarget events for session mapping
+  if (method === "Target.attachedToTarget" && params) {
+    const sessionId = params.sessionId;
+    const targetInfo = params.targetInfo;
+    if (sessionId && targetInfo && targetInfo.targetId) {
+      sessionToTarget.set(sessionId, targetInfo.targetId);
+      targetToSession.set(targetInfo.targetId, sessionId);
+    }
+  }
+
+  // Track Target.detachedFromTarget events to clean up mappings
+  if (method === "Target.detachedFromTarget" && params) {
+    const sessionId = params.sessionId;
+    if (sessionId) {
+      const targetId = sessionToTarget.get(sessionId);
+      if (targetId) {
+        targetToSession.delete(targetId);
+      }
+      sessionToTarget.delete(sessionId);
+    }
+  }
+
+  // Determine sessionId from source
+  let sessionId = null;
+  if (source.targetId) {
+    sessionId = targetToSession.get(source.targetId) || null;
+  }
+
+  wsSend({
+    type: "cdp_event",
+    method: method,
+    params: params || {},
+    sessionId: sessionId,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chrome.debugger detach notification
+// ---------------------------------------------------------------------------
+
+chrome.debugger.onDetach.addListener(function (source, reason) {
+  console.log("[OpenBrowser] Debugger detached. Source:", source, "Reason:", reason);
+
+  // If the detached target is our active tab, reset state
+  if (source.tabId && source.tabId === activeTabId) {
+    activeTabId = null;
+    debuggerAttached = false;
+    sessionToTarget.clear();
+    targetToSession.clear();
+    persistState();
+  }
+
+  // If the detached target is a child target, clean up its mapping
+  if (source.targetId) {
+    const sessionId = targetToSession.get(source.targetId);
+    if (sessionId) {
+      sessionToTarget.delete(sessionId);
+      targetToSession.delete(source.targetId);
+    }
+  }
+
+  wsSend({
+    type: "debugger_detached",
+    reason: reason,
+    tabId: source.tabId || null,
+    targetId: source.targetId || null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message listener (from content script and popup)
+// ---------------------------------------------------------------------------
+
+chrome.runtime.onMessage.addListener(function (message, _sender, sendResponse) {
+  if (!message || !message.type) {
+    return;
+  }
+
+  switch (message.type) {
+    case "set_backend_url":
+      if (message.url) {
+        connect(message.url);
+      }
+      sendResponse({ ok: true });
+      break;
+
+    case "get_status":
+      sendResponse({
+        connected: ws !== null && ws.readyState === WebSocket.OPEN,
+        backendUrl: backendUrl,
+        activeTabId: activeTabId,
+        debuggerAttached: debuggerAttached,
+      });
+      break;
+
+    case "manual_connect":
+      if (message.url) {
+        connect(message.url);
+      }
+      sendResponse({ ok: true });
+      break;
+
+    case "manual_disconnect":
+      disconnect();
+      sendResponse({ ok: true });
+      break;
+
+    default:
+      break;
+  }
+
+  // Return true to indicate async sendResponse is possible
+  return true;
+});
+
+// ---------------------------------------------------------------------------
+// Startup: restore previous backend URL and reconnect
+// ---------------------------------------------------------------------------
+
+chrome.storage.local.get(["backendUrl"], function (data) {
+  if (data.backendUrl) {
+    console.log("[OpenBrowser] Restoring connection to", data.backendUrl);
+    connect(data.backendUrl);
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,73 @@
+/**
+ * OpenBrowser Content Script
+ *
+ * Runs on OpenBrowser frontend pages. Discovers the backend WebSocket URL
+ * from a <meta> tag or derives it from the current page URL, then relays
+ * it to the background service worker.
+ */
+
+(function () {
+  "use strict";
+
+  let lastSentUrl = null;
+
+  /**
+   * Derive the default WebSocket backend URL from the current page origin.
+   * e.g. http://localhost:3000 -> ws://localhost:8000/ws/extension
+   *      https://app.openbrowser.me -> wss://api.openbrowser.me/ws/extension
+   */
+  function deriveBackendUrl() {
+    const loc = window.location;
+    const isSecure = loc.protocol === "https:";
+    const wsProtocol = isSecure ? "wss" : "ws";
+
+    if (loc.hostname === "localhost" || loc.hostname === "127.0.0.1") {
+      return `${wsProtocol}://${loc.hostname}:8000/ws/extension`;
+    }
+
+    // For production: replace app/www subdomain with api subdomain
+    const apiHost = loc.hostname.replace(/^(app|www)\./, "api.");
+    return `${wsProtocol}://${apiHost}/ws/extension`;
+  }
+
+  /**
+   * Read the WebSocket URL from the page meta tag, falling back to
+   * a derived URL based on the current page origin.
+   */
+  function resolveBackendUrl() {
+    const meta = document.querySelector('meta[name="openbrowser-ws-url"]');
+    if (meta && meta.content) {
+      return meta.content.trim();
+    }
+    return deriveBackendUrl();
+  }
+
+  /**
+   * Send the backend URL to the background service worker if it has
+   * changed since the last time we sent it.
+   */
+  function sendBackendUrl() {
+    const url = resolveBackendUrl();
+    if (url === lastSentUrl) {
+      return;
+    }
+    lastSentUrl = url;
+
+    chrome.runtime.sendMessage(
+      { type: "set_backend_url", url: url },
+      function (_response) {
+        // Suppress errors when the background script is not ready
+        if (chrome.runtime.lastError) {
+          // Will retry on the next interval tick
+          lastSentUrl = null;
+        }
+      }
+    );
+  }
+
+  // Send on initial load
+  sendBackendUrl();
+
+  // Poll every 5 seconds to detect SPA navigation or meta tag changes
+  setInterval(sendBackendUrl, 5000);
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 3,
+  "name": "OpenBrowser - Browser Operator",
+  "description": "Let OpenBrowser AI control your current browser with your cookies, profile, and logged-in sessions.",
+  "version": "0.1.0",
+  "minimum_chrome_version": "116",
+  "permissions": [
+    "debugger",
+    "tabs",
+    "activeTab",
+    "scripting",
+    "storage"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://localhost/*",
+        "*://*.openbrowser.me/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      width: 300px;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .container {
+      padding: 16px;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+
+    .title {
+      font-size: 16px;
+      font-weight: 700;
+      color: #ffffff;
+      letter-spacing: 0.3px;
+    }
+
+    .version {
+      font-size: 11px;
+      color: #888;
+    }
+
+    /* Status section */
+    .status-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .status-dot.connected {
+      background: #4ade80;
+      box-shadow: 0 0 6px rgba(74, 222, 128, 0.5);
+    }
+
+    .status-dot.disconnected {
+      background: #ef4444;
+      box-shadow: 0 0 6px rgba(239, 68, 68, 0.4);
+    }
+
+    .status-text {
+      font-weight: 600;
+    }
+
+    .info-row {
+      margin-bottom: 6px;
+      color: #aaa;
+      font-size: 12px;
+      word-break: break-all;
+    }
+
+    .info-row .label {
+      color: #888;
+    }
+
+    .info-row .value {
+      color: #c0c0c0;
+    }
+
+    /* Divider */
+    .divider {
+      border: none;
+      border-top: 1px solid #2a2a4a;
+      margin: 14px 0;
+    }
+
+    /* Collapsible override section */
+    .override-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      cursor: pointer;
+      padding: 6px 0;
+      user-select: none;
+    }
+
+    .override-header:hover .override-title {
+      color: #ffffff;
+    }
+
+    .override-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: #aaa;
+      transition: color 0.15s;
+    }
+
+    .override-arrow {
+      font-size: 10px;
+      color: #888;
+      transition: transform 0.2s;
+    }
+
+    .override-arrow.open {
+      transform: rotate(90deg);
+    }
+
+    .override-body {
+      display: none;
+      margin-top: 8px;
+    }
+
+    .override-body.open {
+      display: block;
+    }
+
+    .input-group {
+      display: flex;
+      gap: 6px;
+      margin-bottom: 8px;
+    }
+
+    .input-group input {
+      flex: 1;
+      padding: 6px 8px;
+      border-radius: 4px;
+      border: 1px solid #3a3a5c;
+      background: #0f0f23;
+      color: #e0e0e0;
+      font-size: 12px;
+      outline: none;
+    }
+
+    .input-group input:focus {
+      border-color: #6366f1;
+    }
+
+    .input-group input::placeholder {
+      color: #555;
+    }
+
+    .btn {
+      padding: 6px 12px;
+      border-radius: 4px;
+      border: none;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s, opacity 0.15s;
+    }
+
+    .btn:hover {
+      opacity: 0.9;
+    }
+
+    .btn-primary {
+      background: #6366f1;
+      color: #fff;
+    }
+
+    .btn-danger {
+      background: #dc2626;
+      color: #fff;
+    }
+
+    .btn-small {
+      padding: 4px 10px;
+      font-size: 11px;
+    }
+
+    .action-row {
+      display: flex;
+      gap: 6px;
+    }
+
+    /* Footer link */
+    .footer {
+      margin-top: 14px;
+      text-align: center;
+    }
+
+    .footer a {
+      color: #6366f1;
+      text-decoration: none;
+      font-size: 11px;
+    }
+
+    .footer a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <!-- Header -->
+    <div class="header">
+      <span class="title">OpenBrowser</span>
+      <span class="version">v0.1.0</span>
+    </div>
+
+    <!-- Status -->
+    <div class="status-row">
+      <div id="statusDot" class="status-dot disconnected"></div>
+      <span id="statusText" class="status-text">Disconnected</span>
+    </div>
+
+    <div id="connectedInfo" style="display:none;">
+      <div class="info-row">
+        <span class="label">Backend: </span>
+        <span id="backendUrlDisplay" class="value">--</span>
+      </div>
+      <div class="info-row">
+        <span class="label">Tab: </span>
+        <span id="tabIdDisplay" class="value">--</span>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <!-- Manual override -->
+    <div class="override-header" id="overrideToggle">
+      <span class="override-title">Manual Connection</span>
+      <span class="override-arrow" id="overrideArrow">&#9654;</span>
+    </div>
+
+    <div class="override-body" id="overrideBody">
+      <div class="input-group">
+        <input
+          type="text"
+          id="manualUrl"
+          placeholder="ws://localhost:8000/ws/extension"
+        >
+      </div>
+      <div class="action-row">
+        <button class="btn btn-primary btn-small" id="connectBtn">Connect</button>
+        <button class="btn btn-danger btn-small" id="disconnectBtn">Disconnect</button>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="footer">
+      <a href="https://openbrowser.me" target="_blank">Visit openbrowser.me</a>
+    </div>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,146 @@
+/**
+ * OpenBrowser Popup Script
+ *
+ * Reads connection state from the background service worker and
+ * chrome.storage.local, updates the popup UI, and provides manual
+ * connect/disconnect controls.
+ */
+
+(function () {
+  "use strict";
+
+  // -----------------------------------------------------------------------
+  // DOM references
+  // -----------------------------------------------------------------------
+
+  const statusDot = document.getElementById("statusDot");
+  const statusText = document.getElementById("statusText");
+  const connectedInfo = document.getElementById("connectedInfo");
+  const backendUrlDisplay = document.getElementById("backendUrlDisplay");
+  const tabIdDisplay = document.getElementById("tabIdDisplay");
+
+  const overrideToggle = document.getElementById("overrideToggle");
+  const overrideArrow = document.getElementById("overrideArrow");
+  const overrideBody = document.getElementById("overrideBody");
+
+  const manualUrlInput = document.getElementById("manualUrl");
+  const connectBtn = document.getElementById("connectBtn");
+  const disconnectBtn = document.getElementById("disconnectBtn");
+
+  // -----------------------------------------------------------------------
+  // UI update
+  // -----------------------------------------------------------------------
+
+  function updateUI(state) {
+    const connected = state.connected === true;
+
+    if (connected) {
+      statusDot.className = "status-dot connected";
+      statusText.textContent = "Connected";
+      connectedInfo.style.display = "block";
+      backendUrlDisplay.textContent = state.backendUrl || "--";
+      tabIdDisplay.textContent =
+        state.activeTabId != null ? "Tab " + state.activeTabId : "None";
+    } else {
+      statusDot.className = "status-dot disconnected";
+      statusText.textContent = "Disconnected";
+      connectedInfo.style.display = "none";
+      backendUrlDisplay.textContent = "--";
+      tabIdDisplay.textContent = "--";
+    }
+
+    // Pre-fill manual URL input if we have a stored backend URL
+    if (state.backendUrl && !manualUrlInput.value) {
+      manualUrlInput.value = state.backendUrl;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Load initial state
+  // -----------------------------------------------------------------------
+
+  function loadState() {
+    // Ask the background worker directly for live status
+    chrome.runtime.sendMessage({ type: "get_status" }, function (response) {
+      if (chrome.runtime.lastError) {
+        // Background worker may not be active yet; fall back to storage
+        chrome.storage.local.get(
+          ["connected", "backendUrl", "activeTabId", "debuggerAttached"],
+          function (data) {
+            updateUI(data);
+          }
+        );
+        return;
+      }
+      if (response) {
+        updateUI(response);
+      }
+    });
+  }
+
+  loadState();
+
+  // -----------------------------------------------------------------------
+  // Listen for storage changes (real-time status updates)
+  // -----------------------------------------------------------------------
+
+  chrome.storage.onChanged.addListener(function (changes, area) {
+    if (area !== "local") return;
+
+    // Re-read full state whenever anything relevant changes
+    if (
+      changes.connected ||
+      changes.backendUrl ||
+      changes.activeTabId ||
+      changes.debuggerAttached
+    ) {
+      loadState();
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Collapsible manual override section
+  // -----------------------------------------------------------------------
+
+  overrideToggle.addEventListener("click", function () {
+    const isOpen = overrideBody.classList.toggle("open");
+    if (isOpen) {
+      overrideArrow.classList.add("open");
+    } else {
+      overrideArrow.classList.remove("open");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Manual connect / disconnect
+  // -----------------------------------------------------------------------
+
+  connectBtn.addEventListener("click", function () {
+    const url = manualUrlInput.value.trim();
+    if (!url) {
+      return;
+    }
+
+    chrome.runtime.sendMessage(
+      { type: "manual_connect", url: url },
+      function (_response) {
+        if (chrome.runtime.lastError) {
+          console.error("[OpenBrowser Popup] Connect error:", chrome.runtime.lastError.message);
+        }
+        // State will update via storage listener
+      }
+    );
+  });
+
+  disconnectBtn.addEventListener("click", function () {
+    chrome.runtime.sendMessage(
+      { type: "manual_disconnect" },
+      function (_response) {
+        if (chrome.runtime.lastError) {
+          console.error("[OpenBrowser Popup] Disconnect error:", chrome.runtime.lastError.message);
+        }
+        // State will update via storage listener
+      }
+    );
+  });
+})();

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+const EXTENSION_WS_URL = (process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8000/ws")
+  .replace(/\/ws$/, "/ws/extension");
+
 export const metadata: Metadata = {
   title: "OpenBrowser - AI Browser Automation",
   description: "Control your browser with natural language. OpenBrowser is an open-source AI browser automation framework.",
@@ -30,6 +33,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
+      <head>
+        <meta name="openbrowser-ws-url" content={EXTENSION_WS_URL} />
+      </head>
       <body className="min-h-screen bg-zinc-950 text-zinc-100 antialiased">
         {children}
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -129,6 +129,9 @@ export default function Home() {
     setAvailableProviders,
     setModelsLoading,
     setModelsError,
+    // Current browser
+    useCurrentBrowser,
+    setExtensionConnected,
   } = useAppStore();
   const [isLoading, setIsLoading] = useState(false);
   const [currentTaskId, setCurrentTaskId] = useState<string | null>(null);
@@ -301,8 +304,14 @@ export default function Home() {
           taskId: task_id,
         });
         break;
+
+      case "extension_status": {
+        const connected = data.connected as boolean;
+        setExtensionConnected(connected);
+        break;
+      }
     }
-  }, [addMessage, addLog, clearLogs, setVncInfo]);
+  }, [addMessage, addLog, clearLogs, setVncInfo, setExtensionConnected]);
 
   const { isConnected, sendMessage } = useWebSocket({
     onMessage: handleWSMessage,
@@ -325,7 +334,8 @@ export default function Home() {
       agent_type: agentType,
       max_steps: maxSteps,
       use_vision: useVision,
-      llm_model: selectedModel, // Include selected model
+      llm_model: selectedModel,
+      use_current_browser: useCurrentBrowser,
     });
 
     if (!sent) {
@@ -338,7 +348,7 @@ export default function Home() {
         metadata: { isError: true },
       });
     }
-  }, [addMessage, sendMessage, agentType, maxSteps, useVision, selectedModel]);
+  }, [addMessage, sendMessage, agentType, maxSteps, useVision, selectedModel, useCurrentBrowser]);
 
   const hasMessages = messages.length > 0;
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,14 +2,14 @@
 
 import React from "react";
 import { motion } from "framer-motion";
-import { Bell, Sparkles, User, Monitor } from "lucide-react";
+import { Bell, Sparkles, User, Monitor, Globe } from "lucide-react";
 import { Button } from "@/components/ui";
 import { ModelSelector } from "./ModelSelector";
 import { useAppStore } from "@/store";
 import { cn } from "@/lib/utils";
 
 export function Header() {
-  const { vncInfo, browserViewerOpen, toggleBrowserViewer } = useAppStore();
+  const { vncInfo, browserViewerOpen, toggleBrowserViewer, useCurrentBrowser, setUseCurrentBrowser, extensionConnected } = useAppStore();
   const hasVncSession = !!vncInfo;
 
   return (
@@ -44,6 +44,34 @@ export function Header() {
 
         {/* Center: Plan status + View Browser button */}
         <div className="flex items-center gap-3">
+          {/* Use Current Browser Toggle */}
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => setUseCurrentBrowser(!useCurrentBrowser)}
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 rounded-lg transition-all border",
+              useCurrentBrowser
+                ? "bg-amber-500/20 text-amber-300 border-amber-500/30"
+                : "bg-zinc-800/50 text-zinc-400 hover:bg-zinc-700/50 border-transparent"
+            )}
+            title={useCurrentBrowser
+              ? "Using your current browser (extension connected)"
+              : "Switch to use your current browser with the OpenBrowser extension"
+            }
+          >
+            <Globe className={cn("w-4 h-4", useCurrentBrowser && "text-amber-400")} />
+            <span className="text-sm font-medium">
+              {useCurrentBrowser ? "Current Browser" : "New Browser"}
+            </span>
+            {useCurrentBrowser && (
+              <span className={cn(
+                "w-2 h-2 rounded-full",
+                extensionConnected ? "bg-green-400" : "bg-red-400 animate-pulse"
+              )} />
+            )}
+          </motion.button>
+
           {/* View Browser Button - Always clickable, shows empty state if no VNC session */}
           <motion.button
             whileHover={{ scale: 1.02 }}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -56,7 +56,13 @@ interface AppState {
   setMaxSteps: (steps: number) => void;
   useVision: boolean;
   setUseVision: (use: boolean) => void;
-  
+
+  // Current browser mode
+  useCurrentBrowser: boolean;
+  setUseCurrentBrowser: (use: boolean) => void;
+  extensionConnected: boolean;
+  setExtensionConnected: (connected: boolean) => void;
+
   // LLM Model Selection
   availableModels: LLMModel[];
   setAvailableModels: (models: LLMModel[]) => void;
@@ -144,7 +150,13 @@ export const useAppStore = create<AppState>()(
       setMaxSteps: (steps) => set({ maxSteps: steps }),
       useVision: true,
       setUseVision: (use) => set({ useVision: use }),
-      
+
+      // Current browser mode
+      useCurrentBrowser: false,
+      setUseCurrentBrowser: (use) => set({ useCurrentBrowser: use }),
+      extensionConnected: false,
+      setExtensionConnected: (connected) => set({ extensionConnected: connected }),
+
       // LLM Model Selection
       availableModels: [],
       setAvailableModels: (models) => set({ availableModels: models }),
@@ -166,6 +178,7 @@ export const useAppStore = create<AppState>()(
         agentType: state.agentType,
         maxSteps: state.maxSteps,
         useVision: state.useVision,
+        useCurrentBrowser: state.useCurrentBrowser,
         sidebarOpen: state.sidebarOpen,
         showLogs: state.showLogs,
         browserViewerMode: state.browserViewerMode,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,7 +16,8 @@ export type WSMessageType =
   | "task_failed"
   | "task_cancelled"
   | "log"
-  | "vnc_info";  // VNC connection information
+  | "vnc_info"  // VNC connection information
+  | "extension_status";  // Extension connected/disconnected
 
 export interface WSMessage {
   type: WSMessageType;

--- a/infra/eval/terraform/main.tf
+++ b/infra/eval/terraform/main.tf
@@ -156,8 +156,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "datasets" {
 
 # Results bucket: {project}/runs/{ISO_DATE}/{run_id}/
 resource "aws_s3_bucket" "results" {
-  bucket = "${var.project_name}-eval-results-${data.aws_caller_identity.current.account_id}"
-  tags   = { Name = "${var.project_name}-eval-results" }
+  bucket        = "${var.project_name}-eval-results-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true
+  tags          = { Name = "${var.project_name}-eval-results" }
 }
 
 resource "aws_s3_bucket_versioning" "results" {

--- a/infra/eval/terraform/main.tf
+++ b/infra/eval/terraform/main.tf
@@ -116,8 +116,9 @@ resource "aws_security_group" "eval" {
 
 # Dataset bucket: mind2web/, webarena/, formfactory/, stress-tests/
 resource "aws_s3_bucket" "datasets" {
-  bucket = "${var.project_name}-eval-datasets-${data.aws_caller_identity.current.account_id}"
-  tags   = { Name = "${var.project_name}-eval-datasets" }
+  bucket        = "${var.project_name}-eval-datasets-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true
+  tags          = { Name = "${var.project_name}-eval-datasets" }
 }
 
 resource "aws_s3_bucket_versioning" "datasets" {


### PR DESCRIPTION
This pull request introduces support for controlling the user's current browser via a Chrome extension, alongside enhancements to WebSocket handling and agent session management. The main changes enable the backend to communicate with a Chrome extension for browser automation, add new WebSocket endpoints for extension connections, and update the agent service to optionally use the user's browser instead of launching a new one. There are also schema updates to support this new workflow, and a new content script for the extension to discover the backend URL.

**Chrome Extension Integration and WebSocket Handling:**

* Added a new `extension_handler.py` module to manage Chrome extension WebSocket connections, including connection management, message routing, and broadcasting extension status to frontend clients.
* Registered new WebSocket endpoints `/ws/extension` and `/ws/extension/{extension_id}` in `main.py` to handle extension connections, ensuring proper routing and avoiding conflicts with dynamic client IDs. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R14) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R112-R126)
* Updated the frontend WebSocket handler to send the current extension connection status to clients upon connection, and to broadcast status updates when the extension connects or disconnects.

**Agent Service Enhancements (Browser Control):**

* Updated the `AgentService` to support a `use_current_browser` mode, which connects to the user's Chrome browser via the extension and a CDP bridge, instead of launching a new browser. This includes setup, cleanup, and session creation logic. [[1]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR28) [[2]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffL42-R45) [[3]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR59) [[4]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffL97-R148) [[5]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR183-R207) [[6]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR598-R617) [[7]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR642) [[8]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR655) [[9]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR668) [[10]](diffhunk://#diff-905f0d23dff56fa16aacf2bb1b964d47782fca3b03a1d4e6485026d650d5ccffR690)

**Schema and API Updates:**

* Added the `use_current_browser` field to task creation and WebSocket start task schemas, enabling clients to request use of the current browser. [[1]](diffhunk://#diff-91be382f5b87362f65c307b9564fb39f710dc0d61207de89a492b8a226470a3aR42) [[2]](diffhunk://#diff-91be382f5b87362f65c307b9564fb39f710dc0d61207de89a492b8a226470a3aR174)
* Introduced a new WebSocket message type `EXTENSION_STATUS` to notify clients about the Chrome extension's connection status.
* Passed the `use_current_browser` flag throughout the agent session creation pipeline and WebSocket handlers.

**CORS and Extension Content Script:**

* Updated CORS settings to allow requests from `http://localhost:3001`, supporting local extension/frontend development.
* Added a new content script (`extension/content.js`) for the Chrome extension to discover the backend WebSocket URL from the frontend and relay it to the background worker, improving extension connectivity in various environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support to control the user’s current Chrome via a new extension and CDP bridge, so agents can run against the user’s logged-in profile without launching a new browser. Includes new WebSocket endpoints, schemas, and a frontend toggle with live extension status.

- **New Features**
  - Chrome extension (MV3) relays CDP over WebSocket; content script auto-discovers backend WS URL; popup allows manual connect/disconnect.
  - Backend WebSocket routes for the extension: /ws/extension and /ws/extension/{id}, with a manager that broadcasts EXTENSION_STATUS to clients.
  - CDPBridge local WS server maps CDP <-> extension (handles Target.* and blocks unsupported Browser.*) for stable control.
  - AgentService: new use_current_browser flag; connects via CDP bridge, attaches to a tab, stops gracefully (doesn’t kill user’s browser), and disables VNC in this mode.
  - Schemas/API: add use_current_browser to CreateTaskRequest and WSStartTaskData; new WS message type extension_status.
  - Frontend: “Current Browser” toggle in header, sends use_current_browser on task start, shows extension connection status; meta tag exposes the extension WS URL.
  - CORS: allow http://localhost:3001.
  - Reliability/misc: retry loop for CDP /json/version discovery; force_destroy for eval S3 buckets; .gitignore updates for extension artifacts and runtime data.

- **Migration**
  - Load the extension (extension/ folder) as “Load unpacked” in Chrome and grant “Debugger” permission.
  - Run backend and frontend; open the app so the content script sets the correct WS URL; confirm the green indicator in the header/popup.
  - Toggle “Current Browser” before starting a task to use the user’s browser (VNC is not used in this mode).
  - If auto-discovery fails, set the WS URL manually in the popup (e.g., ws://localhost:8000/ws/extension).

<sup>Written for commit 77508417e69a7fabe1a619f982b39616cf46aab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Chrome extension enabling browser control through your existing browser instead of launching a new one
* New "Current Browser" toggle in the interface to switch between modes
* Extension popup displays live connection status and backend information
* Real-time connection indicator shows when the extension is properly linked

## Chores
* Updated CORS configuration to support additional development ports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->