### PR TITLE
Fix integration test: add return to JS expression

### DIFF
--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -233,7 +233,7 @@ class TestIntegrationJavaScript:
         """Extracts structured data from a table via JavaScript."""
         server, loop = mcp_server_with_browser
         code = "\n".join([
-            'js = \'Array.from(document.querySelectorAll("#data-section tbody tr"))'
+            'js = \'return Array.from(document.querySelectorAll("#data-section tbody tr"))'
             '.map(row => { const cells = row.querySelectorAll("td");'
             ' return {name: cells[0].textContent, value: parseInt(cells[1].textContent)}; })\'',
             "data = await evaluate(js)",


### PR DESCRIPTION
## Summary

- `evaluate()` wraps JS containing semicolons in `(function(){ ... })()` without `return`, causing `undefined` result
- Added explicit `return` to the `Array.from(...).map(...)` expression so the IIFE returns the value

## Test plan

- [ ] CI `test_extract_data_from_table` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit return to the JS Array.from(...).map(...) in test_extract_data_from_table so evaluate() returns the table data instead of undefined. Fixes the integration test when evaluate() wraps multi-statement code in an IIFE.

<sup>Written for commit 9c8a133400517fb9b12b83885ea41305244f8283. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

