### PR TITLE
feat(infra): add disaster recovery demo script for A2 Part 5

### DIFF
--- a/infra/eval/disaster_recovery_demo.sh
+++ b/infra/eval/disaster_recovery_demo.sh
@@ -1,0 +1,759 @@
+#!/bin/bash
+# ============================================================================
+# CSC490 Assignment 2 -- Part 5: Disaster Recovery Demonstration
+# OpenBrowser-AI Evaluation Infrastructure
+#
+# This script demonstrates:
+#   1. Inspecting the existing production infrastructure (23 AWS resources)
+#   2. Destroying all resources with terraform destroy
+#   3. Restoring everything with terraform apply
+#   4. Verifying the restored environment works end-to-end
+#
+# Prerequisites:
+#   - AWS CLI configured (aws configure)
+#   - Terraform >= 1.5.0 installed
+#   - uv installed (for Python eval pipeline)
+#   - .env file at project root with API keys
+#   - Infrastructure currently deployed (terraform apply has been run)
+#
+# Usage:
+#   cd /path/to/openbrowser-ai
+#   bash infra/eval/disaster_recovery_demo.sh
+# ============================================================================
+
+set -e
+
+# -- Configuration -----------------------------------------------------------
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TF_DIR="$PROJECT_ROOT/infra/eval/terraform"
+AWS_REGION="ca-central-1"
+PROJECT_NAME="openbrowser"
+
+# -- Load AWS credentials from .env ------------------------------------------
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading AWS credentials from $ENV_FILE ..."
+    # Export AWS credential variables from .env (handles quoted values)
+    while IFS='=' read -r key value; do
+        # Skip comments and blank lines
+        [[ "$key" =~ ^#.*$ || -z "$key" ]] && continue
+        # Strip surrounding quotes from value
+        value="${value%\"}"
+        value="${value#\"}"
+        case "$key" in
+            AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|AWS_REGION|AWS_DEFAULT_REGION)
+                export "$key=$value"
+                echo "  Exported $key"
+                ;;
+        esac
+    done < "$ENV_FILE"
+    echo ""
+else
+    echo "WARNING: $ENV_FILE not found -- falling back to global AWS credentials."
+    echo ""
+fi
+
+# -- Pre-flight: check required tools and credentials -----------------------
+check_command() {
+    if ! command -v "$1" &>/dev/null; then
+        echo "ERROR: $1 is not installed or not in PATH." >&2
+        exit 1
+    fi
+}
+check_command terraform
+check_command aws
+check_command uv
+
+echo "Checking AWS credentials..."
+if ! aws sts get-caller-identity --region "$AWS_REGION" &>/dev/null; then
+    echo "ERROR: AWS credentials are invalid or expired." >&2
+    echo "Run 'aws sts get-caller-identity' to debug, or refresh your session." >&2
+    exit 1
+fi
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --region "$AWS_REGION" --query 'Account' --output text)
+echo "AWS Account: $AWS_ACCOUNT_ID -- credentials OK."
+echo ""
+
+# -- Color codes -------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# -- Timer -------------------------------------------------------------------
+SCRIPT_START=$(date +%s)
+DESTROY_DURATION=0
+RESTORE_DURATION=0
+EVAL_DURATION=0
+
+# -- PASS/FAIL tracking ------------------------------------------------------
+declare -a RESULTS=()
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# -- Helper functions --------------------------------------------------------
+
+section_header() {
+    local title="$1"
+    local color="$2"
+    printf "\n"
+    printf "${color}================================================================${NC}\n"
+    printf "${color}  %s${NC}\n" "$title"
+    printf "${color}================================================================${NC}\n"
+    printf "\n"
+}
+
+pass_fail() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        RESULTS+=("${GREEN}[PASS]${NC} $description")
+        ((PASS_COUNT++)) || true
+        echo -e "${GREEN}[PASS]${NC} $description"
+    else
+        RESULTS+=("${RED}[FAIL]${NC} $description")
+        ((FAIL_COUNT++)) || true
+        echo -e "${RED}[FAIL]${NC} $description"
+    fi
+}
+
+pause() {
+    printf "\n${YELLOW}>>> Press Enter to continue...${NC}\n"
+    read -r
+}
+
+info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+destroy_msg() {
+    echo -e "${RED}[DESTROY]${NC} $*"
+}
+
+restore_msg() {
+    echo -e "${GREEN}[RESTORE]${NC} $*"
+}
+
+show_cmd() {
+    echo -e "${YELLOW}\$ $*${NC}"
+}
+
+# ============================================================================
+# PHASE 0: PRE-FLIGHT -- Inspecting Current Infrastructure
+# ============================================================================
+
+section_header "PHASE 0: PRE-FLIGHT -- Inspecting Current Infrastructure" "$BLUE"
+
+info "Working directory: $PROJECT_ROOT"
+info "Terraform directory: $TF_DIR"
+info "AWS Region: $AWS_REGION"
+info "Project: $PROJECT_NAME"
+printf "\n"
+
+# Step 0.1: Terraform state list
+info "--- Step 0.1: Listing all Terraform-managed resources ---"
+cd "$TF_DIR"
+show_cmd "terraform state list"
+terraform state list
+RESOURCE_COUNT=$(terraform state list | wc -l | tr -d ' ')
+info "Total entries in state: $RESOURCE_COUNT (23 resources + 4 data sources)"
+printf "\n"
+
+# Step 0.2: Capture current resource IDs for before/after comparison
+info "--- Step 0.2: Capturing current resource IDs ---"
+show_cmd "terraform output (capturing VPC, SG, LT, S3 buckets)"
+BEFORE_VPC_ID=$(terraform output -raw vpc_id 2>/dev/null || echo "N/A")
+BEFORE_SG_ID=$(terraform output -raw security_group_id 2>/dev/null || echo "N/A")
+BEFORE_LT_ID=$(terraform output -raw launch_template_id 2>/dev/null || echo "N/A")
+BEFORE_DATASETS_BUCKET=$(terraform output -raw datasets_bucket 2>/dev/null || echo "N/A")
+BEFORE_RESULTS_BUCKET=$(terraform output -raw results_bucket 2>/dev/null || echo "N/A")
+show_cmd "aws iam get-role --role-name ${PROJECT_NAME}-eval-role"
+BEFORE_IAM_ROLE_ARN=$(aws iam get-role --role-name "${PROJECT_NAME}-eval-role" \
+    --query 'Role.Arn' --output text 2>/dev/null || echo "N/A")
+
+info "VPC ID:            $BEFORE_VPC_ID"
+info "Security Group ID: $BEFORE_SG_ID"
+info "Launch Template:   $BEFORE_LT_ID"
+info "Datasets Bucket:   $BEFORE_DATASETS_BUCKET"
+info "Results Bucket:    $BEFORE_RESULTS_BUCKET"
+info "IAM Role ARN:      $BEFORE_IAM_ROLE_ARN"
+printf "\n"
+
+# Step 0.3: Verify S3 buckets
+info "--- Step 0.3: Verifying S3 buckets exist ---"
+show_cmd "aws s3 ls | grep $PROJECT_NAME"
+aws s3 ls --region "$AWS_REGION" | grep "$PROJECT_NAME" || warn "No matching S3 buckets found"
+printf "\n"
+
+# Step 0.4: Verify VPC
+info "--- Step 0.4: Verifying VPC exists ---"
+show_cmd "aws ec2 describe-vpcs --filters \"Name=tag:Project,Values=$PROJECT_NAME\""
+aws ec2 describe-vpcs --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'Vpcs[*].{VpcId:VpcId,CidrBlock:CidrBlock,State:State}' \
+    --output table 2>/dev/null || warn "VPC query failed"
+printf "\n"
+
+# Step 0.5: Verify IAM role and policies
+info "--- Step 0.5: Verifying IAM role and attached policies ---"
+show_cmd "aws iam get-role --role-name ${PROJECT_NAME}-eval-role"
+aws iam get-role --role-name "${PROJECT_NAME}-eval-role" \
+    --query 'Role.{RoleName:RoleName,Arn:Arn,CreateDate:CreateDate}' \
+    --output table 2>/dev/null || warn "IAM role not found"
+
+info "Inline policies:"
+show_cmd "aws iam list-role-policies --role-name ${PROJECT_NAME}-eval-role"
+aws iam list-role-policies --role-name "${PROJECT_NAME}-eval-role" \
+    --output table 2>/dev/null || warn "No inline policies"
+
+info "Managed policy attachments:"
+show_cmd "aws iam list-attached-role-policies --role-name ${PROJECT_NAME}-eval-role"
+aws iam list-attached-role-policies --role-name "${PROJECT_NAME}-eval-role" \
+    --output table 2>/dev/null || warn "No managed policies"
+printf "\n"
+
+# Step 0.6: Verify launch template
+info "--- Step 0.6: Verifying EC2 launch template ---"
+show_cmd "aws ec2 describe-launch-templates --filters \"Name=tag:Project,Values=$PROJECT_NAME\""
+aws ec2 describe-launch-templates --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'LaunchTemplates[*].{Id:LaunchTemplateId,Name:LaunchTemplateName,Version:LatestVersionNumber,Created:CreateTime}' \
+    --output table 2>/dev/null || warn "Launch template not found"
+printf "\n"
+
+# Step 0.7: Verify SSM parameters
+info "--- Step 0.7: Verifying SSM parameters (API key placeholders) ---"
+show_cmd "aws ssm describe-parameters --parameter-filters \"Name=BeginsWith,Values=/${PROJECT_NAME}/\""
+aws ssm describe-parameters --region "$AWS_REGION" \
+    --parameter-filters "Key=Name,Option=BeginsWith,Values=/${PROJECT_NAME}/" \
+    --query 'Parameters[*].{Name:Name,Type:Type,Version:Version,LastModified:LastModifiedDate}' \
+    --output table 2>/dev/null || warn "SSM parameters not found"
+printf "\n"
+
+# Step 0.8: Verify security group rules
+info "--- Step 0.8: Verifying security group rules ---"
+if [ "$BEFORE_SG_ID" != "N/A" ]; then
+    info "Ingress rules (SSH):"
+    show_cmd "aws ec2 describe-security-groups --group-ids $BEFORE_SG_ID"
+    aws ec2 describe-security-groups --region "$AWS_REGION" \
+        --group-ids "$BEFORE_SG_ID" \
+        --query 'SecurityGroups[0].IpPermissions[*].{FromPort:FromPort,ToPort:ToPort,Protocol:IpProtocol,CIDR:IpRanges[0].CidrIp}' \
+        --output table 2>/dev/null || warn "Could not query ingress rules"
+
+    info "Egress rules (all outbound):"
+    aws ec2 describe-security-groups --region "$AWS_REGION" \
+        --group-ids "$BEFORE_SG_ID" \
+        --query 'SecurityGroups[0].IpPermissionsEgress[*].{FromPort:FromPort,ToPort:ToPort,Protocol:IpProtocol,CIDR:IpRanges[0].CidrIp}' \
+        --output table 2>/dev/null || warn "Could not query egress rules"
+else
+    warn "Security group ID not available, skipping rule check"
+fi
+printf "\n"
+
+# Step 0.9: Upload sample data to datasets bucket
+info "--- Step 0.9: Uploading sample data to S3 datasets bucket ---"
+if [ "$BEFORE_DATASETS_BUCKET" != "N/A" ]; then
+    show_cmd "aws s3 cp stress-tests/InteractionTasks_v8.json s3://${BEFORE_DATASETS_BUCKET}/stress-tests/"
+    aws s3 cp "$PROJECT_ROOT/stress-tests/InteractionTasks_v8.json" \
+        "s3://${BEFORE_DATASETS_BUCKET}/stress-tests/InteractionTasks_v8.json" \
+        --region "$AWS_REGION" --quiet 2>&1 || warn "Upload failed"
+    info "Verifying upload:"
+    show_cmd "aws s3 ls s3://${BEFORE_DATASETS_BUCKET}/stress-tests/"
+    aws s3 ls "s3://${BEFORE_DATASETS_BUCKET}/stress-tests/" \
+        --region "$AWS_REGION" 2>/dev/null || warn "List failed"
+else
+    warn "Datasets bucket not available, skipping upload"
+fi
+printf "\n"
+
+# Step 0.10: Show Terraform outputs
+info "--- Step 0.10: Current Terraform outputs ---"
+show_cmd "terraform output"
+terraform output
+printf "\n"
+
+info "Pre-flight inspection complete."
+info "Next phase will DESTROY all infrastructure."
+pause
+
+# ============================================================================
+# PHASE 1: DESTRUCTION -- Destroying All Infrastructure
+# ============================================================================
+
+section_header "PHASE 1: DESTRUCTION -- Destroying All Infrastructure" "$RED"
+
+# We are about to destroy ALL 23 managed resources:
+#   - VPC + subnet + internet gateway + route table + route table association (5)
+#   - Security group with SSH ingress and all-outbound egress (1)
+#   - S3 datasets bucket + versioning + encryption + public access block + lifecycle (5)
+#   - S3 results bucket + versioning + encryption + public access block + lifecycle (5)
+#   - IAM role + instance profile + inline policy + managed policy attachment (4)
+#   - EC2 launch template (spot, t3.small, 30GB gp3) (1)
+#   - SSM parameters: GOOGLE_API_KEY + OPENAI_API_KEY (2)
+#
+# This simulates a catastrophic infrastructure failure.
+
+destroy_msg "Running terraform destroy -auto-approve..."
+destroy_msg "This will permanently delete all 23 managed AWS resources."
+printf "\n"
+
+cd "$TF_DIR"
+
+# S3 buckets have versioning enabled, so we first apply force_destroy=true
+# so Terraform can empty all object versions before deleting the buckets.
+info "Updating S3 bucket config to allow force destroy (empties versioned objects)..."
+show_cmd "terraform apply -auto-approve -target=aws_s3_bucket.datasets -target=aws_s3_bucket.results"
+terraform apply -auto-approve \
+    -target=aws_s3_bucket.datasets \
+    -target=aws_s3_bucket.results \
+    2>&1 | tail -3
+printf "\n"
+
+show_cmd "terraform destroy -auto-approve"
+DESTROY_START=$(date +%s)
+terraform destroy -auto-approve
+DESTROY_END=$(date +%s)
+DESTROY_DURATION=$((DESTROY_END - DESTROY_START))
+
+printf "\n"
+destroy_msg "Destruction completed in ${DESTROY_DURATION} seconds."
+printf "\n"
+
+# Step 1.1: Verify state is empty
+info "--- Step 1.1: Verifying Terraform state is empty ---"
+show_cmd "terraform show"
+REMAINING=$(terraform show 2>&1 || true)
+if echo "$REMAINING" | grep -q "empty\|no resources\|No resources" || [ -z "$REMAINING" ]; then
+    pass_fail "Terraform state is empty" 0
+else
+    echo "$REMAINING"
+    pass_fail "Terraform state is empty" 1
+fi
+
+# Step 1.2: Verify S3 buckets gone
+info "--- Step 1.2: Verifying S3 buckets are destroyed ---"
+show_cmd "aws s3 ls | grep $PROJECT_NAME"
+BUCKET_CHECK=$(aws s3 ls --region "$AWS_REGION" 2>/dev/null | grep "$PROJECT_NAME" || true)
+if [ -z "$BUCKET_CHECK" ]; then
+    pass_fail "S3 buckets destroyed" 0
+else
+    echo "$BUCKET_CHECK"
+    pass_fail "S3 buckets destroyed" 1
+fi
+
+# Step 1.3: Verify VPC gone
+info "--- Step 1.3: Verifying VPC is destroyed ---"
+show_cmd "aws ec2 describe-vpcs --filters \"Name=tag:Project,Values=$PROJECT_NAME\""
+VPC_CHECK=$(aws ec2 describe-vpcs --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'Vpcs[*].VpcId' --output text 2>/dev/null || true)
+if [ -z "$VPC_CHECK" ]; then
+    pass_fail "VPC destroyed" 0
+else
+    pass_fail "VPC destroyed" 1
+fi
+
+# Step 1.4: Verify IAM role gone
+info "--- Step 1.4: Verifying IAM role is destroyed ---"
+show_cmd "aws iam get-role --role-name ${PROJECT_NAME}-eval-role"
+ROLE_CHECK=$(aws iam get-role --role-name "${PROJECT_NAME}-eval-role" 2>&1 || true)
+if echo "$ROLE_CHECK" | grep -q "NoSuchEntity\|cannot be found"; then
+    pass_fail "IAM role destroyed" 0
+else
+    pass_fail "IAM role destroyed" 1
+fi
+
+# Step 1.5: Verify launch template gone
+info "--- Step 1.5: Verifying launch template is destroyed ---"
+show_cmd "aws ec2 describe-launch-templates --filters \"Name=tag:Project,Values=$PROJECT_NAME\""
+LT_CHECK=$(aws ec2 describe-launch-templates --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'LaunchTemplates[*].LaunchTemplateId' --output text 2>/dev/null || true)
+if [ -z "$LT_CHECK" ]; then
+    pass_fail "Launch template destroyed" 0
+else
+    pass_fail "Launch template destroyed" 1
+fi
+
+# Step 1.6: Verify SSM parameters gone
+info "--- Step 1.6: Verifying SSM parameters are destroyed ---"
+show_cmd "aws ssm describe-parameters --parameter-filters \"Name=BeginsWith,Values=/${PROJECT_NAME}/\""
+SSM_CHECK=$(aws ssm describe-parameters --region "$AWS_REGION" \
+    --parameter-filters "Key=Name,Option=BeginsWith,Values=/${PROJECT_NAME}/" \
+    --query 'Parameters[*].Name' --output text 2>/dev/null || true)
+if [ -z "$SSM_CHECK" ]; then
+    pass_fail "SSM parameters destroyed" 0
+else
+    pass_fail "SSM parameters destroyed" 1
+fi
+
+printf "\n"
+destroy_msg "All infrastructure destroyed. State is empty."
+destroy_msg "Next phase will restore everything from IaC definitions."
+pause
+
+# ============================================================================
+# PHASE 2: RESTORATION -- Restoring Infrastructure from IaC
+# ============================================================================
+
+section_header "PHASE 2: RESTORATION -- Restoring Infrastructure from IaC" "$GREEN"
+
+# Infrastructure as Code allows us to recreate the entire environment
+# from the Terraform configuration files alone. The .tf files in
+# infra/eval/terraform/ define all 23 resources declaratively.
+#
+# terraform init  -- reinitialize providers
+# terraform apply -- recreate all resources from the .tf definitions
+#
+# No manual console configuration. No undocumented steps. Everything is in code.
+
+# Step 2.1: Terraform init
+restore_msg "--- Step 2.1: Reinitializing Terraform ---"
+cd "$TF_DIR"
+show_cmd "terraform init"
+terraform init
+printf "\n"
+
+# Step 2.2: Terraform apply
+restore_msg "--- Step 2.2: Restoring all infrastructure ---"
+restore_msg "Recreating all 23 resources from .tf definitions..."
+printf "\n"
+
+show_cmd "terraform apply -auto-approve"
+RESTORE_START=$(date +%s)
+terraform apply -auto-approve
+RESTORE_END=$(date +%s)
+RESTORE_DURATION=$((RESTORE_END - RESTORE_START))
+
+printf "\n"
+restore_msg "Restoration completed in ${RESTORE_DURATION} seconds."
+printf "\n"
+
+# Step 2.3: Show new state
+restore_msg "--- Step 2.3: New Terraform state ---"
+show_cmd "terraform state list"
+terraform state list
+NEW_RESOURCE_COUNT=$(terraform state list | wc -l | tr -d ' ')
+info "Total entries restored: $NEW_RESOURCE_COUNT"
+printf "\n"
+
+# Step 2.4: Show new outputs
+restore_msg "--- Step 2.4: New Terraform outputs ---"
+show_cmd "terraform output"
+terraform output
+printf "\n"
+
+# Step 2.5: Capture new resource IDs
+AFTER_VPC_ID=$(terraform output -raw vpc_id 2>/dev/null || echo "N/A")
+AFTER_SG_ID=$(terraform output -raw security_group_id 2>/dev/null || echo "N/A")
+AFTER_LT_ID=$(terraform output -raw launch_template_id 2>/dev/null || echo "N/A")
+AFTER_DATASETS_BUCKET=$(terraform output -raw datasets_bucket 2>/dev/null || echo "N/A")
+AFTER_RESULTS_BUCKET=$(terraform output -raw results_bucket 2>/dev/null || echo "N/A")
+AFTER_IAM_ROLE_ARN=$(aws iam get-role --role-name "${PROJECT_NAME}-eval-role" \
+    --query 'Role.Arn' --output text 2>/dev/null || echo "N/A")
+
+restore_msg "Infrastructure restored. Next phase will verify everything works."
+pause
+
+# ============================================================================
+# PHASE 3: VERIFICATION -- Proving the Restored Environment Works
+# ============================================================================
+
+section_header "PHASE 3: VERIFICATION -- Proving the Restored Environment Works" "$GREEN"
+
+# Step 3.1: Verify S3 buckets
+info "--- Step 3.1: Verifying S3 buckets recreated ---"
+show_cmd "aws s3 ls | grep $PROJECT_NAME"
+BUCKET_CHECK=$(aws s3 ls --region "$AWS_REGION" 2>/dev/null | grep "$PROJECT_NAME" || true)
+if [ -n "$BUCKET_CHECK" ]; then
+    echo "$BUCKET_CHECK"
+    pass_fail "S3 buckets restored" 0
+else
+    pass_fail "S3 buckets restored" 1
+fi
+printf "\n"
+
+# Step 3.2: Verify VPC
+info "--- Step 3.2: Verifying VPC recreated ---"
+show_cmd "aws ec2 describe-vpcs --filters \"Name=tag:Project,Values=$PROJECT_NAME\""
+aws ec2 describe-vpcs --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'Vpcs[*].{VpcId:VpcId,CidrBlock:CidrBlock,State:State}' \
+    --output table 2>/dev/null || true
+VPC_STATE=$(aws ec2 describe-vpcs --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'Vpcs[0].State' --output text 2>/dev/null || echo "")
+if [ "$VPC_STATE" = "available" ]; then
+    pass_fail "VPC restored and available" 0
+else
+    pass_fail "VPC restored and available" 1
+fi
+printf "\n"
+
+# Step 3.3: Verify IAM role and policies
+info "--- Step 3.3: Verifying IAM role and policies restored ---"
+show_cmd "aws iam get-role --role-name ${PROJECT_NAME}-eval-role"
+aws iam get-role --role-name "${PROJECT_NAME}-eval-role" \
+    --query 'Role.{RoleName:RoleName,Arn:Arn,CreateDate:CreateDate}' \
+    --output table 2>/dev/null
+ROLE_RC=$?
+pass_fail "IAM role restored" $ROLE_RC
+
+info "Inline policy:"
+show_cmd "aws iam list-role-policies --role-name ${PROJECT_NAME}-eval-role"
+aws iam list-role-policies --role-name "${PROJECT_NAME}-eval-role" \
+    --output table 2>/dev/null
+INLINE_RC=$?
+pass_fail "IAM inline policy restored" $INLINE_RC
+
+info "Managed policy (SSM):"
+show_cmd "aws iam list-attached-role-policies --role-name ${PROJECT_NAME}-eval-role"
+aws iam list-attached-role-policies --role-name "${PROJECT_NAME}-eval-role" \
+    --output table 2>/dev/null
+MANAGED_RC=$?
+pass_fail "SSM managed policy attached" $MANAGED_RC
+printf "\n"
+
+# Step 3.4: Verify launch template
+info "--- Step 3.4: Verifying launch template restored ---"
+show_cmd "aws ec2 describe-launch-templates --filters \"Name=tag:Project,Values=$PROJECT_NAME\""
+aws ec2 describe-launch-templates --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'LaunchTemplates[*].{Id:LaunchTemplateId,Name:LaunchTemplateName,Version:LatestVersionNumber}' \
+    --output table 2>/dev/null || true
+LT_EXISTS=$(aws ec2 describe-launch-templates --region "$AWS_REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_NAME" \
+    --query 'LaunchTemplates[0].LaunchTemplateId' --output text 2>/dev/null || echo "")
+if [ -n "$LT_EXISTS" ] && [ "$LT_EXISTS" != "None" ]; then
+    pass_fail "Launch template restored" 0
+else
+    pass_fail "Launch template restored" 1
+fi
+printf "\n"
+
+# Step 3.5: Verify SSM parameters
+info "--- Step 3.5: Verifying SSM parameters restored ---"
+show_cmd "aws ssm describe-parameters --parameter-filters \"Name=BeginsWith,Values=/${PROJECT_NAME}/\""
+aws ssm describe-parameters --region "$AWS_REGION" \
+    --parameter-filters "Key=Name,Option=BeginsWith,Values=/${PROJECT_NAME}/" \
+    --query 'Parameters[*].{Name:Name,Type:Type,Version:Version}' \
+    --output table 2>/dev/null || true
+SSM_COUNT=$(aws ssm describe-parameters --region "$AWS_REGION" \
+    --parameter-filters "Key=Name,Option=BeginsWith,Values=/${PROJECT_NAME}/" \
+    --query 'length(Parameters)' --output text 2>/dev/null || echo "0")
+if [ "$SSM_COUNT" -ge 2 ] 2>/dev/null; then
+    pass_fail "SSM parameters restored ($SSM_COUNT parameters)" 0
+else
+    pass_fail "SSM parameters restored" 1
+fi
+printf "\n"
+
+# Step 3.6: Verify security group rules
+info "--- Step 3.6: Verifying security group rules ---"
+if [ "$AFTER_SG_ID" != "N/A" ]; then
+    show_cmd "aws ec2 describe-security-groups --group-ids $AFTER_SG_ID"
+    aws ec2 describe-security-groups --region "$AWS_REGION" \
+        --group-ids "$AFTER_SG_ID" \
+        --query 'SecurityGroups[0].IpPermissions[*].{FromPort:FromPort,ToPort:ToPort,Protocol:IpProtocol,CIDR:IpRanges[0].CidrIp}' \
+        --output table 2>/dev/null || true
+    SSH_RULE=$(aws ec2 describe-security-groups --region "$AWS_REGION" \
+        --group-ids "$AFTER_SG_ID" \
+        --query 'SecurityGroups[0].IpPermissions[?FromPort==`22`].FromPort' \
+        --output text 2>/dev/null || echo "")
+    if [ "$SSH_RULE" = "22" ]; then
+        pass_fail "Security group SSH ingress rule restored" 0
+    else
+        pass_fail "Security group SSH ingress rule restored" 1
+    fi
+else
+    pass_fail "Security group SSH ingress rule restored" 1
+fi
+printf "\n"
+
+# Step 3.7: Push API keys to SSM from local .env
+info "--- Step 3.7: Restoring API keys to SSM from local .env ---"
+show_cmd "aws ssm put-parameter --name /${PROJECT_NAME}/GOOGLE_API_KEY --type SecureString --overwrite"
+show_cmd "aws ssm put-parameter --name /${PROJECT_NAME}/OPENAI_API_KEY --type SecureString --overwrite"
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    push_key_to_ssm() {
+        local key_name="$1"
+        local ssm_name="$2"
+        local value
+        value=$(grep "^${key_name}=" "$PROJECT_ROOT/.env" | head -1 | cut -d= -f2- || true)
+        if [ -z "$value" ] || [ "$value" = "PLACEHOLDER" ]; then
+            # Try GEMINI_API_KEY as fallback for GOOGLE_API_KEY
+            if [ "$key_name" = "GOOGLE_API_KEY" ]; then
+                value=$(grep "^GEMINI_API_KEY=" "$PROJECT_ROOT/.env" | head -1 | cut -d= -f2- || true)
+            fi
+        fi
+        if [ -z "$value" ] || [ "$value" = "PLACEHOLDER" ]; then
+            warn "SKIP: $key_name not set in .env"
+            return
+        fi
+        aws ssm put-parameter \
+            --name "$ssm_name" \
+            --value "$value" \
+            --type SecureString \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --output text > /dev/null 2>&1
+        info "Pushed $key_name -> $ssm_name"
+    }
+    push_key_to_ssm "GOOGLE_API_KEY" "/${PROJECT_NAME}/GOOGLE_API_KEY"
+    push_key_to_ssm "OPENAI_API_KEY" "/${PROJECT_NAME}/OPENAI_API_KEY"
+    pass_fail "API keys pushed to SSM" 0
+else
+    warn ".env file not found at $PROJECT_ROOT/.env -- skipping SSM key push"
+    pass_fail "API keys pushed to SSM (skipped -- no .env)" 0
+fi
+printf "\n"
+
+# Step 3.8: Re-upload sample data to restored bucket
+info "--- Step 3.8: Re-uploading sample dataset to restored S3 bucket ---"
+if [ "$AFTER_DATASETS_BUCKET" != "N/A" ]; then
+    show_cmd "aws s3 cp stress-tests/InteractionTasks_v8.json s3://${AFTER_DATASETS_BUCKET}/stress-tests/"
+    aws s3 cp "$PROJECT_ROOT/stress-tests/InteractionTasks_v8.json" \
+        "s3://${AFTER_DATASETS_BUCKET}/stress-tests/InteractionTasks_v8.json" \
+        --region "$AWS_REGION" --quiet 2>&1
+    DATA_CHECK=$(aws s3 ls "s3://${AFTER_DATASETS_BUCKET}/stress-tests/" \
+        --region "$AWS_REGION" 2>/dev/null || true)
+    if [ -n "$DATA_CHECK" ]; then
+        echo "$DATA_CHECK"
+        pass_fail "Dataset uploaded to restored bucket" 0
+    else
+        pass_fail "Dataset uploaded to restored bucket" 1
+    fi
+else
+    pass_fail "Dataset uploaded to restored bucket" 1
+fi
+printf "\n"
+
+# Step 3.9: End-to-end evaluation pipeline test
+info "--- Step 3.9: Running end-to-end evaluation pipeline (2 stress test tasks) ---"
+info "This proves the full pipeline works:"
+info "  data loading -> agent execution -> results collection -> S3 upload"
+printf "\n"
+
+cd "$PROJECT_ROOT"
+show_cmd "uv run infra/eval/pipelines/eval_benchmark.py --datasets stress_tests --max-tasks 2 --agent-types Agent --models gemini-2.5-flash --no-record-video --results-bucket \$RESULTS_BUCKET"
+EVAL_START=$(date +%s)
+
+# Run 2 stress test tasks with Gemini 2.5 Flash, no video for speed
+uv run infra/eval/pipelines/eval_benchmark.py \
+    --datasets stress_tests \
+    --max-tasks 2 \
+    --agent-types Agent \
+    --models gemini-2.5-flash \
+    --no-record-video \
+    --output-dir results/disaster-recovery-test \
+    --results-bucket "$AFTER_RESULTS_BUCKET" \
+    2>&1 || warn "Eval pipeline exited with non-zero status"
+
+EVAL_END=$(date +%s)
+EVAL_DURATION=$((EVAL_END - EVAL_START))
+info "Pipeline completed in ${EVAL_DURATION} seconds."
+printf "\n"
+
+# Verify local results
+info "Checking local results..."
+if ls results/disaster-recovery-test/*/results.csv 1>/dev/null 2>&1; then
+    ls -la results/disaster-recovery-test/*/results.csv
+    pass_fail "Local eval results generated" 0
+else
+    pass_fail "Local eval results generated" 1
+fi
+
+# Verify S3 upload
+info "Checking S3 results..."
+if [ "$AFTER_RESULTS_BUCKET" != "N/A" ]; then
+    S3_RESULTS=$(aws s3 ls "s3://${AFTER_RESULTS_BUCKET}/" \
+        --region "$AWS_REGION" --recursive 2>/dev/null | tail -5 || true)
+    if [ -n "$S3_RESULTS" ]; then
+        echo "$S3_RESULTS"
+        pass_fail "Results uploaded to restored S3 bucket" 0
+    else
+        pass_fail "Results uploaded to restored S3 bucket" 1
+    fi
+else
+    pass_fail "Results uploaded to restored S3 bucket" 1
+fi
+
+printf "\n"
+info "Verification complete."
+pause
+
+# ============================================================================
+# PHASE 4: SUMMARY -- Before vs After Comparison
+# ============================================================================
+
+section_header "PHASE 4: SUMMARY -- Before vs After Comparison" "$BLUE"
+
+# Step 4.1: Before/After resource ID comparison
+info "--- Resource ID Comparison ---"
+printf "\n"
+printf "${BOLD}%-25s %-35s %-35s${NC}\n" "Resource" "Before (Destroyed)" "After (Restored)"
+printf "%-25s %-35s %-35s\n" "-------------------------" "-----------------------------------" "-----------------------------------"
+printf "%-25s %-35s %-35s\n" "VPC ID" "$BEFORE_VPC_ID" "$AFTER_VPC_ID"
+printf "%-25s %-35s %-35s\n" "Security Group ID" "$BEFORE_SG_ID" "$AFTER_SG_ID"
+printf "%-25s %-35s %-35s\n" "Launch Template ID" "$BEFORE_LT_ID" "$AFTER_LT_ID"
+printf "%-25s %-35s %-35s\n" "Datasets Bucket" "$BEFORE_DATASETS_BUCKET" "$AFTER_DATASETS_BUCKET"
+printf "%-25s %-35s %-35s\n" "Results Bucket" "$BEFORE_RESULTS_BUCKET" "$AFTER_RESULTS_BUCKET"
+printf "%-25s %-35s %-35s\n" "IAM Role ARN" "$BEFORE_IAM_ROLE_ARN" "$AFTER_IAM_ROLE_ARN"
+printf "\n"
+
+info "New resource IDs were generated by AWS, but the configuration is identical."
+info "S3 bucket names remain the same (deterministic name with account ID)."
+info "IAM role ARN remains the same (deterministic role name)."
+printf "\n"
+
+# Step 4.2: All verification results
+info "--- Verification Results ---"
+printf "\n"
+for result in "${RESULTS[@]}"; do
+    echo -e "  $result"
+done
+printf "\n"
+printf "${BOLD}Total: ${GREEN}${PASS_COUNT} PASSED${NC} / ${RED}${FAIL_COUNT} FAILED${NC}\n"
+printf "\n"
+
+# Step 4.3: Timing summary
+SCRIPT_END=$(date +%s)
+TOTAL_DURATION=$((SCRIPT_END - SCRIPT_START))
+
+info "--- Timing Summary ---"
+printf "\n"
+printf "  Destruction:     %4d seconds\n" "$DESTROY_DURATION"
+printf "  Restoration:     %4d seconds\n" "$RESTORE_DURATION"
+printf "  Eval pipeline:   %4d seconds\n" "$EVAL_DURATION"
+printf "  Total script:    %4d seconds (%d min %d sec)\n" \
+    "$TOTAL_DURATION" $((TOTAL_DURATION / 60)) $((TOTAL_DURATION % 60))
+printf "\n"
+
+# Step 4.4: Rubric coverage checklist
+info "--- CSC490 A2 Part 5 -- Rubric Coverage ---"
+printf "\n"
+info "  [x] Data processing services / deployed applications"
+info "      S3 buckets, eval pipeline, EC2 launch template"
+info ""
+info "  [x] Database systems and their data"
+info "      S3 datasets bucket with versioning + AES256 encryption"
+info ""
+info "  [x] Configuration settings"
+info "      SSM parameters, Terraform variables, user_data.sh bootstrap"
+info ""
+info "  [x] Access controls and security settings"
+info "      IAM role/policy, security group rules, S3 public access blocks"
+info ""
+info "  [x] Verification of system functionality"
+info "      2-task stress test eval + S3 upload (end-to-end)"
+printf "\n"
+
+section_header "DISASTER RECOVERY DEMONSTRATION COMPLETE" "$GREEN"
+info "All infrastructure was destroyed and restored from IaC definitions."
+info "The evaluation pipeline runs successfully on the restored environment."


