### PR TITLE
Fix integration test table extraction string escaping

### DIFF
--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -232,19 +232,18 @@ class TestIntegrationJavaScript:
     def test_extract_data_from_table(self, mcp_server_with_browser):
         """Extracts structured data from a table via JavaScript."""
         server, loop = mcp_server_with_browser
-        result = loop.run_until_complete(server._execute_code(
-            "data = await evaluate(\"\"\"\n"
-            "Array.from(document.querySelectorAll('#data-section tbody tr')).map(row => {\n"
-            "    const cells = row.querySelectorAll('td');\n"
-            "    return {name: cells[0].textContent, value: parseInt(cells[1].textContent)};\n"
-            "})\n"
-            "\"\"\")\n"
-            "print(json.dumps(data))"
-        ))
-        data = json.loads(result)
-        assert len(data) == 3
-        assert data[0]["name"] == "Alpha"
-        assert data[0]["value"] == 100
+        code = "\n".join([
+            'js = \'Array.from(document.querySelectorAll("#data-section tbody tr"))'
+            '.map(row => { const cells = row.querySelectorAll("td");'
+            ' return {name: cells[0].textContent, value: parseInt(cells[1].textContent)}; })\'',
+            "data = await evaluate(js)",
+            "for row in data:",
+            "    print(row['name'], row['value'])",
+        ])
+        result = loop.run_until_complete(server._execute_code(code))
+        assert "Alpha" in result and "100" in result
+        assert "Beta" in result and "200" in result
+        assert "Gamma" in result and "300" in result
 
 
 class TestIntegrationBrowserState:


### PR DESCRIPTION
## Summary

- Fixed `test_extract_data_from_table` CI failure caused by triple-quoted JavaScript string inside Python string concatenation producing invalid code when passed to `_execute_code`
- Simplified to single-line JS and text assertions instead of JSON round-tripping

## Test plan

- [ ] CI pipeline passes (this was the only failing test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the table extraction integration test by correcting JavaScript string escaping and removing the triple-quoted concatenation. Switched to a single-line JS string and text-based assertions instead of JSON, resolving the CI failure.

<sup>Written for commit 81b6470babdc2005a9785cb18bdc6e7864e5563b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

