### PR TITLE
fix(mcp): fix uvx import chain and close_tab about:blank

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ groq = ["groq>=0.30.0"]
 ollama = ["ollama>=0.5.1"]
 aws = ["boto3"]
 azure = ["openai"]
-mcp = ["mcp>=1.0.0"]
+mcp = ["mcp>=1.0.0", "posthog>=3.7.0"]
 telemetry = ["posthog>=3.7.0"]
 pdf = ["pypdf", "reportlab"]
 dev = [

--- a/src/openbrowser/mcp/__init__.py
+++ b/src/openbrowser/mcp/__init__.py
@@ -1,16 +1,24 @@
 """MCP (Model Context Protocol) support for openbrowser.
 
 This module provides integration with MCP servers and clients for browser automation.
+
+All imports are lazy to avoid pulling in heavy dependencies when only the MCP server
+is needed (e.g., ``python -m openbrowser.mcp`` or ``uvx openbrowser-ai[mcp] --mcp``).
 """
 
-from openbrowser.mcp.client import MCPClient
-from openbrowser.mcp.controller import MCPToolWrapper
-
-__all__ = ['MCPClient', 'MCPToolWrapper', 'OpenBrowserServer']  # type: ignore
+__all__ = ['MCPClient', 'MCPToolWrapper', 'OpenBrowserServer']
 
 
-def __getattr__(name):
-	"""Lazy import to avoid importing server module when only client is needed."""
+def __getattr__(name: str):
+	"""Lazy import to avoid pulling in heavy openbrowser dependencies for MCP server mode."""
+	if name == 'MCPClient':
+		from openbrowser.mcp.client import MCPClient
+
+		return MCPClient
+	if name == 'MCPToolWrapper':
+		from openbrowser.mcp.controller import MCPToolWrapper
+
+		return MCPToolWrapper
 	if name == 'OpenBrowserServer':
 		from openbrowser.mcp.server import OpenBrowserServer
 

--- a/uv.lock
+++ b/uv.lock
@@ -1603,6 +1603,7 @@ groq = [
 ]
 mcp = [
     { name = "mcp" },
+    { name = "posthog" },
 ]
 ollama = [
     { name = "ollama" },
@@ -1657,6 +1658,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "playwright" },
     { name = "posthog", marker = "extra == 'all'", specifier = ">=3.7.0" },
+    { name = "posthog", marker = "extra == 'mcp'", specifier = ">=3.7.0" },
     { name = "posthog", marker = "extra == 'telemetry'", specifier = ">=3.7.0" },
     { name = "psutil", specifier = ">=7.2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- Fix all import chain failures that prevented `uvx openbrowser-ai[mcp] --mcp` from working (3 separate root causes: eager __init__.py imports, cli.py module-level imports, sys.path shadowing pip mcp package)
- Add `posthog` to `[mcp]` extra so telemetry works out of the box
- Fix `_close_tab` auto-switching away from `about:blank` leftover tabs

## Test plan

- [x] 111 unit tests pass (`uv run python -m pytest tests/test_mcp_server.py -v`)
- [x] 18 integration tests pass (`uv run python -m pytest tests/test_mcp_integration.py -v -m integration`)
- [x] `uvx openbrowser-ai[mcp] --mcp` starts successfully with rebuilt wheel (no import errors)
- [x] E2E test of all 18 MCP tools via Claude Code: 18/18 PASS
- [x] Verify `openbrowser.mcp` package imports without pulling in heavy deps (anthropic, reportlab)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP mode startup by removing import-chain failures and heavy CLI imports, and improves tab closing to auto-switch away from about:blank. Telemetry works in MCP mode and remains optional.

- **Bug Fixes**
  - Make mcp/__init__.py imports lazy to avoid heavy deps and import errors.
  - Handle --mcp early in cli.py to bypass heavy module imports and run the MCP server directly.
  - Insert src/ into sys.path (not openbrowser/) to prevent shadowing the pip mcp package.
  - Guard telemetry with TELEMETRY_AVAILABLE; capture events only when available.
  - After closing a tab, auto-switch from about:blank to a non-blank tab when possible.

- **Dependencies**
  - Add posthog to the [mcp] extra to enable telemetry in MCP mode.

<sup>Written for commit 07bcc09aef749a366a26a702dacbff2378c9a838. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced MCP server startup with optional telemetry capture.
  * Improved tab management: automatically switches to non-blank tabs when closing.

* **Chores**
  * Added optional analytics dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->