### PR TITLE
feat(mcp): add return_by_value, resource subscriptions, marketplace config, README docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,9 @@
+{
+  "name": "openbrowser-ai",
+  "plugins": [
+    {
+      "name": "openbrowser",
+      "path": "./plugin"
+    }
+  ]
+}

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,0 +1,76 @@
+# Installing OpenBrowser for Codex
+
+Browser automation skills for Codex via native skill discovery. Clone and symlink.
+
+## Prerequisites
+
+- Git
+- Chrome or Chromium installed
+- Python 3.12+ with [uv](https://docs.astral.sh/uv/)
+
+## Installation
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/billy-enrizky/openbrowser-ai.git ~/.codex/openbrowser
+   ```
+
+2. **Create the skills symlink:**
+   ```bash
+   mkdir -p ~/.agents/skills
+   ln -s ~/.codex/openbrowser/plugin/skills ~/.agents/skills/openbrowser
+   ```
+
+   **Windows (PowerShell):**
+   ```powershell
+   New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills"
+   cmd /c mklink /J "$env:USERPROFILE\.agents\skills\openbrowser" "$env:USERPROFILE\.codex\openbrowser\plugin\skills"
+   ```
+
+3. **Set up the MCP server** by adding to your project configuration:
+   ```json
+   {
+     "mcpServers": {
+       "openbrowser": {
+         "command": "uvx",
+         "args": ["openbrowser-ai[mcp]", "--mcp"]
+       }
+     }
+   }
+   ```
+
+4. **Restart Codex** to discover the skills.
+
+## Verify
+
+```bash
+ls -la ~/.agents/skills/openbrowser
+```
+
+You should see a symlink pointing to the openbrowser plugin skills directory.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `web-scraping` | Extract structured data from websites, handle pagination |
+| `form-filling` | Fill forms, login flows, multi-step wizards |
+| `e2e-testing` | Test web apps by simulating user interactions |
+| `page-analysis` | Analyze page content, structure, metadata |
+| `accessibility-audit` | Audit pages for WCAG compliance |
+
+## Updating
+
+```bash
+cd ~/.codex/openbrowser && git pull
+```
+
+Skills update instantly through the symlink.
+
+## Uninstalling
+
+```bash
+rm ~/.agents/skills/openbrowser
+```
+
+Optionally delete the clone: `rm -rf ~/.codex/openbrowser`

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,98 @@
+# Installing OpenBrowser for OpenCode
+
+## Prerequisites
+
+- [OpenCode.ai](https://opencode.ai) installed
+- Git installed
+- Chrome or Chromium installed
+- Python 3.12+ with [uv](https://docs.astral.sh/uv/)
+
+## Installation
+
+### macOS / Linux
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/billy-enrizky/openbrowser-ai.git ~/.config/opencode/openbrowser
+
+# 2. Create directories
+mkdir -p ~/.config/opencode/plugins ~/.config/opencode/skills
+
+# 3. Create plugin symlink
+ln -s ~/.config/opencode/openbrowser/.opencode/plugins/openbrowser.js ~/.config/opencode/plugins/openbrowser.js
+
+# 4. Create skills symlink
+ln -s ~/.config/opencode/openbrowser/plugin/skills ~/.config/opencode/skills/openbrowser
+
+# 5. Restart OpenCode
+```
+
+### Windows (PowerShell)
+
+Run as Administrator or with Developer Mode enabled:
+
+```powershell
+# 1. Clone the repository
+git clone https://github.com/billy-enrizky/openbrowser-ai.git "$env:USERPROFILE\.config\opencode\openbrowser"
+
+# 2. Create directories
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\plugins"
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\skills"
+
+# 3. Create plugin symlink
+New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\opencode\plugins\openbrowser.js" -Target "$env:USERPROFILE\.config\opencode\openbrowser\.opencode\plugins\openbrowser.js"
+
+# 4. Create skills junction
+cmd /c mklink /J "$env:USERPROFILE\.config\opencode\skills\openbrowser" "$env:USERPROFILE\.config\opencode\openbrowser\plugin\skills"
+
+# 5. Restart OpenCode
+```
+
+## Verify
+
+```bash
+ls -l ~/.config/opencode/plugins/openbrowser.js
+ls -l ~/.config/opencode/skills/openbrowser
+```
+
+Both should show symlinks pointing to the openbrowser directories.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `web-scraping` | Extract structured data from websites, handle pagination |
+| `form-filling` | Fill forms, login flows, multi-step wizards |
+| `e2e-testing` | Test web apps by simulating user interactions |
+| `page-analysis` | Analyze page content, structure, metadata |
+| `accessibility-audit` | Audit pages for WCAG compliance |
+
+## Usage
+
+Skills are discovered automatically. Load a specific skill:
+
+```
+use skill tool to load openbrowser/web-scraping
+```
+
+### Tool Mapping
+
+When skills reference Claude Code tools, substitute OpenCode equivalents:
+- `Read`, `Write`, `Edit`, `Bash` -- use your native tools
+- `Task` with subagents -- use OpenCode's subagent system
+- `Skill` tool -- use OpenCode's native `skill` tool
+
+## Updating
+
+```bash
+cd ~/.config/opencode/openbrowser && git pull
+```
+
+## Uninstalling
+
+```bash
+rm ~/.config/opencode/plugins/openbrowser.js
+rm -rf ~/.config/opencode/skills/openbrowser
+```
+
+Optionally delete the clone: `rm -rf ~/.config/opencode/openbrowser`

--- a/.opencode/plugins/openbrowser.js
+++ b/.opencode/plugins/openbrowser.js
@@ -1,0 +1,87 @@
+/**
+ * OpenBrowser plugin for OpenCode.ai
+ *
+ * Injects MCP server configuration context via system prompt transform.
+ * Skills are discovered via OpenCode's native skill tool from symlinked directory.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const normalizePath = (p, homeDir) => {
+  if (!p || typeof p !== 'string') return null;
+  let normalized = p.trim();
+  if (!normalized) return null;
+  if (normalized.startsWith('~/')) {
+    normalized = path.join(homeDir, normalized.slice(2));
+  } else if (normalized === '~') {
+    normalized = homeDir;
+  }
+  return path.resolve(normalized);
+};
+
+export const OpenBrowserPlugin = async ({ client, directory }) => {
+  const homeDir = os.homedir();
+  const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
+  const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
+  const skillsDir = path.join(configDir, 'skills/openbrowser');
+
+  const getBootstrapContent = () => {
+    const skills = [];
+    if (fs.existsSync(skillsDir)) {
+      try {
+        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+          if (entry.isDirectory()) {
+            const skillPath = path.join(skillsDir, entry.name, 'SKILL.md');
+            if (fs.existsSync(skillPath)) {
+              skills.push(entry.name);
+            }
+          }
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+
+    const skillList = skills.length > 0
+      ? `Available OpenBrowser skills: ${skills.join(', ')}`
+      : 'No OpenBrowser skills found in skills directory.';
+
+    return `<openbrowser-context>
+You have access to OpenBrowser -- AI-powered browser automation tools via MCP.
+
+The OpenBrowser MCP server provides browser control tools: browser_navigate, browser_click,
+browser_type, browser_get_state, browser_get_text, browser_grep, browser_search_elements,
+browser_find_and_scroll, browser_get_accessibility_tree, browser_execute_js, browser_scroll,
+browser_go_back, browser_list_tabs, browser_switch_tab, browser_close_tab,
+browser_list_sessions, browser_close_session, browser_close_all.
+
+${skillList}
+
+Use OpenCode's native skill tool to load OpenBrowser skills when relevant:
+  skill load openbrowser/web-scraping
+  skill load openbrowser/form-filling
+  skill load openbrowser/e2e-testing
+  skill load openbrowser/page-analysis
+  skill load openbrowser/accessibility-audit
+
+**Tool Mapping:**
+- Read, Write, Edit, Bash -- use your native tools
+- Task with subagents -- use OpenCode's subagent system
+- Skill tool -- use OpenCode's native skill tool
+</openbrowser-context>`;
+  };
+
+  return {
+    'experimental.chat.system.transform': async (_input, output) => {
+      const bootstrap = getBootstrapContent();
+      if (bootstrap) {
+        (output.system ||= []).push(bootstrap);
+      }
+    }
+  };
+};

--- a/README.md
+++ b/README.md
@@ -187,33 +187,128 @@ profile = BrowserProfile(
 | **OCI** | `ChatOCIRaw` | Oracle Cloud GenAI models |
 | **Browser-Use** | `ChatBrowserUse` | External LLM service |
 
-## MCP Server (Claude Desktop Integration)
+## MCP Server
 
-OpenBrowser includes an MCP server for integration with Claude Desktop.
+OpenBrowser includes an MCP (Model Context Protocol) server that exposes browser automation as tools for AI assistants like Claude. No external LLM API keys required -- the MCP client (Claude) provides the intelligence.
 
-### Running the MCP Server
+### Quick Setup
 
-```bash
-python -m openbrowser.mcp
-```
-
-### Claude Desktop Configuration
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**Claude Code** -- add to your project's `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "openbrowser": {
       "command": "uvx",
-      "args": ["openbrowser-ai", "mcp"],
+      "args": ["openbrowser-ai[mcp]", "--mcp"]
+    }
+  }
+}
+```
+
+**Claude Desktop** -- add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "openbrowser": {
+      "command": "uvx",
+      "args": ["openbrowser-ai[mcp]", "--mcp"],
       "env": {
-        "GOOGLE_API_KEY": "..."
+        "OPENBROWSER_HEADLESS": "true"
       }
     }
   }
 }
 ```
+
+**Run directly:**
+
+```bash
+uvx openbrowser-ai[mcp] --mcp
+```
+
+### Tools (18)
+
+#### Navigation
+
+| Tool | Description |
+|------|-------------|
+| `browser_navigate` | Navigate to a URL, optionally in a new tab |
+| `browser_go_back` | Go back to the previous page |
+| `browser_scroll` | Scroll the page up or down |
+
+#### Interaction
+
+| Tool | Description |
+|------|-------------|
+| `browser_click` | Click an element by its index |
+| `browser_type` | Type text into an input field |
+
+#### Content Extraction
+
+| Tool | Description |
+|------|-------------|
+| `browser_get_state` | Get page metadata and interactive elements (compact or full) |
+| `browser_get_text` | Get page content as clean markdown |
+| `browser_grep` | Search page text with regex or string patterns |
+
+#### DOM Inspection
+
+| Tool | Description |
+|------|-------------|
+| `browser_search_elements` | Search elements by text, tag, id, class, or attribute |
+| `browser_find_and_scroll` | Find text on page and scroll to it |
+| `browser_get_accessibility_tree` | Get page a11y tree (tree or flat format, depth limit) |
+| `browser_execute_js` | Execute JavaScript in page context (await/fire-and-forget, by-value/by-reference) |
+
+#### Tab Management
+
+| Tool | Description |
+|------|-------------|
+| `browser_list_tabs` | List all open tabs |
+| `browser_switch_tab` | Switch to a tab by ID |
+| `browser_close_tab` | Close a tab by ID |
+
+#### Session Management
+
+| Tool | Description |
+|------|-------------|
+| `browser_list_sessions` | List active browser sessions |
+| `browser_close_session` | Close a specific session |
+| `browser_close_all` | Close all browser sessions |
+
+### MCP Resources
+
+| URI | Type | Description |
+|-----|------|-------------|
+| `browser://current-page/content` | text/markdown | Current page as markdown |
+| `browser://current-page/state` | application/json | Interactive elements and metadata |
+| `browser://current-page/accessibility` | application/json | Accessibility tree |
+| `browser://sessions/{id}/content` | text/markdown | Specific session page content |
+| `browser://sessions/{id}/state` | application/json | Specific session state |
+| `browser://sessions/{id}/accessibility` | application/json | Specific session a11y tree |
+
+### Claude Code Plugin
+
+OpenBrowser is available as a Claude Code plugin with 5 built-in skills:
+
+| Skill | Description |
+|-------|-------------|
+| `web-scraping` | Extract structured data, handle pagination |
+| `form-filling` | Fill forms, login flows, multi-step wizards |
+| `e2e-testing` | Test web apps by simulating user interactions |
+| `page-analysis` | Analyze page content, structure, metadata |
+| `accessibility-audit` | Audit pages for WCAG compliance |
+
+See [plugin/README.md](plugin/README.md) for installation and detailed tool parameter documentation.
+
+### Configuration
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `OPENBROWSER_HEADLESS` | Run browser without GUI | `false` |
+| `OPENBROWSER_ALLOWED_DOMAINS` | Comma-separated domain whitelist | (none) |
 
 ## CLI Usage
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ OpenBrowser is a framework for intelligent browser automation. It combines direc
 - [Configuration](#configuration)
 - [Supported LLM Providers](#supported-llm-providers)
 - [Claude Code Plugin](#claude-code-plugin)
+- [Codex](#codex)
+- [OpenCode](#opencode)
+- [OpenClaw](#openclaw)
 - [MCP Server](#mcp-server)
 - [CLI Usage](#cli-usage)
 - [Project Structure](#project-structure)
@@ -218,6 +221,90 @@ OpenBrowser is available as a Claude Code plugin with 5 built-in skills:
 
 See [plugin/README.md](plugin/README.md) for installation and detailed tool parameter documentation.
 
+## Codex
+
+OpenBrowser works with OpenAI Codex via native skill discovery.
+
+### Quick Install
+
+Tell Codex:
+
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/billy-enrizky/openbrowser-ai/refs/heads/main/.codex/INSTALL.md
+```
+
+### Manual Install
+
+```bash
+# Clone the repository
+git clone https://github.com/billy-enrizky/openbrowser-ai.git ~/.codex/openbrowser
+
+# Symlink skills for native discovery
+mkdir -p ~/.agents/skills
+ln -s ~/.codex/openbrowser/plugin/skills ~/.agents/skills/openbrowser
+
+# Restart Codex
+```
+
+Then configure the MCP server in your project (see [MCP Server](#mcp-server) below).
+
+Detailed docs: [.codex/INSTALL.md](.codex/INSTALL.md)
+
+## OpenCode
+
+OpenBrowser works with [OpenCode.ai](https://opencode.ai) via plugin and skill symlinks.
+
+### Quick Install
+
+Tell OpenCode:
+
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/billy-enrizky/openbrowser-ai/refs/heads/main/.opencode/INSTALL.md
+```
+
+### Manual Install
+
+```bash
+# Clone the repository
+git clone https://github.com/billy-enrizky/openbrowser-ai.git ~/.config/opencode/openbrowser
+
+# Create directories
+mkdir -p ~/.config/opencode/plugins ~/.config/opencode/skills
+
+# Symlink plugin and skills
+ln -s ~/.config/opencode/openbrowser/.opencode/plugins/openbrowser.js ~/.config/opencode/plugins/openbrowser.js
+ln -s ~/.config/opencode/openbrowser/plugin/skills ~/.config/opencode/skills/openbrowser
+
+# Restart OpenCode
+```
+
+Then configure the MCP server in your project (see [MCP Server](#mcp-server) below).
+
+Detailed docs: [.opencode/INSTALL.md](.opencode/INSTALL.md)
+
+## OpenClaw
+
+OpenBrowser works with [OpenClaw](https://openclaw.ai) via its plugin system.
+
+### Install via Plugin Registry
+
+```bash
+openclaw plugin install openbrowser
+```
+
+### Manual Install
+
+Clone the repository and register the plugin:
+
+```bash
+git clone https://github.com/billy-enrizky/openbrowser-ai.git
+openclaw plugin add ./openbrowser-ai/plugin
+```
+
+Then configure the MCP server in your project (see [MCP Server](#mcp-server) below).
+
+For OpenClaw plugin documentation, see [https://docs.openclaw.ai/tools/plugin](https://docs.openclaw.ai/tools/plugin).
+
 ## MCP Server
 
 OpenBrowser includes an MCP (Model Context Protocol) server that exposes browser automation as tools for AI assistants like Claude. No external LLM API keys required -- the MCP client (Claude) provides the intelligence.
@@ -344,31 +431,29 @@ uvx openbrowser mcp
 
 ```
 openbrowser-ai/
+├── .claude-plugin/            # Claude Code marketplace config
+├── .codex/                    # Codex integration
+│   └── INSTALL.md
+├── .opencode/                 # OpenCode integration
+│   ├── INSTALL.md
+│   └── plugins/openbrowser.js
+├── plugin/                    # Plugin package (skills + MCP config)
+│   ├── .claude-plugin/
+│   ├── .mcp.json
+│   └── skills/                # 5 browser automation skills
 ├── src/openbrowser/
-│   ├── __init__.py          # Main exports
-│   ├── cli.py                # CLI commands
-│   ├── config.py             # Configuration
-│   ├── actor/                # Element interaction
-│   ├── agent/                # LangGraph agent
-│   │   ├── graph.py          # Agent workflow
-│   │   ├── service.py        # Agent class
-│   │   └── views.py          # Data models
-│   ├── browser/              # CDP browser control
-│   │   ├── session.py        # BrowserSession
-│   │   └── profile.py        # BrowserProfile
-│   ├── code_use/             # Code agent
-│   ├── dom/                  # DOM extraction
-│   ├── llm/                  # LLM providers
-│   │   ├── openai/
-│   │   ├── anthropic/
-│   │   ├── google/
-│   │   ├── groq/
-│   │   ├── aws/
-│   │   ├── azure/
-│   │   └── ...
-│   ├── mcp/                  # MCP server
-│   └── tools/                # Action registry
-└── tests/                    # Test suite
+│   ├── __init__.py            # Main exports
+│   ├── cli.py                 # CLI commands
+│   ├── config.py              # Configuration
+│   ├── actor/                 # Element interaction
+│   ├── agent/                 # LangGraph agent
+│   ├── browser/               # CDP browser control
+│   ├── code_use/              # Code agent
+│   ├── dom/                   # DOM extraction
+│   ├── llm/                   # LLM providers
+│   ├── mcp/                   # MCP server
+│   └── tools/                 # Action registry
+└── tests/                     # Test suite
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ https://github.com/user-attachments/assets/632128f6-3d09-497f-9e7d-e29b9cb65e0f
 
 OpenBrowser is a framework for intelligent browser automation. It combines direct CDP communication with LangGraph orchestration to create AI agents that can navigate, interact with, and extract information from web pages autonomously.
 
+## Table of Contents
+
+- [Documentation](#documentation)
+- [Key Features](#key-features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Supported LLM Providers](#supported-llm-providers)
+- [Claude Code Plugin](#claude-code-plugin)
+- [MCP Server](#mcp-server)
+- [CLI Usage](#cli-usage)
+- [Project Structure](#project-structure)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contact](#contact)
+
 ## Documentation
 
 **Full documentation**: [https://docs.openbrowser.me](https://docs.openbrowser.me)
@@ -187,6 +204,20 @@ profile = BrowserProfile(
 | **OCI** | `ChatOCIRaw` | Oracle Cloud GenAI models |
 | **Browser-Use** | `ChatBrowserUse` | External LLM service |
 
+## Claude Code Plugin
+
+OpenBrowser is available as a Claude Code plugin with 5 built-in skills:
+
+| Skill | Description |
+|-------|-------------|
+| `web-scraping` | Extract structured data, handle pagination |
+| `form-filling` | Fill forms, login flows, multi-step wizards |
+| `e2e-testing` | Test web apps by simulating user interactions |
+| `page-analysis` | Analyze page content, structure, metadata |
+| `accessibility-audit` | Audit pages for WCAG compliance |
+
+See [plugin/README.md](plugin/README.md) for installation and detailed tool parameter documentation.
+
 ## MCP Server
 
 OpenBrowser includes an MCP (Model Context Protocol) server that exposes browser automation as tools for AI assistants like Claude. No external LLM API keys required -- the MCP client (Claude) provides the intelligence.
@@ -288,20 +319,6 @@ uvx openbrowser-ai[mcp] --mcp
 | `browser://sessions/{id}/content` | text/markdown | Specific session page content |
 | `browser://sessions/{id}/state` | application/json | Specific session state |
 | `browser://sessions/{id}/accessibility` | application/json | Specific session a11y tree |
-
-### Claude Code Plugin
-
-OpenBrowser is available as a Claude Code plugin with 5 built-in skills:
-
-| Skill | Description |
-|-------|-------------|
-| `web-scraping` | Extract structured data, handle pagination |
-| `form-filling` | Fill forms, login flows, multi-step wizards |
-| `e2e-testing` | Test web apps by simulating user interactions |
-| `page-analysis` | Analyze page content, structure, metadata |
-| `accessibility-audit` | Audit pages for WCAG compliance |
-
-See [plugin/README.md](plugin/README.md) for installation and detailed tool parameter documentation.
 
 ### Configuration
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -131,6 +131,20 @@ When a browser session is active, three MCP resources are available:
 | `browser://current-page/state` | application/json | Interactive elements and metadata |
 | `browser://current-page/accessibility` | application/json | Accessibility tree |
 
+## Skills
+
+The plugin includes 5 built-in skills that provide guided workflows for common browser automation tasks. Each skill is triggered automatically when the user's request matches its description.
+
+| Skill | Directory | Description |
+|-------|-----------|-------------|
+| `web-scraping` | `skills/web-scraping/` | Extract structured data from websites, handle pagination, and multi-tab scraping |
+| `form-filling` | `skills/form-filling/` | Fill out web forms, handle login/registration flows, and multi-step wizards |
+| `e2e-testing` | `skills/e2e-testing/` | Test web applications end-to-end by simulating user interactions and verifying outcomes |
+| `page-analysis` | `skills/page-analysis/` | Analyze page content, structure, metadata, and interactive elements |
+| `accessibility-audit` | `skills/accessibility-audit/` | Audit pages for WCAG compliance, heading structure, labels, alt text, ARIA, and landmarks |
+
+Each skill file (`SKILL.md`) contains YAML frontmatter with trigger conditions and a step-by-step workflow that references the MCP tools listed above.
+
 ## Troubleshooting
 
 **Browser does not launch**: Ensure Chrome or Chromium is installed and accessible from PATH.

--- a/plugin/skills/accessibility-audit/SKILL.md
+++ b/plugin/skills/accessibility-audit/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: accessibility-audit
+description: |
+  Audit web pages for accessibility issues, WCAG compliance, and screen reader compatibility.
+  Trigger when the user asks to: check accessibility, run an a11y audit, test WCAG compliance,
+  check screen reader support, audit ARIA attributes, verify keyboard navigation,
+  find accessibility issues, or check for missing alt text or labels.
+---
+
+# Accessibility Audit
+
+Audit web pages for accessibility issues following WCAG 2.1 guidelines. Checks heading structure, form labels, image alt text, ARIA attributes, color contrast indicators, and keyboard navigation.
+
+## Workflow
+
+### Step 1 -- Navigate to the page
+
+Open the page to audit:
+
+```
+browser_navigate(url="https://example.com")
+```
+
+Confirm the page loaded:
+
+```
+browser_get_state(compact=true)
+```
+
+### Step 2 -- Get the accessibility tree
+
+The accessibility tree is the primary data source for an a11y audit. It shows how assistive technologies interpret the page.
+
+```
+browser_get_accessibility_tree()
+```
+
+Review the tree for:
+- Missing roles on interactive elements
+- Empty or missing names on buttons and links
+- Incorrect heading hierarchy
+- Missing landmark regions (banner, navigation, main, contentinfo)
+
+### Step 3 -- Check heading structure
+
+Verify headings follow a logical hierarchy (h1 -> h2 -> h3, no skipped levels):
+
+```
+browser_execute_js(expression="(() => { const headings = Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6')); const issues = []; let prevLevel = 0; const h1Count = headings.filter(h => h.tagName === 'H1').length; if (h1Count === 0) issues.push('No h1 element found'); if (h1Count > 1) issues.push('Multiple h1 elements found: ' + h1Count); headings.forEach(h => { const level = parseInt(h.tagName[1]); if (prevLevel > 0 && level > prevLevel + 1) { issues.push('Skipped heading level: h' + prevLevel + ' -> h' + level + ' (\"' + h.textContent.trim().substring(0, 50) + '\")'); } if (!h.textContent.trim()) { issues.push('Empty heading: ' + h.tagName); } prevLevel = level; }); return { total: headings.length, h1Count, hierarchy: headings.map(h => ({ tag: h.tagName, text: h.textContent.trim().substring(0, 80) })), issues }; })()")
+```
+
+### Step 4 -- Check images for alt text
+
+Find images missing alt attributes or with empty alt text that should have descriptions:
+
+```
+browser_execute_js(expression="(() => { const images = Array.from(document.querySelectorAll('img')); const issues = []; const results = { total: images.length, withAlt: 0, withEmptyAlt: 0, missingAlt: 0, details: [] }; images.forEach(img => { const alt = img.getAttribute('alt'); const src = img.src?.substring(0, 100); if (alt === null) { results.missingAlt++; issues.push('Missing alt attribute: ' + src); results.details.push({ src, alt: null, issue: 'missing alt' }); } else if (alt === '') { results.withEmptyAlt++; results.details.push({ src, alt: '', issue: 'empty alt (decorative)' }); } else { results.withAlt++; } }); return { ...results, issues }; })()")
+```
+
+### Step 5 -- Check form labels
+
+Verify all form inputs have associated labels:
+
+```
+browser_execute_js(expression="(() => { const inputs = Array.from(document.querySelectorAll('input:not([type=\"hidden\"]),select,textarea')); const issues = []; inputs.forEach(input => { const id = input.id; const ariaLabel = input.getAttribute('aria-label'); const ariaLabelledBy = input.getAttribute('aria-labelledby'); const title = input.getAttribute('title'); const placeholder = input.getAttribute('placeholder'); const label = id ? document.querySelector('label[for=\"' + id + '\"]') : null; const parentLabel = input.closest('label'); const hasLabel = label || parentLabel || ariaLabel || ariaLabelledBy || title; if (!hasLabel) { issues.push({ tag: input.tagName, type: input.type || 'text', id: id || '(none)', name: input.name || '(none)', placeholder: placeholder || '(none)', issue: 'No label, aria-label, aria-labelledby, or title' }); } }); return { totalInputs: inputs.length, unlabeled: issues.length, issues }; })()")
+```
+
+### Step 6 -- Check ARIA attributes
+
+Verify ARIA attributes are used correctly:
+
+```
+browser_execute_js(expression="(() => { const issues = []; const ariaElements = document.querySelectorAll('[role],[aria-label],[aria-labelledby],[aria-describedby],[aria-hidden]'); const results = { totalAriaElements: ariaElements.length, issues: [] }; ariaElements.forEach(el => { const role = el.getAttribute('role'); const ariaLabel = el.getAttribute('aria-label'); const ariaLabelledBy = el.getAttribute('aria-labelledby'); const ariaDescribedBy = el.getAttribute('aria-describedby'); if (ariaLabelledBy) { const ids = ariaLabelledBy.split(/\\s+/); ids.forEach(id => { if (!document.getElementById(id)) { results.issues.push({ element: el.tagName, issue: 'aria-labelledby references missing id: ' + id }); } }); } if (ariaDescribedBy) { const ids = ariaDescribedBy.split(/\\s+/); ids.forEach(id => { if (!document.getElementById(id)) { results.issues.push({ element: el.tagName, issue: 'aria-describedby references missing id: ' + id }); } }); } if (role === 'button' && !ariaLabel && !el.textContent.trim()) { results.issues.push({ element: el.tagName, issue: 'Button role with no accessible name' }); } if (el.getAttribute('aria-hidden') === 'true' && el.querySelector('a,button,input,select,textarea,[tabindex]')) { results.issues.push({ element: el.tagName, issue: 'aria-hidden=true on element containing focusable children' }); } }); return results; })()")
+```
+
+### Step 7 -- Check landmark regions
+
+Verify the page has proper landmark structure:
+
+```
+browser_execute_js(expression="(() => { const landmarks = { banner: document.querySelectorAll('header,[role=\"banner\"]').length, navigation: document.querySelectorAll('nav,[role=\"navigation\"]').length, main: document.querySelectorAll('main,[role=\"main\"]').length, contentinfo: document.querySelectorAll('footer,[role=\"contentinfo\"]').length, complementary: document.querySelectorAll('aside,[role=\"complementary\"]').length, search: document.querySelectorAll('[role=\"search\"]').length }; const issues = []; if (landmarks.main === 0) issues.push('No main landmark found'); if (landmarks.main > 1) issues.push('Multiple main landmarks found: ' + landmarks.main); if (landmarks.banner === 0) issues.push('No banner/header landmark found'); if (landmarks.navigation === 0) issues.push('No navigation landmark found'); if (landmarks.contentinfo === 0) issues.push('No contentinfo/footer landmark found'); return { landmarks, issues }; })()")
+```
+
+### Step 8 -- Check link and button accessibility
+
+Verify links and buttons have descriptive text:
+
+```
+browser_execute_js(expression="(() => { const issues = []; const links = Array.from(document.querySelectorAll('a')); links.forEach(a => { const text = a.textContent.trim(); const ariaLabel = a.getAttribute('aria-label'); const title = a.getAttribute('title'); const img = a.querySelector('img[alt]'); const name = text || ariaLabel || title || img?.alt; if (!name) { issues.push({ tag: 'a', href: a.href?.substring(0, 80), issue: 'Link with no accessible name' }); } else if (['click here', 'here', 'read more', 'more', 'link'].includes(name.toLowerCase())) { issues.push({ tag: 'a', text: name, issue: 'Non-descriptive link text' }); } }); const buttons = Array.from(document.querySelectorAll('button,[role=\"button\"]')); buttons.forEach(btn => { const text = btn.textContent.trim(); const ariaLabel = btn.getAttribute('aria-label'); const title = btn.getAttribute('title'); if (!text && !ariaLabel && !title) { issues.push({ tag: btn.tagName, issue: 'Button with no accessible name' }); } }); return { totalLinks: links.length, totalButtons: buttons.length, issues }; })()")
+```
+
+### Step 9 -- Check tab order and keyboard access
+
+Verify interactive elements have a logical tab order:
+
+```
+browser_execute_js(expression="(() => { const focusable = Array.from(document.querySelectorAll('a[href],button,input:not([type=\"hidden\"]),select,textarea,[tabindex]')); const issues = []; const positiveTabindex = focusable.filter(el => { const ti = parseInt(el.getAttribute('tabindex')); return ti > 0; }); if (positiveTabindex.length > 0) { issues.push('Elements with positive tabindex (disrupts natural tab order): ' + positiveTabindex.length); positiveTabindex.forEach(el => { issues.push('  tabindex=' + el.getAttribute('tabindex') + ' on ' + el.tagName + (el.id ? '#' + el.id : '')); }); } const negativeTabindex = focusable.filter(el => { const ti = parseInt(el.getAttribute('tabindex')); return ti < 0 && ['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(el.tagName); }); if (negativeTabindex.length > 0) { issues.push('Interactive elements removed from tab order (tabindex=-1): ' + negativeTabindex.length); } return { totalFocusable: focusable.length, positiveTabindex: positiveTabindex.length, negativeTabindex: negativeTabindex.length, issues }; })()")
+```
+
+### Step 10 -- Compile the audit report
+
+Use `browser_get_text` to capture the full page content for reference:
+
+```
+browser_get_text()
+```
+
+Compile all findings from Steps 2-9 into a structured report with:
+- Summary of issues by severity (critical, serious, moderate, minor)
+- Specific elements and their issues
+- WCAG success criteria references where applicable
+- Recommended fixes for each issue
+
+### Step 11 -- Clean up
+
+Close the browser session:
+
+```
+browser_close_all()
+```
+
+## WCAG Quick Reference
+
+| Check | WCAG Criterion | Level |
+|-------|---------------|-------|
+| Images have alt text | 1.1.1 Non-text Content | A |
+| Heading hierarchy is logical | 1.3.1 Info and Relationships | A |
+| Form inputs have labels | 1.3.1 Info and Relationships | A |
+| Link purpose is clear | 2.4.4 Link Purpose (In Context) | A |
+| Page has landmark regions | 1.3.1 Info and Relationships | A |
+| Focus order is logical | 2.4.3 Focus Order | A |
+| ARIA attributes are valid | 4.1.2 Name, Role, Value | A |
+| Page has a single h1 | 1.3.1 Info and Relationships | A |
+| Interactive elements are keyboard accessible | 2.1.1 Keyboard | A |
+
+## Tips
+
+- Start with `browser_get_accessibility_tree` for a quick overview of how assistive technologies see the page.
+- The heading check (Step 3) catches the most common structural issues.
+- Missing form labels (Step 5) are the most common cause of form accessibility failures.
+- Run audits on multiple pages of a site, not just the homepage.
+- ARIA misuse is often worse than no ARIA at all; verify that ARIA attributes reference valid IDs and use correct roles.

--- a/plugin/skills/e2e-testing/SKILL.md
+++ b/plugin/skills/e2e-testing/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: e2e-testing
+description: |
+  Test web applications end-to-end by simulating user interactions and verifying expected outcomes.
+  Trigger when the user asks to: test a web app, verify a user flow, run end-to-end tests,
+  QA a feature, check that a page works correctly, validate user journeys, or test a deployment.
+---
+
+# End-to-End Testing
+
+Simulate real user interactions in a browser and verify that web applications behave correctly. Covers navigation, form interaction, content assertions, and multi-page flows.
+
+## Workflow
+
+### Step 1 -- Navigate to the application
+
+Open the application under test:
+
+```
+browser_navigate(url="https://staging.example.com")
+```
+
+Verify the page loaded correctly by checking title and URL:
+
+```
+browser_get_state(compact=true)
+```
+
+### Step 2 -- Define test assertions
+
+Before interacting, establish what success looks like. Use `browser_grep` to assert that expected content is present:
+
+```
+browser_grep(pattern="Welcome to Example App", case_insensitive=false)
+```
+
+Use `browser_search_elements` to assert that required UI elements exist:
+
+```
+browser_search_elements(query="Sign In", by="text")
+browser_search_elements(query="nav", by="tag")
+```
+
+Use `browser_execute_js` for precise assertions on DOM state:
+
+```
+browser_execute_js(expression="document.querySelector('h1')?.textContent?.trim()")
+browser_execute_js(expression="document.querySelectorAll('.error-message').length === 0")
+```
+
+### Step 3 -- Test user interactions
+
+Simulate a typical user flow. For example, a login flow:
+
+1. Find and fill the email field:
+   ```
+   browser_get_state(compact=false)
+   browser_type(index=<email_index>, text="test@example.com")
+   ```
+
+2. Fill the password field:
+   ```
+   browser_type(index=<password_index>, text="test-password")
+   ```
+
+3. Click the login button:
+   ```
+   browser_search_elements(query="Log In", by="text")
+   browser_click(index=<login_button_index>)
+   ```
+
+4. Assert the user is now logged in:
+   ```
+   browser_grep(pattern="Dashboard|Welcome back", case_insensitive=true)
+   ```
+
+### Step 4 -- Test navigation flows
+
+Verify that links and navigation work correctly:
+
+```
+browser_search_elements(query="Settings", by="text")
+browser_click(index=<settings_link_index>)
+browser_get_state(compact=true)
+```
+
+Assert the URL changed to the expected path:
+
+```
+browser_execute_js(expression="window.location.pathname")
+```
+
+Test the back button:
+
+```
+browser_go_back()
+browser_get_state(compact=true)
+```
+
+### Step 5 -- Test error states
+
+Verify that the application handles errors gracefully. For example, submit a form with invalid data:
+
+```
+browser_type(index=<email_index>, text="not-an-email")
+browser_click(index=<submit_index>)
+```
+
+Assert that validation errors appear:
+
+```
+browser_grep(pattern="valid email|invalid|required", case_insensitive=true)
+browser_search_elements(query="error", by="class")
+```
+
+Assert that the page did not navigate away:
+
+```
+browser_execute_js(expression="window.location.pathname")
+```
+
+### Step 6 -- Test responsive behavior
+
+Use `browser_execute_js` to check viewport-dependent behavior:
+
+```
+browser_execute_js(expression="window.innerWidth")
+```
+
+Check that mobile navigation elements exist or are hidden as expected:
+
+```
+browser_execute_js(expression="window.getComputedStyle(document.querySelector('.mobile-menu')).display")
+```
+
+### Step 7 -- Test across multiple pages
+
+For multi-page flows (e.g., checkout), open pages in sequence and verify state at each step:
+
+```
+browser_navigate(url="https://staging.example.com/cart")
+browser_grep(pattern="Your Cart", case_insensitive=false)
+browser_click(index=<checkout_button_index>)
+browser_grep(pattern="Shipping Address", case_insensitive=false)
+```
+
+Use `browser_execute_js` to verify application state (e.g., cart contents, session data):
+
+```
+browser_execute_js(expression="JSON.parse(localStorage.getItem('cart'))?.items?.length")
+```
+
+### Step 8 -- Report results
+
+After running all test steps, compile results. Use `browser_get_state` and `browser_grep` to collect final state. Summarize:
+
+- Which assertions passed
+- Which assertions failed (with details)
+- Screenshots or page content at failure points (use `browser_get_text` to capture page state)
+
+### Step 9 -- Clean up
+
+Close all browser sessions after testing:
+
+```
+browser_close_all()
+```
+
+## Tips
+
+- Always verify page state after each interaction before proceeding to the next step.
+- Use `browser_grep` for content assertions and `browser_execute_js` for DOM state assertions.
+- Test both happy paths and error paths for thorough coverage.
+- For flaky elements, use `browser_find_and_scroll` to ensure elements are in view before clicking.
+- Use `browser_list_tabs` to verify no unexpected popups or new tabs opened during testing.
+- Capture page content with `browser_get_text` at failure points for debugging.

--- a/plugin/skills/form-filling/SKILL.md
+++ b/plugin/skills/form-filling/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: form-filling
+description: |
+  Fill out web forms, submit data, and handle login or registration flows.
+  Trigger when the user asks to: fill a form, submit data on a website, log in to a site,
+  register an account, complete a checkout, enter information into fields, or automate form submission.
+---
+
+# Form Filling
+
+Automate filling web forms including login, registration, checkout, and multi-step form wizards.
+
+## Workflow
+
+### Step 1 -- Navigate to the form page
+
+Use `browser_navigate` to open the page containing the form.
+
+```
+browser_navigate(url="https://example.com/login")
+```
+
+### Step 2 -- Discover form fields
+
+Use `browser_get_state` with `compact=false` to get a full list of interactive elements on the page, including input fields, dropdowns, checkboxes, and buttons.
+
+```
+browser_get_state(compact=false)
+```
+
+This returns each element with an index number, tag type, and any label or placeholder text.
+
+For complex forms, use `browser_search_elements` to find specific fields:
+
+```
+browser_search_elements(query="input", by="tag")
+browser_search_elements(query="email", by="text")
+browser_search_elements(query="password", by="attribute")
+```
+
+### Step 3 -- Fill text inputs
+
+Use `browser_type` with the element index from Step 2 to enter text into each field.
+
+```
+browser_type(index=<email_field_index>, text="user@example.com")
+browser_type(index=<password_field_index>, text="secure-password")
+```
+
+For fields that need to be cleared before typing, click the field first, select all, then type:
+
+```
+browser_click(index=<field_index>)
+browser_execute_js(expression="document.activeElement.select()")
+browser_type(index=<field_index>, text="new value")
+```
+
+### Step 4 -- Handle dropdowns and select elements
+
+For standard HTML `<select>` elements, use `browser_click` to open the dropdown, then click the desired option:
+
+```
+browser_click(index=<select_index>)
+browser_search_elements(query="Option Text", by="text")
+browser_click(index=<option_index>)
+```
+
+For custom dropdown components, use `browser_execute_js`:
+
+```
+browser_execute_js(expression="document.querySelector('select#country').value = 'US'; document.querySelector('select#country').dispatchEvent(new Event('change', { bubbles: true }))")
+```
+
+### Step 5 -- Handle checkboxes and radio buttons
+
+Click the checkbox or radio button element directly:
+
+```
+browser_click(index=<checkbox_index>)
+```
+
+Verify the state after clicking:
+
+```
+browser_execute_js(expression="document.querySelector('input[name=\"agree\"]').checked")
+```
+
+### Step 6 -- Submit the form
+
+Find and click the submit button:
+
+```
+browser_search_elements(query="Submit", by="text")
+browser_click(index=<submit_button_index>)
+```
+
+Alternatively, submit via JavaScript if the button is hard to locate:
+
+```
+browser_execute_js(expression="document.querySelector('form').submit()")
+```
+
+### Step 7 -- Verify submission
+
+After submission, verify the result by checking the page content:
+
+```
+browser_get_state(compact=true)
+```
+
+Check for success or error messages:
+
+```
+browser_grep(pattern="success|thank you|welcome", case_insensitive=true)
+browser_grep(pattern="error|invalid|failed", case_insensitive=true)
+```
+
+For redirects after login, verify the URL changed:
+
+```
+browser_get_state(compact=true)
+```
+
+### Step 8 -- Handle multi-step forms
+
+For form wizards with multiple pages:
+
+1. Fill fields on the current step (Steps 3-5).
+2. Click "Next" or "Continue":
+   ```
+   browser_search_elements(query="Next", by="text")
+   browser_click(index=<next_button_index>)
+   ```
+3. Wait for the next step to load, then call `browser_get_state(compact=false)` again to discover new fields.
+4. Repeat until all steps are complete, then submit on the final step.
+
+### Step 9 -- Clean up
+
+Close the browser session when done:
+
+```
+browser_close_all()
+```
+
+## Tips
+
+- Always use `browser_get_state(compact=false)` to discover fields before typing; do not guess element indices.
+- For sensitive data (passwords, tokens), confirm with the user before entering values.
+- Check for CAPTCHA or bot detection; notify the user if manual intervention is needed.
+- For forms with client-side validation, use `browser_grep` to check for validation error messages after each field.
+- Use `browser_execute_js` to bypass tricky custom components that do not respond to standard click/type interactions.

--- a/plugin/skills/page-analysis/SKILL.md
+++ b/plugin/skills/page-analysis/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: page-analysis
+description: |
+  Analyze web page content, structure, and layout to understand what a page contains and how it is organized.
+  Trigger when the user asks to: analyze a page, understand page structure, inspect a website,
+  summarize page content, examine page layout, review a web page, or describe what is on a page.
+---
+
+# Page Analysis
+
+Analyze and understand web page content, structure, and interactive elements. Produces a comprehensive breakdown of what is on the page and how it is organized.
+
+## Workflow
+
+### Step 1 -- Navigate to the page
+
+Open the target page:
+
+```
+browser_navigate(url="https://example.com")
+```
+
+Get a compact state overview to confirm the page loaded and see basic metadata:
+
+```
+browser_get_state(compact=true)
+```
+
+This returns the URL, page title, tab count, and total number of interactive elements.
+
+### Step 2 -- Get full page content
+
+Retrieve the page content as markdown for a human-readable overview:
+
+```
+browser_get_text()
+```
+
+This captures all visible text, headings, paragraphs, lists, and tables in a structured format.
+
+To include links for further analysis:
+
+```
+browser_get_text(extract_links=true)
+```
+
+### Step 3 -- Search for specific content
+
+Use `browser_grep` to find specific patterns or sections on the page:
+
+```
+browser_grep(pattern="pricing|plans|features", case_insensitive=true, context_lines=3)
+```
+
+Search for contact information:
+
+```
+browser_grep(pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", case_insensitive=true)
+browser_grep(pattern="\\+?\\d[\\d\\s()-]{7,}", case_insensitive=true)
+```
+
+Search for dates:
+
+```
+browser_grep(pattern="\\d{4}-\\d{2}-\\d{2}|\\w+ \\d{1,2},? \\d{4}", case_insensitive=true)
+```
+
+### Step 4 -- Analyze interactive elements
+
+Get the full list of interactive elements to understand what actions are available:
+
+```
+browser_get_state(compact=false)
+```
+
+Search for specific types of interactive elements:
+
+```
+browser_search_elements(query="button", by="tag")
+browser_search_elements(query="input", by="tag")
+browser_search_elements(query="a", by="tag", max_results=50)
+```
+
+### Step 5 -- Inspect page structure with the accessibility tree
+
+Get the accessibility tree for a semantic view of the page structure:
+
+```
+browser_get_accessibility_tree()
+```
+
+For a shallow overview of the top-level structure:
+
+```
+browser_get_accessibility_tree(max_depth=3)
+```
+
+This reveals the heading hierarchy, landmark regions (nav, main, footer), and ARIA roles.
+
+### Step 6 -- Analyze page metadata and technical details
+
+Use `browser_execute_js` to extract metadata not visible in the rendered content:
+
+```
+browser_execute_js(expression="(() => { const meta = {}; meta.title = document.title; meta.description = document.querySelector('meta[name=\"description\"]')?.content; meta.canonical = document.querySelector('link[rel=\"canonical\"]')?.href; meta.ogTitle = document.querySelector('meta[property=\"og:title\"]')?.content; meta.ogImage = document.querySelector('meta[property=\"og:image\"]')?.content; meta.lang = document.documentElement.lang; return meta; })()")
+```
+
+Check for common frameworks and technologies:
+
+```
+browser_execute_js(expression="(() => { const tech = []; if (window.__NEXT_DATA__) tech.push('Next.js'); if (window.__NUXT__) tech.push('Nuxt.js'); if (document.querySelector('[data-reactroot]') || document.querySelector('#__next')) tech.push('React'); if (document.querySelector('[ng-version]')) tech.push('Angular'); if (window.jQuery) tech.push('jQuery'); return tech; })()")
+```
+
+### Step 7 -- Analyze page layout sections
+
+Use `browser_find_and_scroll` to navigate to specific sections and analyze them:
+
+```
+browser_find_and_scroll(text="Footer")
+browser_get_text()
+```
+
+Check the page dimensions and scroll height:
+
+```
+browser_execute_js(expression="({ viewportWidth: window.innerWidth, viewportHeight: window.innerHeight, scrollHeight: document.body.scrollHeight, scrollWidth: document.body.scrollWidth })")
+```
+
+### Step 8 -- Count and categorize content
+
+Use JavaScript to generate a content summary:
+
+```
+browser_execute_js(expression="(() => { return { headings: document.querySelectorAll('h1,h2,h3,h4,h5,h6').length, paragraphs: document.querySelectorAll('p').length, images: document.querySelectorAll('img').length, links: document.querySelectorAll('a').length, forms: document.querySelectorAll('form').length, tables: document.querySelectorAll('table').length, lists: document.querySelectorAll('ul,ol').length, buttons: document.querySelectorAll('button,[role=\"button\"]').length, inputs: document.querySelectorAll('input,textarea,select').length }; })()")
+```
+
+## Tips
+
+- Start with `browser_get_text` for a quick content overview, then drill down with `browser_grep` for specifics.
+- Use `browser_get_accessibility_tree(max_depth=3)` for a high-level structural summary without overwhelming detail.
+- Use `browser_execute_js` to extract metadata, detect technologies, and gather statistics not available through text extraction.
+- Combine `browser_grep` with regex patterns to find structured data like emails, phone numbers, dates, and prices.
+- Use `browser_find_and_scroll` to navigate long pages section by section.

--- a/plugin/skills/web-scraping/SKILL.md
+++ b/plugin/skills/web-scraping/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: web-scraping
+description: |
+  Extract structured data from websites, scrape page content, and collect information across multiple pages.
+  Trigger when the user asks to: extract data from a website, scrape a page, collect information from URLs,
+  pull content from web pages, gather data across multiple pages, or download page content.
+---
+
+# Web Scraping
+
+Extract structured data from websites using browser automation. Handles JavaScript-rendered content, pagination, and multi-tab scraping.
+
+## Workflow
+
+### Step 1 -- Navigate to the target page
+
+Use `browser_navigate` to open the target URL.
+
+```
+browser_navigate(url="https://example.com/data")
+```
+
+If the page requires interaction before data is visible (e.g., accepting cookies or closing a modal), use `browser_get_state(compact=false)` to find the dismiss button, then `browser_click` to close it.
+
+### Step 2 -- Get a content overview
+
+Use `browser_get_text` to retrieve the full page content as clean markdown. This gives you a quick overview of the page structure and available data.
+
+```
+browser_get_text()
+```
+
+For pages with links you need to follow, add `extract_links=true` to include href URLs in the output.
+
+```
+browser_get_text(extract_links=true)
+```
+
+### Step 3 -- Search for specific data
+
+Use `browser_grep` to find targeted content on the page. Supports regex patterns for flexible matching.
+
+```
+browser_grep(pattern="Price:\\s*\\$[\\d.]+", case_insensitive=true)
+```
+
+Adjust `context_lines` to capture surrounding data:
+
+```
+browser_grep(pattern="product-name", context_lines=5, max_matches=50)
+```
+
+### Step 4 -- Extract structured elements
+
+Use `browser_search_elements` to find specific DOM elements by text, tag, class, or attribute.
+
+```
+browser_search_elements(query="product", by="class", max_results=50)
+```
+
+For more precise extraction, use `browser_execute_js` to run JavaScript that collects data into a structured format:
+
+```
+browser_execute_js(expression="(() => { const items = document.querySelectorAll('.product-card'); return Array.from(items).map(el => ({ name: el.querySelector('.title')?.textContent?.trim(), price: el.querySelector('.price')?.textContent?.trim(), url: el.querySelector('a')?.href })); })()")
+```
+
+### Step 5 -- Handle pagination
+
+Check for pagination controls using `browser_search_elements`:
+
+```
+browser_search_elements(query="Next", by="text")
+```
+
+Or search for pagination by class:
+
+```
+browser_search_elements(query="pagination", by="class")
+```
+
+Click the next page button using the element index returned:
+
+```
+browser_click(index=<next_button_index>)
+```
+
+After each page loads, repeat Steps 2-4 to extract data from the new page. Continue until no more pages are available.
+
+### Step 6 -- Multi-tab scraping
+
+For scraping data from multiple URLs, open each in a new tab:
+
+```
+browser_navigate(url="https://example.com/page-1", new_tab=true)
+browser_navigate(url="https://example.com/page-2", new_tab=true)
+```
+
+List open tabs to track progress:
+
+```
+browser_list_tabs()
+```
+
+Switch between tabs to extract data from each:
+
+```
+browser_switch_tab(tab_id="<tab_id>")
+browser_get_text()
+```
+
+Close tabs when done:
+
+```
+browser_close_tab(tab_id="<tab_id>")
+```
+
+### Step 7 -- Handle infinite scroll pages
+
+Some pages load content dynamically as you scroll. Use a scroll-and-collect loop:
+
+```
+browser_scroll(direction="down")
+browser_get_text()
+```
+
+Use `browser_grep` after each scroll to check if new content appeared, and `browser_execute_js` to detect when you have reached the bottom:
+
+```
+browser_execute_js(expression="window.innerHeight + window.scrollY >= document.body.scrollHeight")
+```
+
+### Step 8 -- Clean up
+
+Close the browser session when scraping is complete:
+
+```
+browser_close_all()
+```
+
+## Tips
+
+- Use `browser_get_text` for a quick content overview before targeted extraction.
+- Use `browser_grep` with regex for pattern-based data extraction (prices, dates, emails).
+- Use `browser_execute_js` when you need structured JSON output from complex DOM structures.
+- For large datasets, process pages incrementally rather than loading all tabs at once.
+- Check for rate limiting or bot detection; add reasonable delays between page loads if needed.

--- a/src/openbrowser/mcp/manifest.json
+++ b/src/openbrowser/mcp/manifest.json
@@ -86,11 +86,11 @@
     },
     {
       "name": "browser_get_accessibility_tree",
-      "description": "Get the page accessibility tree with roles, names, and properties for structure analysis and a11y testing"
+      "description": "Get the page accessibility tree. Supports format='tree' (nested, default) or 'flat' (array with parent_id). Use max_depth to limit depth. Returns total_nodes and total_nodes_in_page"
     },
     {
       "name": "browser_execute_js",
-      "description": "Execute JavaScript in the page context and return the result. Use for advanced interactions and data extraction"
+      "description": "Execute JavaScript in the page context and return the result. Set await_promise=false for fire-and-forget scripts"
     }
   ],
   "prompts": [

--- a/src/openbrowser/mcp/manifest.json
+++ b/src/openbrowser/mcp/manifest.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "browser_execute_js",
-      "description": "Execute JavaScript in the page context and return the result. Set await_promise=false for fire-and-forget scripts"
+      "description": "Execute JavaScript in the page context and return the result. Set await_promise=false for fire-and-forget scripts. Set return_by_value=false to get RemoteObject references for DOM elements"
     }
   ],
   "prompts": [

--- a/src/openbrowser/mcp/server.py
+++ b/src/openbrowser/mcp/server.py
@@ -1328,7 +1328,11 @@ class OpenBrowserServer:
 			self.active_sessions[session_id]['last_activity'] = time.time()
 
 	async def _read_session_resource(self, session_id: str, resource_type: str) -> str:
-		"""Read a resource from a specific session by temporarily swapping the active session."""
+		"""Read a resource from a specific session by temporarily swapping the active session.
+
+		NOTE: This session swap is safe because MCP stdio transport processes requests sequentially.
+		If switching to a concurrent transport (SSE, WebSocket), use a lock or pass the session directly.
+		"""
 		if session_id not in self.active_sessions:
 			return f'Session {session_id} not found'
 		session_data = self.active_sessions[session_id]
@@ -1458,7 +1462,7 @@ class OpenBrowserServer:
 			try:
 				await self._mcp_session.send_resource_updated(AnyUrl(uri_str))
 			except Exception:
-				pass
+				logger.debug('Failed to send resource notification for %s', uri_str, exc_info=True)
 
 	async def _start_cleanup_task(self) -> None:
 		"""Start the background cleanup task."""

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -148,6 +148,15 @@ class DummyServer:
     def call_tool(self):
         return lambda f: f
 
+    def list_resource_templates(self):
+        return lambda f: f
+
+    def subscribe_resource(self):
+        return lambda f: f
+
+    def unsubscribe_resource(self):
+        return lambda f: f
+
     def get_capabilities(self, **kwargs):
         return {}
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -9,8 +9,9 @@ Requirements:
     - Tests are marked with @pytest.mark.integration and are skipped by default
     - Run with: pytest tests/test_mcp_integration.py -m integration
 
-These tests use a local HTML file served via file:// protocol to avoid
-network dependencies.
+These tests serve a local HTML file via a lightweight HTTP server to avoid
+file:// protocol issues with the browser security policy (which blocks URLs
+without hostnames).
 """
 
 import asyncio
@@ -21,7 +22,6 @@ import threading
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -101,14 +101,30 @@ TEST_HTML = """<!DOCTYPE html>
 
 
 @pytest.fixture(scope="module")
-def test_html_path():
-    """Create a temporary HTML file for testing."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
-        f.write(TEST_HTML)
-        f.flush()
-        yield Path(f.name)
+def test_html_server():
+    """Serve test HTML via a local HTTP server.
 
-    Path(f.name).unlink(missing_ok=True)
+    Uses HTTP instead of file:// because the browser security policy
+    blocks URLs without hostnames (file:// has no hostname).
+    """
+    # Write HTML to a temp directory
+    tmp_dir = tempfile.mkdtemp()
+    html_path = Path(tmp_dir) / "test.html"
+    html_path.write_text(TEST_HTML)
+
+    # Start a local HTTP server in a background thread
+    handler = partial(SimpleHTTPRequestHandler, directory=tmp_dir)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield f"http://127.0.0.1:{port}/test.html"
+
+    server.shutdown()
+    html_path.unlink(missing_ok=True)
+    Path(tmp_dir).rmdir()
 
 
 class DummyServer:
@@ -166,8 +182,12 @@ class DummyTypes:
 
 
 @pytest.fixture(scope="module")
-def mcp_server_with_browser(test_html_path, monkeypatch_module):
-    """Create an OpenBrowserServer with a real browser session."""
+def mcp_server_with_browser(test_html_server, monkeypatch_module):
+    """Create an OpenBrowserServer with a real browser session.
+
+    Yields (server, loop) so tests can run async methods on the same
+    event loop that owns the browser session.
+    """
     monkeypatch_module.setattr(mcp_server_module, "MCP_AVAILABLE", True)
     monkeypatch_module.setattr(mcp_server_module, "Server", DummyServer)
     monkeypatch_module.setattr(mcp_server_module, "types", DummyTypes)
@@ -180,17 +200,16 @@ def mcp_server_with_browser(test_html_path, monkeypatch_module):
         session = BrowserSession(browser_profile=profile)
         await session.start()
 
-        # Navigate to the test HTML file
-        file_url = f"file://{test_html_path}"
-        await session.navigate_to(file_url)
+        # Navigate to the test page served via local HTTP
+        await session.navigate_to(test_html_server)
 
         server.browser_session = session
         return server
 
     loop = asyncio.new_event_loop()
     try:
-        result = loop.run_until_complete(setup())
-        yield result
+        loop.run_until_complete(setup())
+        yield server, loop
     finally:
         async def teardown():
             if server.browser_session:
@@ -220,17 +239,20 @@ class TestIntegrationGetText:
 
     def test_extracts_page_title(self, mcp_server_with_browser):
         """Extracts page title from real HTML."""
-        result = asyncio.run(mcp_server_with_browser._get_text())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_text())
         assert "Integration Test Page" in result
 
     def test_extracts_paragraph_content(self, mcp_server_with_browser):
         """Extracts paragraph text from real HTML."""
-        result = asyncio.run(mcp_server_with_browser._get_text())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_text())
         assert "important text" in result
 
     def test_extracts_links_when_requested(self, mcp_server_with_browser):
         """Includes link URLs when extract_links=True."""
-        result = asyncio.run(mcp_server_with_browser._get_text(extract_links=True))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_text(extract_links=True))
         assert "/about" in result or "About Us" in result
 
 
@@ -239,19 +261,22 @@ class TestIntegrationGrep:
 
     def test_grep_finds_text(self, mcp_server_with_browser):
         """Finds matching text in real page content."""
-        result = asyncio.run(mcp_server_with_browser._grep("important"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._grep("important"))
         data = json.loads(result)
         assert data["total_matches"] >= 1
 
     def test_grep_finds_table_data(self, mcp_server_with_browser):
         """Finds table data via grep."""
-        result = asyncio.run(mcp_server_with_browser._grep("Alpha"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._grep("Alpha"))
         data = json.loads(result)
         assert data["total_matches"] >= 1
 
     def test_grep_no_matches(self, mcp_server_with_browser):
         """Returns zero matches for non-existent text."""
-        result = asyncio.run(mcp_server_with_browser._grep("zzz_nonexistent_xyz_123"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._grep("zzz_nonexistent_xyz_123"))
         data = json.loads(result)
         assert data["total_matches"] == 0
 
@@ -261,25 +286,29 @@ class TestIntegrationSearchElements:
 
     def test_search_links_by_tag(self, mcp_server_with_browser):
         """Finds link elements by tag name."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("a", by="tag"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("a", by="tag"))
         data = json.loads(result)
         assert data["count"] >= 3  # At least the 3 nav links
 
     def test_search_by_id(self, mcp_server_with_browser):
         """Finds element by ID."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("submit", by="id"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("submit", by="id"))
         data = json.loads(result)
         assert data["count"] >= 1
 
     def test_search_by_class(self, mcp_server_with_browser):
         """Finds elements by class name."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("nav-link", by="class"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("nav-link", by="class"))
         data = json.loads(result)
         assert data["count"] >= 3
 
     def test_search_input_by_text(self, mcp_server_with_browser):
         """Finds button by text content."""
-        result = asyncio.run(mcp_server_with_browser._search_elements("Submit", by="text"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._search_elements("Submit", by="text"))
         data = json.loads(result)
         assert data["count"] >= 1
 
@@ -289,14 +318,16 @@ class TestIntegrationGetState:
 
     def test_compact_state(self, mcp_server_with_browser):
         """Compact state returns URL and element count."""
-        result = asyncio.run(mcp_server_with_browser._get_browser_state(compact=True))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_browser_state(compact=True))
         data = json.loads(result)
-        assert "file://" in data["url"]
+        assert "127.0.0.1" in data["url"]
         assert data["interactive_element_count"] >= 4  # links + input + button
 
     def test_full_state(self, mcp_server_with_browser):
         """Full state includes element details."""
-        result = asyncio.run(mcp_server_with_browser._get_browser_state(compact=False))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_browser_state(compact=False))
         data = json.loads(result)
         assert "interactive_elements" in data
         assert len(data["interactive_elements"]) >= 4
@@ -307,26 +338,30 @@ class TestIntegrationExecuteJs:
 
     def test_evaluate_simple_expression(self, mcp_server_with_browser):
         """Evaluates a simple JavaScript expression."""
-        result = asyncio.run(mcp_server_with_browser._execute_js("2 + 2"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._execute_js("2 + 2"))
         data = json.loads(result)
         assert data["result"] == 4
 
     def test_get_document_title(self, mcp_server_with_browser):
         """Gets document title via JavaScript."""
-        result = asyncio.run(mcp_server_with_browser._execute_js("document.title"))
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._execute_js("document.title"))
         data = json.loads(result)
         assert data["result"] == "MCP Integration Test Page"
 
     def test_query_dom_elements(self, mcp_server_with_browser):
         """Queries DOM elements via JavaScript."""
-        result = asyncio.run(
-            mcp_server_with_browser._execute_js("document.querySelectorAll('a.nav-link').length")
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(
+            server._execute_js("document.querySelectorAll('a.nav-link').length")
         )
         data = json.loads(result)
         assert data["result"] == 3
 
     def test_extract_data_from_table(self, mcp_server_with_browser):
         """Extracts structured data from a table via JavaScript."""
+        server, loop = mcp_server_with_browser
         js = """
         (() => {
             const rows = document.querySelectorAll('#data-section tbody tr');
@@ -336,7 +371,7 @@ class TestIntegrationExecuteJs:
             });
         })()
         """
-        result = asyncio.run(mcp_server_with_browser._execute_js(js))
+        result = loop.run_until_complete(server._execute_js(js))
         data = json.loads(result)
         assert len(data["result"]) == 3
         assert data["result"][0]["name"] == "Alpha"
@@ -348,13 +383,15 @@ class TestIntegrationAccessibilityTree:
 
     def test_returns_tree_structure(self, mcp_server_with_browser):
         """Returns a non-empty accessibility tree."""
-        result = asyncio.run(mcp_server_with_browser._get_accessibility_tree())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_accessibility_tree())
         data = json.loads(result)
         assert data["total_nodes"] > 0
 
     def test_tree_contains_page_elements(self, mcp_server_with_browser):
         """Tree contains expected page elements."""
-        result = asyncio.run(mcp_server_with_browser._get_accessibility_tree())
+        server, loop = mcp_server_with_browser
+        result = loop.run_until_complete(server._get_accessibility_tree())
         # The tree should have nodes -- just verify it parsed successfully
         data = json.loads(result)
         assert "total_nodes" in data

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -175,6 +175,10 @@ class DummyTypes:
         def __init__(self, **kwargs):
             pass
 
+    class ResourceTemplate:
+        def __init__(self, **kwargs):
+            pass
+
     class Prompt:
         pass
 


### PR DESCRIPTION
## Summary

Continuation of MCP server work from PR #44. Adds remaining features, comprehensive documentation, and marketplace distribution config.

- **return_by_value parameter** for `browser_execute_js`: When `false`, returns CDP RemoteObject reference (objectId, type, subtype, className) instead of serialized value, enabling DOM element queries
- **Resource subscriptions**: `subscribe_resource` and `unsubscribe_resource` MCP handlers that track subscribed URIs; notifications filtered to subscribed URIs only (all URIs when no subscriptions for backward compat)
- **Comprehensive README docs**: Replaced minimal MCP section with full documentation covering 18 tools, 6 MCP resources, 5 plugin skills, setup guides for Claude Code and Claude Desktop
- **Marketplace config**: `.claude-plugin/marketplace.json` at repo root for Claude Code plugin distribution

## Test plan

- [x] 111 unit tests pass (`uv run python -m pytest tests/test_mcp_server.py -v`)
- [x] Integration tests pass (`uv run python -m pytest tests/test_mcp_integration.py -v -m integration`)
- [x] Verify `return_by_value=false` returns RemoteObject fields (objectId, type, subtype, className)
- [x] Verify resource subscriptions filter notifications correctly
- [x] Verify README renders correctly on GitHub
- [x] Verify marketplace.json at repo root points to ./plugin

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes MCP server features and plugin distribution with new JS exec modes, resource subscriptions/notifications, session-scoped resources, and expanded docs; adds Codex and OpenCode integrations plus marketplace config.

- **New Features**
  - Execute JS: add return_by_value (RemoteObject refs when false) and await_promise (fire-and-forget when false).
  - Resources: add subscribe_resource/unsubscribe_resource; send resource-updated notifications; add session-scoped resources and templates (browser://sessions/{id}/content|state|accessibility).
  - Accessibility tree: add flat format (array with parent_id) and manifest docs for format/max_depth.
  - Integrations/docs: add Codex native skill discovery (.codex/INSTALL.md), OpenCode plugin and skills symlinks (.opencode/INSTALL.md, plugins/openbrowser.js), OpenClaw section, README expansions, and .claude-plugin/marketplace.json; keep 5 Claude Code skills (web-scraping, form-filling, e2e-testing, page-analysis, accessibility-audit).

- **Bug Fixes**
  - Accessibility tree counts total_nodes correctly with depth limits and exposes total_nodes_in_page.
  - Integration tests: serve pages via local HTTP and run on a shared event loop; add missing DummyServer and ResourceTemplate stubs to fix setup errors.

<sup>Written for commit bd296dd43ff47cfe81db7c5b1c4a7514aa0715b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code / marketplace plugin with five built-in skills: web-scraping, form-filling, e2e-testing, page-analysis, accessibility-audit
  * Session-scoped resource subscriptions via browser:// URIs with real-time notifications
  * Accessibility tree output: tree or flat formats, depth limits; JS execution supports await/return modes

* **Documentation**
  * Expanded README and plugin docs with tools catalog, quick-install flows, configuration, and per-skill guides
  * New installation guides for Codex/OpenCode/OpenClaw integrations

* **Tests**
  * Switched tests to an HTTP server flow and added coverage for subscriptions, notifications, accessibility formats, and JS execution options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->