### PR TITLE
docs: add MCP benchmark comparison (Playwright vs CDP vs OpenBrowser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ OpenBrowser is a framework for intelligent browser automation. It combines direc
 - [OpenCode](#opencode)
 - [OpenClaw](#openclaw)
 - [MCP Server](#mcp-server)
+- [MCP Benchmark: Why OpenBrowser](#mcp-benchmark-why-openbrowser)
 - [CLI Usage](#cli-usage)
 - [Project Structure](#project-structure)
 - [Testing](#testing)
@@ -359,7 +360,7 @@ OpenBrowser includes an MCP (Model Context Protocol) server that exposes browser
 uvx openbrowser-ai[mcp] --mcp
 ```
 
-### Tools (18)
+### Tools (11)
 
 #### Navigation
 
@@ -409,6 +410,38 @@ uvx openbrowser-ai[mcp] --mcp
 |---------------------|-------------|---------|
 | `OPENBROWSER_HEADLESS` | Run browser without GUI | `false` |
 | `OPENBROWSER_ALLOWED_DOMAINS` | Comma-separated domain whitelist | (none) |
+
+## MCP Benchmark: Why OpenBrowser
+
+Benchmark on identical 5-step workflow (navigate Wikipedia, get state, click, go back, get state). Real measurements via JSON-RPC stdio transport.
+
+### Token Usage (5-Step Workflow, Wikipedia)
+
+| MCP Server | Tools | Response Tokens | vs OpenBrowser |
+|------------|------:|----------------:|---------------:|
+| **Playwright MCP** (Microsoft) | 22 | 249,077 | 610x more |
+| **Chrome DevTools MCP** | 35+ | ~300,000 (est.) | ~735x more |
+| **OpenBrowser MCP** | 11 | **408** | baseline |
+
+### Cost per Workflow
+
+| Model | Playwright MCP | OpenBrowser MCP | Savings |
+|-------|---------------:|----------------:|--------:|
+| Claude Sonnet ($3/M) | $0.747 | $0.001 | 99.9% |
+| Claude Opus ($15/M) | $3.736 | $0.006 | 99.8% |
+| GPT-4o ($2.50/M) | $0.623 | $0.001 | 99.8% |
+
+### Per-Operation Comparison (Wikipedia, 327 Elements)
+
+| Operation | Playwright MCP | OpenBrowser MCP | Ratio |
+|-----------|---------------:|----------------:|------:|
+| Navigate | ~123,400 tokens | ~68 tokens | 1,815x |
+| Get page state | ~123,370 tokens | ~44 tokens | 2,804x |
+| Click element | ~1,027 tokens | ~23 tokens | 45x |
+
+**Why?** Playwright returns the full accessibility snapshot (~120K tokens) with every action. OpenBrowser returns minimal confirmations and lets the agent request only the detail level it needs.
+
+[Full comparison with methodology](https://docs.openbrowser.me/comparison)
 
 ## CLI Usage
 

--- a/docs/comparison.mdx
+++ b/docs/comparison.mdx
@@ -1,0 +1,166 @@
+---
+title: "MCP Server Comparison"
+description: "Benchmark comparison of OpenBrowser MCP vs Playwright MCP vs Chrome DevTools MCP"
+---
+
+# Browser MCP Server Comparison
+
+Benchmark date: 2026-02-18 | OpenBrowser MCP v0.1.17 | Playwright MCP v0.0.68
+
+## Overview
+
+Three approaches to browser automation via MCP, measured on identical tasks.
+
+| | Playwright MCP | Chrome DevTools MCP | OpenBrowser MCP |
+|---|---|---|---|
+| **Maintainer** | Microsoft | benjaminr | OpenBrowser |
+| **GitHub Stars** | 27,300+ | 283 | -- |
+| **Engine** | Playwright (Chromium/Firefox/WebKit) | Raw CDP (websockets) | Raw CDP (direct) |
+| **Tools** | 22 core (39 total) | 35+ | 11 |
+| **Approach** | A11y snapshot with every action | Raw DOM / CSS queries | Text-first, progressive disclosure |
+| **Element IDs** | `ref` from snapshot (`[ref=e25]`) | CSS selectors | Numeric index from state |
+| **Transport** | stdio | stdio | stdio |
+| **Language** | TypeScript (Node.js) | Python | Python |
+
+## Token Usage Benchmark
+
+### Methodology
+
+Both Playwright MCP and OpenBrowser MCP were started as subprocesses and tested via JSON-RPC stdio transport. Same 5-step workflow, same pages, same measurement method. Chrome DevTools MCP estimates are based on tool response pattern analysis (returns raw DOM/HTML, no compact mode).
+
+**Workflow**: Navigate to Wikipedia Python page (327 interactive elements) -> get page state -> click link -> go back -> get state again.
+
+### Results: 5-Step Workflow on Wikipedia (Complex Page)
+
+| Metric | Playwright MCP | Chrome DevTools MCP | OpenBrowser MCP |
+|--------|---------------|--------------------:|----------------:|
+| **Tool calls** | 9 | ~8 | 12 |
+| **Total response chars** | 996,308 | ~1,200,000 (est.) | 1,631 |
+| **Est. response tokens** | **249,077** | **~300,000** (est.) | **408** |
+| **Total latency** | 7.2s | ~8-10s (est.) | 0.1s* |
+| **Token ratio vs OpenBrowser** | 610x more | ~735x more (est.) | 1x (baseline) |
+
+\* Excludes 30s Chrome cold-start on first navigate. Subsequent operations: 2-34ms each.
+
+### Results: Small Page (httpbin.org/forms/post)
+
+| Operation | Playwright MCP | OpenBrowser MCP | Ratio |
+|-----------|---------------|----------------:|------:|
+| Navigate | 1,985 chars | 105 chars | 19x |
+| Page state | 1,896 chars | 176 chars (compact) | 10.8x |
+| Type into form | 526 chars | 91 chars | 5.8x |
+| List tabs | 367 chars | 63 chars | 5.8x |
+
+### Per-Operation Token Breakdown (Wikipedia)
+
+| Operation | Playwright MCP | OpenBrowser MCP |
+|-----------|---------------|----------------:|
+| Navigate | 493,604 chars (~123K tokens) | 272 chars (~68 tokens) |
+| Snapshot / Get state | 493,486 chars (~123K tokens) | 176 chars (~44 tokens) |
+| Click | 4,107 chars (~1K tokens) | 91 chars (~23 tokens) |
+| Go back | 198 chars (~50 tokens) | 75 chars (~19 tokens) |
+| Get state (2nd) | 139 chars (~35 tokens) | 176 chars (~44 tokens) |
+
+## Why the Difference
+
+| Design Decision | Playwright MCP | Chrome DevTools MCP | OpenBrowser MCP |
+|----------------|----------------|--------------------:|----------------:|
+| Navigate response | Full a11y snapshot | URL confirmation | URL confirmation |
+| State query | Always full snapshot | Full DOM (`get_document`) | Compact (44 tokens) or full |
+| Click response | Updated snapshot | Action confirmation | Action confirmation |
+| Text extraction | No dedicated tool | No dedicated tool | `browser_get_text` (markdown) |
+| Content search | Dump full snapshot | `query_selector_all` (CSS) | `search` param (regex grep) |
+| Element search | Part of snapshot | `query_selector` (CSS) | `filter_by` param (text/tag/id) |
+
+**Playwright MCP**: Every action returns the full page accessibility snapshot. Simple and consistent, but forces the LLM to process ~120K tokens per interaction on large pages.
+
+**Chrome DevTools MCP**: Returns raw DOM data via CSS selectors. Flexible but requires the agent to construct CSS selectors, and `get_document()` returns the entire page HTML (often larger than an a11y snapshot).
+
+**OpenBrowser MCP**: Actions return minimal confirmations. The agent explicitly requests the level of detail it needs -- from 44 tokens (compact state) to 1,250 tokens (targeted grep) to 24K tokens (full text). More tool calls, dramatically fewer tokens.
+
+## Cost Comparison
+
+Estimated MCP tool response costs per 5-step workflow on a complex page (Wikipedia). These tokens are added to the LLM's context window, charged at input token rates.
+
+| Model | Playwright MCP | Chrome DevTools MCP | OpenBrowser MCP |
+|-------|---------------|--------------------:|----------------:|
+| Claude Sonnet ($3/M input) | $0.747 | ~$0.900 | **$0.001** |
+| Claude Opus ($15/M input) | $3.736 | ~$4.500 | **$0.006** |
+| GPT-4o ($2.50/M input) | $0.623 | ~$0.750 | **$0.001** |
+
+**Per 1,000 workflows:**
+
+| Model | Playwright MCP | OpenBrowser MCP | Savings |
+|-------|---------------|----------------:|--------:|
+| Claude Sonnet | $747 | $1.22 | **$746** |
+| Claude Opus | $3,736 | $6.12 | **$3,730** |
+| GPT-4o | $623 | $1.02 | **$622** |
+
+## Tool Surface Comparison
+
+### Playwright MCP (22 core tools)
+
+Navigation, interaction, form filling, file upload, drag, hover, key press, select option, screenshots, snapshots, console messages, dialog handling, network requests, tab management, code generation, PDF export, wait conditions.
+
+### Chrome DevTools MCP (35+ tools)
+
+Chrome management, navigation, DOM/CSS queries, JS execution, console logs, network monitoring, storage/cookies, performance metrics, CSS coverage tracking. No accessibility tree. No text extraction. No content search.
+
+### OpenBrowser MCP (11 tools)
+
+| Tool | Capabilities |
+|------|-------------|
+| `browser_navigate` | URL navigation, new tab |
+| `browser_click` | Element click by index, new tab |
+| `browser_type` | Text input by index |
+| `browser_get_state` | Compact/full state, element filtering by text/tag/id/class/attribute |
+| `browser_scroll` | Direction scroll, find-and-scroll by text |
+| `browser_go_back` | History back |
+| `browser_get_text` | Page as markdown, regex search with context lines |
+| `browser_tab` | List, switch, close tabs |
+| `browser_session` | List, close, close-all sessions |
+| `browser_get_accessibility_tree` | Tree/flat format, depth limit |
+| `browser_execute_js` | JS execution, await/fire-and-forget, by-value/by-reference |
+
+## Unique to OpenBrowser
+
+Features no competitor offers:
+
+- **Progressive disclosure** -- compact state (44 tokens) vs full state vs text vs grep
+- **Regex content search** -- `browser_get_text(search="pattern")` returns only matching lines with context
+- **Element filtering** -- `browser_get_state(filter_by="text", filter_query="Login")` searches interactive elements
+- **Find-and-scroll** -- `browser_scroll(target_text="Section 3")` locates and scrolls to text
+- **MCP Resources** -- `browser://current-page/content`, `/state`, `/accessibility`
+- **Multi-session templates** -- read from specific sessions by ID
+- **Resource subscriptions** -- subscribe to specific URIs for change notifications
+- **WebMCP ToolAnnotations** -- `readOnlyHint`, `destructiveHint`, `idempotentHint` on all tools
+
+## Gaps vs Competitors
+
+| Capability | Playwright MCP | Chrome DevTools MCP | OpenBrowser MCP |
+|-----------|:-:|:-:|:-:|
+| Cross-browser | Yes (Chromium/Firefox/WebKit) | No | No |
+| Screenshots | Yes | No | No |
+| File upload | Yes | No | No |
+| PDF export | Yes | No | No |
+| Network interception | Yes | Yes | No |
+| Console logs | Yes | Yes | No |
+| Cookie management | No | Yes | No |
+| DOM/CSS inspection | No | Yes | No |
+| Performance metrics | No | Yes | No |
+| Code generation | Yes | No | No |
+| Incremental snapshots | Yes | No | No |
+| Accessibility tree | Via snapshot | No | Yes (dedicated tool) |
+| Content grep/search | No | No | Yes |
+| Progressive disclosure | No | No | Yes |
+| Session reuse | No | Yes (existing Chrome) | Yes (existing Chrome) |
+
+## Benchmark Methodology Notes
+
+- Response sizes measured as total JSON-RPC response character count
+- Estimated tokens = characters / 4 (standard approximation for mixed English/JSON)
+- Chrome DevTools MCP estimates based on `get_document()` returning full page HTML (~1.2M chars for Wikipedia) and typical DOM query response patterns
+- Playwright MCP v0.0.68 tested via `npx @playwright/mcp@latest`
+- OpenBrowser MCP v0.1.17 tested via `uvx openbrowser-ai[mcp]@0.1.17 --mcp`
+- All tests run on macOS, M-series Apple Silicon
+- Latency measured as round-trip time from JSON-RPC request to response

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -141,6 +141,7 @@
           "quickstart",
           "quickstart_llm",
           "supported-models",
+          "comparison",
           "production"
         ]
       },

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -63,7 +63,7 @@ bridges MCP servers to OpenClaw agents.
 }
 ```
 
-All 18 browser tools will be registered as native OpenClaw agent tools.
+All 11 browser tools will be registered as native OpenClaw agent tools.
 
 For OpenClaw plugin documentation, see [docs.openclaw.ai/tools/plugin](https://docs.openclaw.ai/tools/plugin).
 
@@ -114,6 +114,20 @@ Add to your project's `.mcp.json`:
 |------|-------------|
 | `browser_tab` | Manage tabs: `action=list` / `switch` / `close` |
 | `browser_session` | Manage sessions: `action=list` / `close` / `close_all` |
+
+## Benchmark: Token Efficiency
+
+Measured on a 5-step workflow (navigate Wikipedia, get state, click, go back, get state) via JSON-RPC stdio.
+
+| MCP Server | Tools | Response Tokens | Cost (Sonnet) | vs OpenBrowser |
+|------------|------:|----------------:|--------------:|---------------:|
+| **Playwright MCP** | 22 | 249,077 | $0.747 | 610x more |
+| **Chrome DevTools MCP** | 35+ | ~300,000 (est.) | ~$0.900 | ~735x more |
+| **OpenBrowser MCP** | 11 | **408** | **$0.001** | baseline |
+
+OpenBrowser returns minimal confirmations for actions and lets the agent request only the detail level it needs -- from 44 tokens (compact state) to 24K tokens (full page text).
+
+[Full comparison](https://docs.openbrowser.me/comparison)
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- New public comparison page at `docs/comparison.mdx` comparing Playwright MCP, Chrome DevTools MCP, and OpenBrowser MCP
- Benchmark summary tables added to README.md and plugin/README.md
- Fixed stale tool count headers (18 -> 11)

## Key findings

- OpenBrowser uses **610x fewer tokens** than Playwright MCP on complex pages (Wikipedia, 327 elements)
- Cost per 5-step workflow: **$0.001** (OpenBrowser) vs **$0.747** (Playwright) on Claude Sonnet
- Navigate on Wikipedia: 68 tokens (OpenBrowser) vs 123,400 tokens (Playwright) -- 1,815x difference

## Test plan

- [x] docs/comparison.mdx renders with Mintlify-compatible frontmatter
- [x] docs/docs.json updated with comparison page in navigation
- [x] README.md benchmark section renders correctly
- [x] plugin/README.md benchmark table renders correctly
- [x] Tool count headers corrected from 18 to 11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public MCP server comparison with real benchmarks (Playwright vs Chrome DevTools vs OpenBrowser) and updates READMEs to show OpenBrowser’s token and cost advantages. Also fixes stale tool count references.

- **New Features**
  - Added docs/comparison.mdx with methodology and results.
  - Added benchmark tables to README.md and plugin/README.md.
  - Added the comparison page to docs navigation (docs/docs.json).

- **Bug Fixes**
  - Corrected tool count headers from 18 to 11.

<sup>Written for commit 1e17b6f1bbd7e3897cae8fc5966ed31dee582a5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive MCP Benchmark documentation comparing browser automation approaches with performance metrics, token usage, and cost analysis across multiple scenarios.
  * Introduced new comparison page in documentation navigation.
  * Updated tool inventory information across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->