### PR DESCRIPTION
Automated shell script that demonstrates full destroy-and-restore cycle of the Terraform-managed AWS infrastructure (23 resources) with PASS/FAIL verification at each step and an end-to-end eval pipeline test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a disaster recovery demo script that fully destroys and restores our Terraform-managed AWS eval infrastructure and proves it works with a quick end-to-end eval run. This supports CSC490 A2 Part 5 by providing a reproducible, verifiable DR workflow.

- New Features
  - Preflight: lists Terraform state, captures key IDs, and verifies VPC/SG/IAM/SSM/S3/launch template.
  - Destroy: toggles S3 force-destroy for versioned buckets, runs terraform destroy, and checks resources are gone.
  - Restore: re-inits and applies Terraform, shows new outputs, and compares before/after IDs.
  - Verify: pushes API keys from .env to SSM, re-uploads sample dataset, runs a 2-task eval via uv, and validates local/S3 results with PASS/FAIL.
  - UX: colored logs, step pauses, and timing summary for destroy/restore/eval.

- Migration
  - Prereqs: AWS CLI logged in, Terraform >= 1.5, uv, and a .env with API keys at repo root.
  - Run: bash infra/eval/disaster_recovery_demo.sh from the repo root.
  - Warning: This deletes and recreates all 23 resources in ca-central-1; use only on the eval environment.

<sup>Written for commit 8b5bb0d5af0f87452935e33c02915a388518af0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a disaster recovery demonstration and validation script that automates infrastructure testing through inspection, destruction, restoration, and verification phases with resource validation and performance benchmarking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->