### PR TITLE
fix(test): replace file:// with local HTTP server in integration tests

### DIFF
--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -9,8 +9,9 @@ Requirements:
     - Tests are marked with @pytest.mark.integration and are skipped by default
     - Run with: pytest tests/test_mcp_integration.py -m integration
 
-These tests use a local HTML file served via file:// protocol to avoid
-network dependencies.
+These tests serve a local HTML file via a lightweight HTTP server to avoid
+file:// protocol issues with the browser security policy (which blocks URLs
+without hostnames).
 """
 
 import asyncio
@@ -21,7 +22,6 @@ import threading
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -101,14 +101,30 @@ TEST_HTML = """<!DOCTYPE html>
 
 
 @pytest.fixture(scope="module")
-def test_html_path():
-    """Create a temporary HTML file for testing."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
-        f.write(TEST_HTML)
-        f.flush()
-        yield Path(f.name)
+def test_html_server():
+    """Serve test HTML via a local HTTP server.
 
-    Path(f.name).unlink(missing_ok=True)
+    Uses HTTP instead of file:// because the browser security policy
+    blocks URLs without hostnames (file:// has no hostname).
+    """
+    # Write HTML to a temp directory
+    tmp_dir = tempfile.mkdtemp()
+    html_path = Path(tmp_dir) / "test.html"
+    html_path.write_text(TEST_HTML)
+
+    # Start a local HTTP server in a background thread
+    handler = partial(SimpleHTTPRequestHandler, directory=tmp_dir)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield f"http://127.0.0.1:{port}/test.html"
+
+    server.shutdown()
+    html_path.unlink(missing_ok=True)
+    Path(tmp_dir).rmdir()
 
 
 class DummyServer:
@@ -166,8 +182,12 @@ class DummyTypes:
 
 
 @pytest.fixture(scope="module")
-def mcp_server_with_browser(test_html_path, monkeypatch_module):
-    """Create an OpenBrowserServer with a real browser session."""
+def mcp_server_with_browser(test_html_server, monkeypatch_module):
+    """Create an OpenBrowserServer with a real browser session.
+
+    Yields (server, loop) so tests can run async methods on the same
+    event loop that owns the browser session.
+    """
     monkeypatch_module.setattr(mcp_server_module, "MCP_AVAILABLE", True)
     monkeypatch_module.setattr(mcp_server_module, "Server", DummyServer)
     monkeypatch_module.setattr(mcp_server_module, "types", DummyTypes)
@@ -180,17 +200,16 @@ def mcp_server_with_browser(test_html_path, monkeypatch_module):
         session = BrowserSession(browser_profile=profile)
         await session.start()
 
-        # Navigate to the test HTML file
-        file_url = f"file://{test_html_path}"
-        await session.navigate_to(file_url)
+        # Navigate to the test page served via local HTTP
+        await session.navigate_to(test_html_server)
 
         server.browser_session = session
         return server
 
     loop = asyncio.new_event_loop()
     try:
-        result = loop.run_until_complete(setup())
-        yield result
+        loop.run_until_complete(setup())
+        yield server, loop
     finally:
         async def teardown():
             if server.browser_session:
@@ -220,17 +239,20 @@ class TestIntegrationGetText:
 
     def test_extracts_page_title(self, mcp_server_with_browser):
         """Extracts page title from real HTML."""
-        result = asyncio.run(mcp_server_with_browser._get_text())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_text())
         assert "Integration Test Page" in result
 
     def test_extracts_paragraph_content(self, mcp_server_with_browser):
         """Extracts paragraph text from real HTML."""
-        result = asyncio.run(mcp_server_with_browser._get_text())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_text())
         assert "important text" in result
 
     def test_extracts_links_when_requested(self, mcp_server_with_browser):
         """Includes link URLs when extract_links=True."""
-        result = asyncio.run(mcp_server_with_browser._get_text(extract_links=True))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_text(extract_links=True))
         assert "/about" in result or "About Us" in result
 
 
@@ -239,19 +261,22 @@ class TestIntegrationGrep:
 
     def test_grep_finds_text(self, mcp_server_with_browser):
         """Finds matching text in real page content."""
-        result = asyncio.run(mcp_server_with_browser._grep("important"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._grep("important"))
         data = json.loads(result)
         assert data["total_matches"] >= 1
 
     def test_grep_finds_table_data(self, mcp_server_with_browser):
         """Finds table data via grep."""
-        result = asyncio.run(mcp_server_with_browser._grep("Alpha"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._grep("Alpha"))
         data = json.loads(result)
         assert data["total_matches"] >= 1
 
     def test_grep_no_matches(self, mcp_server_with_browser):
         """Returns zero matches for non-existent text."""
-        result = asyncio.run(mcp_server_with_browser._grep("zzz_nonexistent_xyz_123"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._grep("zzz_nonexistent_xyz_123"))
         data = json.loads(result)
         assert data["total_matches"] == 0
 
@@ -261,25 +286,29 @@ class TestIntegrationSearchElements:
 
     def test_search_links_by_tag(self, mcp_server_with_browser):
         """Finds link elements by tag name."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("a", by="tag"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("a", by="tag"))
         data = json.loads(result)
         assert data["count"] >= 3  # At least the 3 nav links
 
     def test_search_by_id(self, mcp_server_with_browser):
         """Finds element by ID."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("submit", by="id"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("submit", by="id"))
         data = json.loads(result)
         assert data["count"] >= 1
 
     def test_search_by_class(self, mcp_server_with_browser):
         """Finds elements by class name."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("nav-link", by="class"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("nav-link", by="class"))
         data = json.loads(result)
         assert data["count"] >= 3
 
     def test_search_input_by_text(self, mcp_server_with_browser):
         """Finds button by text content."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("Submit", by="text"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("Submit", by="text"))
         data = json.loads(result)
         assert data["count"] >= 1
 
@@ -289,14 +318,16 @@ class TestIntegrationGetState:
 
     def test_compact_state(self, mcp_server_with_browser):
         """Compact state returns URL and element count."""
-        result = asyncio.run(mcp_server_with_browser._get_browser_state(compact=True))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_browser_state(compact=True))
         data = json.loads(result)
-        assert "file://" in data["url"]
+        assert "127.0.0.1" in data["url"]
         assert data["interactive_element_count"] >= 4  # links + input + button
 
     def test_full_state(self, mcp_server_with_browser):
         """Full state includes element details."""
-        result = asyncio.run(mcp_server_with_browser._get_browser_state(compact=False))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_browser_state(compact=False))
         data = json.loads(result)
         assert "interactive_elements" in data
         assert len(data["interactive_elements"]) >= 4
@@ -307,26 +338,30 @@ class TestIntegrationExecuteJs:
 
     def test_evaluate_simple_expression(self, mcp_server_with_browser):
         """Evaluates a simple JavaScript expression."""
-        result = asyncio.run(mcp_server_with_browser._execute_js("2 + 2"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._execute_js("2 + 2"))
         data = json.loads(result)
         assert data["result"] == 4
 
     def test_get_document_title(self, mcp_server_with_browser):
         """Gets document title via JavaScript."""
-        result = asyncio.run(mcp_server_with_browser._execute_js("document.title"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._execute_js("document.title"))
         data = json.loads(result)
         assert data["result"] == "MCP Integration Test Page"
 
     def test_query_dom_elements(self, mcp_server_with_browser):
         """Queries DOM elements via JavaScript."""
-        result = asyncio.run(
-            mcp_server_with_browser._execute_js("document.querySelectorAll('a.nav-link').length")
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(
+            server._execute_js("document.querySelectorAll('a.nav-link').length")
         )
         data = json.loads(result)
         assert data["result"] == 3
 
     def test_extract_data_from_table(self, mcp_server_with_browser):
         """Extracts structured data from a table via JavaScript."""
+        server, loop = mcp_server_with_browser
         js = """
         (() => {
             const rows = document.querySelectorAll('#data-section tbody tr');
@@ -336,7 +371,7 @@ class TestIntegrationExecuteJs:
             });
         })()
         """
-        result = asyncio.run(mcp_server_with_browser._execute_js(js))
+        result = loop.run_until_complete(server._execute_js(js))
         data = json.loads(result)
         assert len(data["result"]) == 3
         assert data["result"][0]["name"] == "Alpha"
@@ -348,13 +383,15 @@ class TestIntegrationAccessibilityTree:
 
     def test_returns_tree_structure(self, mcp_server_with_browser):
         """Returns a non-empty accessibility tree."""
-        result = asyncio.run(mcp_server_with_browser._get_accessibility_tree())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_accessibility_tree())
         data = json.loads(result)
         assert data["total_nodes"] > 0
 
     def test_tree_contains_page_elements(self, mcp_server_with_browser):
         """Tree contains expected page elements."""
-        result = asyncio.run(mcp_server_with_browser._get_accessibility_tree())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_accessibility_tree())
         # The tree should have nodes -- just verify it parsed successfully
         data = json.loads(result)
         assert "total_nodes" in data


### PR DESCRIPTION
## Summary

- Fix 18 integration test failures caused by `file://` URLs being blocked by the browser's `SecurityWatchdog`
- Replace `file://` protocol with a local HTTP server on `127.0.0.1` (OS-assigned port)
- Fix event loop deadlock: use fixture's event loop via `loop.run_until_complete()` instead of `asyncio.run()` which creates a separate loop

## Root cause

`SecurityWatchdog._is_url_allowed()` in `security_watchdog.py:187-189` rejects any URL where `urlparse(url).hostname` is `None`. Since `file://` URLs have no network hostname, all 18 integration tests fail with:
```
ValueError: Navigation to file:///... blocked by security policy
```

## Changes

| File | Change |
|------|--------|
| `tests/test_mcp_integration.py` | Replace `test_html_path` fixture (file://) with `test_html_server` fixture (HTTP server); yield `(server, loop)` tuple from `mcp_server_with_browser` fixture; update all 18 tests to use shared event loop; remove unused mock imports |

## Test plan
- [x] 87 unit tests pass
- [x] 18 integration tests pass (previously all 18 failed)
- [x] 105 total tests pass on the fix branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced file:// URLs in browser integration tests with a local HTTP server and fixed event loop usage to avoid deadlocks. This bypasses the SecurityWatchdog block and makes all 18 integration tests pass.

- **Bug Fixes**
  - Serve test HTML over HTTP on 127.0.0.1 (OS-assigned port) and navigate to that URL instead of file://.
  - Use the fixture’s event loop by yielding (server, loop) and call loop.run_until_complete(...) instead of asyncio.run().

<sup>Written for commit fa9b88e4149075e8964d988669629693b9876a2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure by migrating from local file access to HTTP server-based testing for better test execution and environment simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->