### PR TITLE
docs: add concrete browser_get_text search examples to all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,22 @@ OpenBrowser MCP browser_navigate:
      "Navigated to: https://httpbin.org/forms/post"
 ```
 
-OpenBrowser returns minimal confirmations. The agent decides when it needs more: `compact=false` adds the element list (~51K chars), `browser_get_text` returns full page markdown (~100K chars), `search` returns only matching lines. Each detail level is opt-in.
+OpenBrowser returns minimal confirmations. The agent decides when it needs more: `compact=false` adds the element list (~51K chars), `browser_get_text` returns full page markdown (~100K chars). Search returns only matching lines -- not the full page:
+
+```
+browser_get_text(search="Guido van Rossum", context_lines=1)
+-> {
+     "pattern": "Guido van Rossum",
+     "matches": [
+       {"line_number": 244, "line": "| Designed by | Guido van Rossum |", ...},
+       {"line_number": 278, "line": "Guido van Rossum began working on Python...", ...}
+     ],
+     "total_matches": 11
+   }
+
+Full page text: ~97K chars.  Search result: ~3.9K chars (25x smaller).
+Playwright/CDP have no equivalent -- both require dumping the full snapshot.
+```
 
 [Full comparison with methodology](https://docs.openbrowser.me/comparison)
 

--- a/docs/comparison.mdx
+++ b/docs/comparison.mdx
@@ -169,15 +169,74 @@ All three servers return short confirmations for actions:
 
 #### Filter / Search (OpenBrowser only)
 
-No equivalent in Playwright or Chrome DevTools MCP -- both require dumping the full snapshot.
+No equivalent in Playwright or Chrome DevTools MCP -- both require dumping the full snapshot or running JavaScript.
+
+**Element filter** -- find interactive elements by text, tag, id, class, or attribute:
 
 ```json
 browser_get_state(filter_by="text", filter_query="Submit")
--> {"query": "Submit", "by": "text", "results": [{"index": 94, "tag": "button", "text": "Submit order"}], "count": 1}
-
-browser_get_text(search="Customer")
--> (only matching lines with context, not full page)
 ```
+
+```json
+{"query": "Submit", "by": "text", "results": [{"index": 94, "tag": "button", "text": "Submit order"}], "count": 1}
+```
+
+**Regex content search** -- returns only matching lines with context, not the full page.
+
+The Wikipedia Python page is ~97K chars as full markdown. Searching for "Guido van Rossum" returns only the 11 matching lines with context (~3.9K chars -- 25x smaller):
+
+```json
+browser_get_text(search="Guido van Rossum", context_lines=1)
+```
+
+```json
+{
+  "pattern": "Guido van Rossum",
+  "matches": [
+    {
+      "line_number": 244,
+      "line": "| Designed by | Guido van Rossum |",
+      "context_before": ["| Paradigm | Multi-paradigm: object-oriented,... |"],
+      "context_after": ["| Developer | Python Software Foundation |"]
+    },
+    {
+      "line_number": 278,
+      "line": "Guido van Rossum began working on Python in the late 1980s...",
+      "context_before": ["**Python** is a high-level, general-purpose programming language..."],
+      "context_after": ["Python has gained widespread use in the machine learning community..."]
+    }
+  ],
+  "matches_shown": 11,
+  "total_matches": 11
+}
+```
+
+Regex patterns also work -- `search="released in \\d{4}"` finds lines with release years, and `max_matches` limits results:
+
+```json
+browser_get_text(search="released in \\d{4}", context_lines=0, max_matches=3)
+```
+
+```json
+{
+  "pattern": "released in \\d{4}",
+  "matches": [
+    {"line_number": 278, "line": "...Python 3.0, released in 2008, was a major revision..."},
+    {"line_number": 287, "line": "...Python 2.7.18, released in 2020, was the last release of Python 2..."},
+    {"line_number": 463, "line": "...IronPython...An alpha version (released in 2021)..."}
+  ],
+  "matches_shown": 3,
+  "total_matches": 4
+}
+```
+
+**Comparison for finding "Guido van Rossum" on Wikipedia:**
+
+| Server | Method | Response Size |
+|--------|--------|-------------:|
+| Playwright MCP | `browser_snapshot` (dump full tree, search client-side) | ~495K chars |
+| Chrome DevTools MCP | `take_snapshot` (dump full tree, search client-side) | ~538K chars |
+| OpenBrowser MCP | `browser_get_text(search="Guido van Rossum")` | ~3.9K chars |
 
 ## Cost Comparison
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -133,7 +133,14 @@ Measured on a 5-step workflow (navigate Wikipedia, get state, click, go back, ge
 | Chrome DevTools MCP | `"Successfully navigated to URL. ## Pages 1: URL [selected]"` | ~136 chars |
 | OpenBrowser MCP | `"Navigated to: URL"` | ~105 chars |
 
-OpenBrowser returns minimal confirmations for actions and lets the agent request only the detail level it needs -- from 105 tokens (compact state) to 25K tokens (full page text). Each detail level is opt-in.
+OpenBrowser returns minimal confirmations for actions and lets the agent request only the detail level it needs. Search returns only matching lines -- Playwright and Chrome DevTools MCP have no equivalent:
+
+| Detail Level | Example | Wikipedia Size |
+|-------------|---------|---------------:|
+| Compact state | `browser_get_state(compact=true)` | ~250 chars |
+| Search result | `browser_get_text(search="Guido van Rossum")` | ~3.9K chars |
+| Full page text | `browser_get_text()` | ~97K chars |
+| Full a11y snapshot (Playwright/CDP) | `browser_snapshot` / `take_snapshot` | ~495-538K chars |
 
 [Full comparison](https://docs.openbrowser.me/comparison)
 


### PR DESCRIPTION
## Summary

- Add real `browser_get_text(search=...)` response examples to `docs/comparison.mdx`, `README.md`, and `plugin/README.md`
- Show verbatim JSON response for searching "Guido van Rossum" on Wikipedia (11 matches, ~3.9K chars vs ~97K full page -- 25x smaller)
- Show regex example: `search="released in \d{4}"` with `max_matches=3` and `context_lines=0`
- Add comparison table: Playwright/CDP must dump full snapshot (495-538K chars) vs OpenBrowser targeted search (3.9K chars)
- Add progressive disclosure detail levels table in plugin/README.md

## Test plan

- [x] Verify `docs/comparison.mdx` renders correctly on docs site
- [x] Verify README.md search example code block displays properly on GitHub
- [x] Verify plugin/README.md detail levels table renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded OpenBrowser usage descriptions with concrete examples detailing search result behavior and content retrieval across different detail levels.
  * Added detailed breakdowns comparing search results to full-page content, including size comparisons, match examples, and context line information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->