### PR TITLE
feat(training): Flow-GRPO for diffusion language models + training pipeline improvements

### DIFF
--- a/infra/training/anyscale/Containerfile.online-flow-grpo
+++ b/infra/training/anyscale/Containerfile.online-flow-grpo
@@ -5,7 +5,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
     libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
     libasound2 libpango-1.0-0 libpangocairo-1.0-0 libgtk-3-0 \
-    fonts-liberation xdg-utils wget && \
+    fonts-liberation xdg-utils wget git && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Upgrade numpy + reinstall scipy/pyarrow so all C extensions are

--- a/infra/training/anyscale/Containerfile.online-fsdfm-grpo
+++ b/infra/training/anyscale/Containerfile.online-fsdfm-grpo
@@ -5,7 +5,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
     libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
     libasound2 libpango-1.0-0 libpangocairo-1.0-0 libgtk-3-0 \
-    fonts-liberation xdg-utils wget && \
+    fonts-liberation xdg-utils wget git && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Upgrade numpy + reinstall scipy/pyarrow so all C extensions are

--- a/infra/training/anyscale/Containerfile.online-grpo
+++ b/infra/training/anyscale/Containerfile.online-grpo
@@ -5,7 +5,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
     libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
     libasound2 libpango-1.0-0 libpangocairo-1.0-0 libgtk-3-0 \
-    fonts-liberation xdg-utils wget && \
+    fonts-liberation xdg-utils wget git && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Upgrade numpy + reinstall scipy/pyarrow so all C extensions are

--- a/infra/training/anyscale/espo_fsdfm_job.yaml
+++ b/infra/training/anyscale/espo_fsdfm_job.yaml
@@ -1,0 +1,53 @@
+name: openbrowser-espo-fsdfm
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.espo_fsdfm_trainer"
+containerfile: infra/training/anyscale/Containerfile.online-flow-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g5.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
+  MAX_TRAIN_SAMPLES: "992"
+  NUM_EPOCHS: "1"
+  FSDFM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/fsdfm-sft"
+  # ESPO hyperparameters (v19)
+  GROUP_SIZE: "4"
+  LR: "1e-5"
+  KL_COEFF: "3e-3"
+  EPSILON_LOW: "0.2"
+  EPSILON_HIGH: "0.2"
+  MU: "1"
+  NUM_MC: "2"
+  COUPLED: "true"
+  GEN_STEPS: "64"
+  GEN_TEMP: "1.0"
+  SHUFFLE: "true"
+  MIN_NONZERO: "1"
+  EARLY_STOP_MAX_STEPS: "40"
+  GRAD_CLIP: "1.0"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 14400
+tags:
+  project: openbrowser
+  task: espo-fsdfm
+  model: fsdfm-1.3b-dit
+  method: espo-sequence-level

--- a/infra/training/anyscale/espo_refusion_job.yaml
+++ b/infra/training/anyscale/espo_refusion_job.yaml
@@ -1,0 +1,53 @@
+name: openbrowser-espo-refusion
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.espo_refusion_trainer"
+containerfile: infra/training/anyscale/Containerfile.online-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g6e.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
+  MAX_TRAIN_SAMPLES: "992"
+  NUM_EPOCHS: "1"
+  FLOW_LLM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/flow-llm-sft/adapter"
+  # ESPO hyperparameters (v19)
+  GROUP_SIZE: "4"
+  LR: "1e-5"
+  KL_COEFF: "3e-3"
+  EPSILON_LOW: "0.2"
+  EPSILON_HIGH: "0.2"
+  MU: "1"
+  NUM_MC: "2"
+  COUPLED: "true"
+  GEN_STEPS: "64"
+  GEN_TEMP: "1.0"
+  SHUFFLE: "true"
+  MIN_NONZERO: "1"
+  EARLY_STOP_MAX_STEPS: "40"
+  GRAD_CLIP: "1.0"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 14400
+tags:
+  project: openbrowser
+  task: espo-refusion
+  model: refusion-8b-mdm
+  method: espo-sequence-level

--- a/infra/training/anyscale/eval_espo_fsdfm_job.yaml
+++ b/infra/training/anyscale/eval_espo_fsdfm_job.yaml
@@ -1,0 +1,40 @@
+name: openbrowser-eval-espo-fsdfm
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_fsdfm_sft"
+containerfile: infra/training/anyscale/Containerfile.online-flow-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g5.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_VAL_FILE: "data/processed/formfactory_sft_val.jsonl"
+  MAX_EVAL_SAMPLES: "124"
+  # v19 ESPO best checkpoint
+  FSDFM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/espo-fsdfm-best"
+  # Set EVAL_SPLIT=test for test split evaluation; omit for val (default)
+  # EVAL_SPLIT: "test"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 7200
+tags:
+  project: openbrowser
+  task: eval-espo-fsdfm
+  model: fsdfm-1.3b-dit
+  method: espo-sequence-level

--- a/infra/training/anyscale/eval_espo_refusion_job.yaml
+++ b/infra/training/anyscale/eval_espo_refusion_job.yaml
@@ -1,0 +1,40 @@
+name: openbrowser-eval-espo-refusion
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_refusion_sft"
+containerfile: infra/training/anyscale/Containerfile.online-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g6e.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_VAL_FILE: "data/processed/formfactory_sft_val.jsonl"
+  MAX_EVAL_SAMPLES: "124"
+  # v19 ESPO best checkpoint
+  FLOW_LLM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/espo-refusion-best"
+  # Set EVAL_SPLIT=test for test split evaluation; omit for val (default)
+  # EVAL_SPLIT: "test"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 7200
+tags:
+  project: openbrowser
+  task: eval-espo-refusion
+  model: refusion-8b-mdm
+  method: espo-sequence-level

--- a/infra/training/anyscale/eval_fsdfm_flow_grpo_job.yaml
+++ b/infra/training/anyscale/eval_fsdfm_flow_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-fsdfm-flow-grpo
-entrypoint: python -m infra.training.flow_matching.eval_fsdfm_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_fsdfm_sft"
 containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_fsdfm_flow_grpo_job.yaml
+++ b/infra/training/anyscale/eval_fsdfm_flow_grpo_job.yaml
@@ -1,0 +1,37 @@
+name: openbrowser-eval-fsdfm-flow-grpo
+entrypoint: python -m infra.training.flow_matching.eval_fsdfm_sft
+containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g5.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
+  MAX_EVAL_SAMPLES: "25"
+  # Point to Flow-GRPO checkpoint -- same eval script, different weights
+  FSDFM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/fsdfm-flow-grpo/final"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 7200
+tags:
+  project: openbrowser
+  task: eval-fsdfm-flow-grpo
+  model: fsdfm-1.3b-dfm

--- a/infra/training/anyscale/eval_fsdfm_flow_grpo_job.yaml
+++ b/infra/training/anyscale/eval_fsdfm_flow_grpo_job.yaml
@@ -24,10 +24,12 @@ excludes:
   - data/formfactory/img/
   - "*.pyc"
 env_vars:
-  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
-  MAX_EVAL_SAMPLES: "25"
-  # Point to Flow-GRPO checkpoint -- same eval script, different weights
-  FSDFM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/fsdfm-flow-grpo/final"
+  FLOW_VAL_FILE: "data/processed/formfactory_sft_val.jsonl"
+  MAX_EVAL_SAMPLES: "124"
+  # v18 best checkpoint (mu=1 ablation: wd1 + k2, no multi-epoch, no ref reset)
+  FSDFM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/fsdfm-flow-grpo-best"
+  # Set EVAL_SPLIT=test for test split evaluation; omit for val (default)
+  # EVAL_SPLIT: "test"
   # HF_TOKEN injected from .env at submission time by submit_job.py
 max_retries: 1
 timeout_s: 7200

--- a/infra/training/anyscale/eval_fsdfm_grpo_job.yaml
+++ b/infra/training/anyscale/eval_fsdfm_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-fsdfm-grpo
-entrypoint: python -m infra.training.flow_matching.eval_fsdfm_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_fsdfm_sft"
 containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_fsdfm_sft_job.yaml
+++ b/infra/training/anyscale/eval_fsdfm_sft_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-fsdfm-sft
-entrypoint: python -m infra.training.flow_matching.eval_fsdfm_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_fsdfm_sft"
 containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_grpo_job.yaml
+++ b/infra/training/anyscale/eval_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-grpo
-entrypoint: python -m infra.training.finetuning.eval_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.finetuning.eval_sft"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_refusion_flow_grpo_job.yaml
+++ b/infra/training/anyscale/eval_refusion_flow_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-refusion-flow-grpo
-entrypoint: python -m infra.training.flow_matching.eval_refusion_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_refusion_sft"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_refusion_flow_grpo_job.yaml
+++ b/infra/training/anyscale/eval_refusion_flow_grpo_job.yaml
@@ -1,0 +1,36 @@
+name: openbrowser-eval-refusion-flow-grpo
+entrypoint: python -m infra.training.flow_matching.eval_refusion_sft
+containerfile: infra/training/anyscale/Containerfile.online-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g6e.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
+  MAX_EVAL_SAMPLES: "25"
+  FLOW_LLM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/refusion-flow-grpo"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 7200
+tags:
+  project: openbrowser
+  task: eval-refusion-flow-grpo
+  model: refusion-8b-mdm

--- a/infra/training/anyscale/eval_refusion_flow_grpo_job.yaml
+++ b/infra/training/anyscale/eval_refusion_flow_grpo_job.yaml
@@ -24,9 +24,12 @@ excludes:
   - data/formfactory/img/
   - "*.pyc"
 env_vars:
-  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
-  MAX_EVAL_SAMPLES: "25"
-  FLOW_LLM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/refusion-flow-grpo"
+  FLOW_VAL_FILE: "data/processed/formfactory_sft_val.jsonl"
+  MAX_EVAL_SAMPLES: "124"
+  # v18 best checkpoint (mu=1 ablation: wd1 + k2, no multi-epoch, no ref reset)
+  FLOW_LLM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/refusion-flow-grpo-best"
+  # Set EVAL_SPLIT=test for test split evaluation; omit for val (default)
+  # EVAL_SPLIT: "test"
   # HF_TOKEN injected from .env at submission time by submit_job.py
 max_retries: 1
 timeout_s: 7200

--- a/infra/training/anyscale/eval_refusion_grpo_job.yaml
+++ b/infra/training/anyscale/eval_refusion_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-refusion-grpo
-entrypoint: python -m infra.training.flow_matching.eval_refusion_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_refusion_sft"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_refusion_sft_job.yaml
+++ b/infra/training/anyscale/eval_refusion_sft_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-refusion-sft
-entrypoint: python -m infra.training.flow_matching.eval_refusion_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.eval_refusion_sft"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/eval_sft_job.yaml
+++ b/infra/training/anyscale/eval_sft_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-eval-sft
-entrypoint: python -m infra.training.finetuning.eval_sft
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.finetuning.eval_sft"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/fsdfm_flow_grpo_job.yaml
+++ b/infra/training/anyscale/fsdfm_flow_grpo_job.yaml
@@ -1,0 +1,37 @@
+name: openbrowser-fsdfm-flow-grpo
+entrypoint: python -m infra.training.flow_matching.fsdfm_flow_grpo_trainer
+containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g5.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
+  MAX_TRAIN_SAMPLES: "25"
+  NUM_EPOCHS: "1"
+  FSDFM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/fsdfm-sft/lora_adapter"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 14400
+tags:
+  project: openbrowser
+  task: fsdfm-flow-grpo
+  model: fsdfm-1.3b-dfm

--- a/infra/training/anyscale/fsdfm_flow_grpo_job.yaml
+++ b/infra/training/anyscale/fsdfm_flow_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-fsdfm-flow-grpo
-entrypoint: python -m infra.training.flow_matching.fsdfm_flow_grpo_trainer
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.fsdfm_flow_grpo_trainer"
 containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/online_flow_grpo_job.yaml
+++ b/infra/training/anyscale/online_flow_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-online-flow-grpo
-entrypoint: python -m infra.training.flow_matching.online_flow_grpo_trainer
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.online_flow_grpo_trainer"
 containerfile: infra/training/anyscale/Containerfile.online-flow-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/online_flow_llm_grpo_job.yaml
+++ b/infra/training/anyscale/online_flow_llm_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-online-flow-llm-grpo
-entrypoint: python -m infra.training.flow_matching.online_flow_llm_grpo_trainer
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.online_flow_llm_grpo_trainer"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/online_fsdfm_grpo_job.yaml
+++ b/infra/training/anyscale/online_fsdfm_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-online-fsdfm-grpo
-entrypoint: python -m infra.training.flow_matching.fsdfm_online_grpo_trainer
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.fsdfm_online_grpo_trainer"
 containerfile: infra/training/anyscale/Containerfile.online-fsdfm-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/online_grpo_job.yaml
+++ b/infra/training/anyscale/online_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-online-grpo
-entrypoint: python -m infra.training.finetuning.online_grpo_trainer
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.finetuning.online_grpo_trainer"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/refusion_flow_grpo_job.yaml
+++ b/infra/training/anyscale/refusion_flow_grpo_job.yaml
@@ -1,5 +1,5 @@
 name: openbrowser-refusion-flow-grpo
-entrypoint: python -m infra.training.flow_matching.refusion_flow_grpo_trainer
+entrypoint: bash -c "python -m infra.eval.scripts.download_datasets --datasets formfactory && python -m infra.training.flow_matching.refusion_flow_grpo_trainer"
 containerfile: infra/training/anyscale/Containerfile.online-grpo
 compute_config:
   cloud: "Anyscale Cloud"

--- a/infra/training/anyscale/refusion_flow_grpo_job.yaml
+++ b/infra/training/anyscale/refusion_flow_grpo_job.yaml
@@ -1,0 +1,37 @@
+name: openbrowser-refusion-flow-grpo
+entrypoint: python -m infra.training.flow_matching.refusion_flow_grpo_trainer
+containerfile: infra/training/anyscale/Containerfile.online-grpo
+compute_config:
+  cloud: "Anyscale Cloud"
+  head_node:
+    instance_type: g6e.xlarge
+  worker_nodes: []
+working_dir: .
+excludes:
+  - .git
+  - .env
+  - __pycache__
+  - node_modules
+  - frontend
+  - .cursor
+  - presentation
+  - data/mind2web/
+  - data/webarena/
+  - results/
+  - outputs/
+  - openbrowser_agent_data/
+  - data/formfactory/.git/
+  - data/formfactory/img/
+  - "*.pyc"
+env_vars:
+  FLOW_TRAIN_FILE: "data/processed/formfactory_sft.jsonl"
+  MAX_TRAIN_SAMPLES: "25"
+  NUM_EPOCHS: "1"
+  FLOW_LLM_SFT_CHECKPOINT: "/mnt/user_storage/openbrowser/checkpoints/flow-llm-sft/adapter"
+  # HF_TOKEN injected from .env at submission time by submit_job.py
+max_retries: 1
+timeout_s: 14400
+tags:
+  project: openbrowser
+  task: refusion-flow-grpo
+  model: refusion-8b-mdm

--- a/infra/training/anyscale/submit_job.py
+++ b/infra/training/anyscale/submit_job.py
@@ -21,6 +21,8 @@ Usage:
     uv run infra/training/anyscale/submit_job.py eval-fsdfm-grpo
     uv run infra/training/anyscale/submit_job.py eval-refusion-grpo
     uv run infra/training/anyscale/submit_job.py eval-fsdfm-flow-grpo
+    uv run infra/training/anyscale/submit_job.py refusion-flow-grpo
+    uv run infra/training/anyscale/submit_job.py eval-refusion-flow-grpo
     uv run infra/training/anyscale/submit_job.py --list
 """
 
@@ -55,6 +57,8 @@ JOB_CONFIGS = {
     "eval-fsdfm-grpo": JOBS_DIR / "eval_fsdfm_grpo_job.yaml",
     "eval-refusion-grpo": JOBS_DIR / "eval_refusion_grpo_job.yaml",
     "eval-fsdfm-flow-grpo": JOBS_DIR / "eval_fsdfm_flow_grpo_job.yaml",
+    "refusion-flow-grpo": JOBS_DIR / "refusion_flow_grpo_job.yaml",
+    "eval-refusion-flow-grpo": JOBS_DIR / "eval_refusion_flow_grpo_job.yaml",
 }
 
 # Secret env vars to inject from .env into Anyscale jobs

--- a/infra/training/anyscale/submit_job.py
+++ b/infra/training/anyscale/submit_job.py
@@ -59,6 +59,10 @@ JOB_CONFIGS = {
     "eval-fsdfm-flow-grpo": JOBS_DIR / "eval_fsdfm_flow_grpo_job.yaml",
     "refusion-flow-grpo": JOBS_DIR / "refusion_flow_grpo_job.yaml",
     "eval-refusion-flow-grpo": JOBS_DIR / "eval_refusion_flow_grpo_job.yaml",
+    "espo-refusion": JOBS_DIR / "espo_refusion_job.yaml",
+    "espo-fsdfm": JOBS_DIR / "espo_fsdfm_job.yaml",
+    "eval-espo-refusion": JOBS_DIR / "eval_espo_refusion_job.yaml",
+    "eval-espo-fsdfm": JOBS_DIR / "eval_espo_fsdfm_job.yaml",
 }
 
 # Secret env vars to inject from .env into Anyscale jobs

--- a/infra/training/anyscale/submit_job.py
+++ b/infra/training/anyscale/submit_job.py
@@ -13,12 +13,14 @@ Usage:
     uv run infra/training/anyscale/submit_job.py online-grpo
     uv run infra/training/anyscale/submit_job.py fsdfm-sft
     uv run infra/training/anyscale/submit_job.py online-fsdfm-grpo
+    uv run infra/training/anyscale/submit_job.py fsdfm-flow-grpo
     uv run infra/training/anyscale/submit_job.py eval-sft
     uv run infra/training/anyscale/submit_job.py eval-grpo
     uv run infra/training/anyscale/submit_job.py eval-fsdfm-sft
     uv run infra/training/anyscale/submit_job.py eval-refusion-sft
     uv run infra/training/anyscale/submit_job.py eval-fsdfm-grpo
     uv run infra/training/anyscale/submit_job.py eval-refusion-grpo
+    uv run infra/training/anyscale/submit_job.py eval-fsdfm-flow-grpo
     uv run infra/training/anyscale/submit_job.py --list
 """
 
@@ -45,12 +47,14 @@ JOB_CONFIGS = {
     "online-grpo": JOBS_DIR / "online_grpo_job.yaml",
     "fsdfm-sft": JOBS_DIR / "fsdfm_sft_job.yaml",
     "online-fsdfm-grpo": JOBS_DIR / "online_fsdfm_grpo_job.yaml",
+    "fsdfm-flow-grpo": JOBS_DIR / "fsdfm_flow_grpo_job.yaml",
     "eval-sft": JOBS_DIR / "eval_sft_job.yaml",
     "eval-grpo": JOBS_DIR / "eval_grpo_job.yaml",
     "eval-fsdfm-sft": JOBS_DIR / "eval_fsdfm_sft_job.yaml",
     "eval-refusion-sft": JOBS_DIR / "eval_refusion_sft_job.yaml",
     "eval-fsdfm-grpo": JOBS_DIR / "eval_fsdfm_grpo_job.yaml",
     "eval-refusion-grpo": JOBS_DIR / "eval_refusion_grpo_job.yaml",
+    "eval-fsdfm-flow-grpo": JOBS_DIR / "eval_fsdfm_flow_grpo_job.yaml",
 }
 
 # Secret env vars to inject from .env into Anyscale jobs

--- a/infra/training/flow_matching/config.py
+++ b/infra/training/flow_matching/config.py
@@ -191,6 +191,35 @@ ONLINE_FSDFM_GRPO_CONFIG = {
     },
 }
 
+# --- Flow-GRPO for FS-DFM (discrete policy gradients, Liu et al. 2025) ---
+# Adapts continuous Flow-GRPO (ODE-to-SDE + Gaussian log-probs) to the
+# discrete Poisson jump process used by FS-DFM.  Per-step categorical
+# log-probabilities are computed from the jump process, enabling PPO-style
+# clipped policy gradients aligned with the actual generation trajectory.
+# Reference: github.com/yifan123/flow_grpo
+FLOW_GRPO_FSDFM_CONFIG = {
+    "group_size": 2,
+    "learning_rate": 1e-5,            # Lower than SFT (2e-4) per PPO convention
+    "num_epochs": int(os.environ.get("NUM_EPOCHS", "1")),
+    "kl_coeff": 0.04,                 # Matches reference geneval config
+    "clip_range": 0.2,                # Standard PPO clip
+    "adv_clip_max": 5.0,              # Advantage clipping (from reference)
+    "bf16": True,
+    "logging_steps": 5,
+    "grad_clip": 1.0,
+    "num_generation_steps": 10,        # Denoising reduction (T=10, inference uses 64)
+    "generation_temperature": 1.0,     # Full temperature for exploration
+    "formfactory_port": int(os.environ.get("FORMFACTORY_PORT", "5050")),
+    "browser_headless": True,
+    "action_timeout_s": 5,
+    "rollout_timeout_s": 30,
+    "reward_weights": {
+        "task_completion": 0.4,
+        "field_accuracy": 0.4,
+        "execution_completeness": 0.2,
+    },
+}
+
 DATA_CONFIG = {
     "train_file": os.environ.get("FLOW_TRAIN_FILE", "data/processed/formfactory_sft.jsonl"),
     "eval_split": 0.1,

--- a/infra/training/flow_matching/config.py
+++ b/infra/training/flow_matching/config.py
@@ -220,6 +220,35 @@ FLOW_GRPO_FSDFM_CONFIG = {
     },
 }
 
+# --- Flow-GRPO for ReFusion 8B (masked diffusion policy gradients) ---
+# Adapts Flow-GRPO to ReFusion's iterative unmasking process.  Per-step
+# log-probabilities are computed at newly-unmasked positions, enabling
+# PPO-style clipped policy gradients aligned with the generation trajectory.
+# Fixes the generation/optimization mismatch in the existing GRPO trainer
+# which used autoregressive log-probs despite masked diffusion generation.
+FLOW_GRPO_REFUSION_CONFIG = {
+    "group_size": 2,
+    "learning_rate": 1e-5,
+    "num_epochs": int(os.environ.get("NUM_EPOCHS", "1")),
+    "kl_coeff": 0.04,
+    "clip_range": 0.2,
+    "adv_clip_max": 5.0,
+    "bf16": True,
+    "logging_steps": 5,
+    "grad_clip": 1.0,
+    "num_generation_steps": 10,
+    "generation_temperature": 0.7,
+    "formfactory_port": int(os.environ.get("FORMFACTORY_PORT", "5050")),
+    "browser_headless": True,
+    "action_timeout_s": 5,
+    "rollout_timeout_s": 30,
+    "reward_weights": {
+        "task_completion": 0.4,
+        "field_accuracy": 0.4,
+        "execution_completeness": 0.2,
+    },
+}
+
 DATA_CONFIG = {
     "train_file": os.environ.get("FLOW_TRAIN_FILE", "data/processed/formfactory_sft.jsonl"),
     "eval_split": 0.1,

--- a/infra/training/flow_matching/config.py
+++ b/infra/training/flow_matching/config.py
@@ -249,6 +249,75 @@ FLOW_GRPO_REFUSION_CONFIG = {
     },
 }
 
+# --- ESPO for ReFusion 8B (sequence-level ELBO policy optimization) ---
+# Implements ESPO (Li et al., 2025, arXiv:2512.03759): replaces token-level
+# per-step REINFORCE with sequence-level ELBO importance ratios. The ELBO is
+# computed by randomly re-masking the completed output and measuring cross-entropy.
+# Key: k2 KL estimator, sequence-level ratio normalized by L, coupled perturbation.
+ESPO_REFUSION_CONFIG = {
+    "group_size": int(os.environ.get("GROUP_SIZE", "4")),
+    "learning_rate": float(os.environ.get("LR", "1e-5")),
+    "num_epochs": int(os.environ.get("NUM_EPOCHS", "1")),
+    "kl_coeff": float(os.environ.get("KL_COEFF", "3e-3")),
+    "epsilon_low": float(os.environ.get("EPSILON_LOW", "0.2")),
+    "epsilon_high": float(os.environ.get("EPSILON_HIGH", "0.2")),
+    "mu": int(os.environ.get("MU", "1")),
+    "num_mc_samples": int(os.environ.get("NUM_MC", "2")),
+    "coupled_perturbation": os.environ.get("COUPLED", "true").lower() == "true",
+    "bf16": True,
+    "logging_steps": 1,
+    "grad_clip": float(os.environ.get("GRAD_CLIP", "1.0")),
+    "weight_decay": 0.01,
+    "num_generation_steps": int(os.environ.get("GEN_STEPS", "64")),
+    "generation_temperature": float(os.environ.get("GEN_TEMP", "1.0")),
+    "formfactory_port": int(os.environ.get("FORMFACTORY_PORT", "5050")),
+    "browser_headless": True,
+    "action_timeout_s": 5,
+    "rollout_timeout_s": 30,
+    "shuffle_prompts": os.environ.get("SHUFFLE", "true").lower() == "true",
+    "min_nonzero_for_update": int(os.environ.get("MIN_NONZERO", "1")),
+    "early_stop_max_steps": int(os.environ.get("EARLY_STOP_MAX_STEPS", "40")),
+    "reward_weights": {
+        "task_completion": 0.4,
+        "field_accuracy": 0.4,
+        "execution_completeness": 0.2,
+    },
+}
+
+# --- ESPO for FS-DFM 1.3B (sequence-level GKL-based ELBO) ---
+# Adapts ESPO to FS-DFM's Poisson jump process. The ELBO is computed using
+# the GKL loss as a proxy: sample random timestep, noise via forward process,
+# compute GKL loss, negate to get ELBO. Same sequence-level importance ratio.
+ESPO_FSDFM_CONFIG = {
+    "group_size": int(os.environ.get("GROUP_SIZE", "4")),
+    "learning_rate": float(os.environ.get("LR", "1e-5")),
+    "num_epochs": int(os.environ.get("NUM_EPOCHS", "1")),
+    "kl_coeff": float(os.environ.get("KL_COEFF", "3e-3")),
+    "epsilon_low": float(os.environ.get("EPSILON_LOW", "0.2")),
+    "epsilon_high": float(os.environ.get("EPSILON_HIGH", "0.2")),
+    "mu": int(os.environ.get("MU", "1")),
+    "num_mc_samples": int(os.environ.get("NUM_MC", "2")),
+    "coupled_perturbation": os.environ.get("COUPLED", "true").lower() == "true",
+    "bf16": True,
+    "logging_steps": 1,
+    "grad_clip": float(os.environ.get("GRAD_CLIP", "1.0")),
+    "weight_decay": 0.01,
+    "num_generation_steps": int(os.environ.get("GEN_STEPS", "64")),
+    "generation_temperature": float(os.environ.get("GEN_TEMP", "1.0")),
+    "formfactory_port": int(os.environ.get("FORMFACTORY_PORT", "5050")),
+    "browser_headless": True,
+    "action_timeout_s": 5,
+    "rollout_timeout_s": 30,
+    "shuffle_prompts": os.environ.get("SHUFFLE", "true").lower() == "true",
+    "min_nonzero_for_update": int(os.environ.get("MIN_NONZERO", "1")),
+    "early_stop_max_steps": int(os.environ.get("EARLY_STOP_MAX_STEPS", "40")),
+    "reward_weights": {
+        "task_completion": 0.4,
+        "field_accuracy": 0.4,
+        "execution_completeness": 0.2,
+    },
+}
+
 DATA_CONFIG = {
     "train_file": os.environ.get("FLOW_TRAIN_FILE", "data/processed/formfactory_sft.jsonl"),
     "eval_split": 0.1,

--- a/infra/training/flow_matching/espo_fsdfm_trainer.py
+++ b/infra/training/flow_matching/espo_fsdfm_trainer.py
@@ -1,0 +1,661 @@
+"""FS-DFM ESPO trainer: Sequence-level ELBO policy optimization.
+
+Implements ESPO (Li et al., 2025, arXiv:2512.03759) adapted for FS-DFM 1.3B
+Poisson jump discrete flow matching. The ELBO is computed using the GKL loss
+as a proxy: sample random timestep, noise the clean output via the forward
+process, compute GKL loss, and negate to get the ELBO.
+
+Key differences from fsdfm_flow_grpo_trainer.py:
+    - No trajectory recording needed (only final generated sequence)
+    - GKL-based ELBO replaces per-step Poisson jump log-probs
+    - Sequence-level importance ratio instead of per-step REINFORCE
+    - k2 quadratic KL estimator instead of k3 Schulman
+    - Multiple policy updates (mu) over same rollout batch (configurable)
+    - Coupled perturbation for ELBO variance reduction
+
+Key differences from ESPO on masked diffusion (ReFusion):
+    - Forward process uses MixtureDiscreteProbPath (uniform noise) not binary masking
+    - ELBO inner term is the GKL loss from compute_generalized_kl_loss()
+    - Timestep sampling is continuous t ~ U(0,1) not discrete mask count
+
+Reference: https://github.com/ML-GSAI/ESPO
+
+Usage:
+    uv run infra/training/flow_matching/espo_fsdfm_trainer.py
+"""
+
+import asyncio
+import json
+import logging
+import os
+import random
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+from infra.training.flow_matching.config import (
+    DATA_CONFIG,
+    ESPO_FSDFM_CONFIG,
+    FSDFM_MODEL_CONFIG,
+)
+from infra.training.flow_matching.fsdfm_model import (
+    MixtureDiscreteProbPath,
+    PolynomialConvexScheduler,
+    compute_generalized_kl_loss,
+    generate_with_prefix_conditioning,
+    inject_lora,
+    load_fsdfm_from_huggingface,
+    load_lora_weights,
+    save_lora_weights,
+)
+from infra.training.shared.action_parser import parse_rollout_to_actions
+from infra.training.shared.browser_env import BrowserEnvironment
+from infra.training.shared.formfactory_server import FormFactoryServer
+from infra.training.shared.online_reward import compute_online_reward
+from infra.training.shared.reward_functions import compute_grpo_advantages
+from infra.training.shared.utils import persist_checkpoint, resolve_data_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def load_prompts(
+    file_path: str, max_samples: int = 0, shuffle: bool = False, seed: int = 42
+) -> list[dict]:
+    """Load prompts for ESPO rollouts."""
+    records = []
+    with open(file_path) as f:
+        for line in f:
+            records.append(json.loads(line))
+    if max_samples > 0:
+        records = records[:max_samples]
+    if shuffle:
+        rng = random.Random(seed)
+        rng.shuffle(records)
+        logger.info("Shuffled %d prompts with seed %d", len(records), seed)
+    logger.info("Loaded %d prompts for FS-DFM ESPO", len(records))
+    return records
+
+
+def compute_fsdfm_elbo(
+    model,
+    x_1: torch.Tensor,
+    edit_mask: torch.Tensor,
+    scheduler: PolynomialConvexScheduler,
+    vocab_size: int,
+    num_mc: int = 2,
+    coupled: bool = True,
+) -> torch.Tensor:
+    """Compute ELBO for FS-DFM via random noising and GKL loss.
+
+    For each MC sample:
+        1. Sample random timestep t ~ U(epsilon, 1-epsilon)
+        2. Noise clean tokens via forward process: x_t ~ P(x_t | x_0, x_1, t)
+        3. Forward pass model at (x_t, t) to get logits
+        4. Compute GKL loss at response positions
+        5. Negate to get ELBO (GKL loss is negative ELBO)
+
+    If coupled=True, also evaluate at the complementary timestep (1-t)
+    and average the two estimates for variance reduction.
+
+    Args:
+        model: FS-DFM DiT model (with gradients if training).
+        x_1: [B, L] clean (generated) token IDs.
+        edit_mask: [B, L] bool tensor (True = response, False = prefix).
+        scheduler: PolynomialConvexScheduler instance.
+        vocab_size: Vocabulary size for uniform noise sampling.
+        num_mc: Number of MC samples.
+        coupled: Whether to use coupled (antithetic) timestep sampling.
+
+    Returns:
+        [B] ELBO values (higher = better fit).
+    """
+    B, L = x_1.shape
+    device = x_1.device
+    prob_path = MixtureDiscreteProbPath(scheduler)
+
+    L_resp = edit_mask.float().sum(dim=1)  # [B]
+
+    elbo_accum = torch.zeros(B, device=device)
+    num_estimates = 0
+
+    for mc_idx in range(num_mc):
+        # Sample random timestep t ~ U(0.01, 0.99) (avoid boundaries)
+        t = torch.rand(B, device=device) * 0.98 + 0.01  # [B]
+
+        # Sample noise (uniform over vocab)
+        x_0 = torch.randint(0, vocab_size, (B, L), device=device)
+
+        # Forward process: x_t from mixture path
+        path_sample = prob_path.sample(x_0, x_1, t)
+        x_t = path_sample.x_t  # [B, L]
+
+        # Freeze prefix positions
+        x_t = torch.where(edit_mask, x_t, x_1)
+
+        # Forward pass to get logits
+        logits = model(x_t, t)  # [B, L, V]
+
+        # Compute GKL loss per token (without reduction)
+        sched = scheduler(t)
+        alpha_t = sched["alpha_t"]
+        d_alpha_t = sched["d_alpha_t"]
+
+        jump_coeff = d_alpha_t / (1.0 - alpha_t).clamp(min=1e-6)
+        jump_coeff = jump_coeff.unsqueeze(-1)  # [B, 1]
+
+        log_probs = F.log_softmax(logits.float(), dim=-1)  # [B, L, V] in float32
+        probs = torch.exp(log_probs)
+
+        log_p_x1 = log_probs.gather(2, x_1.unsqueeze(-1)).squeeze(-1)  # [B, L]
+        p_xt = probs.gather(2, x_t.unsqueeze(-1)).squeeze(-1)  # [B, L]
+
+        delta = (x_1 == x_t).float()
+
+        # GKL loss per token (positive = loss, negative ELBO)
+        gkl_per_token = -jump_coeff * (p_xt - delta + (1.0 - delta) * log_p_x1)
+
+        # Mask to response only
+        loss_mask = edit_mask.float()
+        gkl_masked = gkl_per_token * loss_mask
+
+        # ELBO = negative of GKL loss, summed over response positions
+        # The sum gives the full-sequence ELBO at this timestep
+        elbo_sample = -gkl_masked.sum(dim=1)  # [B]
+
+        # Delete large tensors
+        del logits, log_probs, probs, gkl_per_token, gkl_masked
+        torch.cuda.empty_cache()
+
+        elbo_accum = elbo_accum + elbo_sample
+        num_estimates += 1
+
+        # Coupled perturbation: complementary timestep (1 - t)
+        if coupled:
+            t_comp = 1.0 - t  # [B]
+            # Clamp to avoid exact 0 or 1
+            t_comp = t_comp.clamp(min=0.01, max=0.99)
+
+            path_sample_comp = prob_path.sample(x_0, x_1, t_comp)
+            x_t_comp = path_sample_comp.x_t
+            x_t_comp = torch.where(edit_mask, x_t_comp, x_1)
+
+            logits_comp = model(x_t_comp, t_comp)
+
+            sched_comp = scheduler(t_comp)
+            alpha_t_comp = sched_comp["alpha_t"]
+            d_alpha_t_comp = sched_comp["d_alpha_t"]
+
+            jump_coeff_comp = d_alpha_t_comp / (1.0 - alpha_t_comp).clamp(min=1e-6)
+            jump_coeff_comp = jump_coeff_comp.unsqueeze(-1)
+
+            log_probs_comp = F.log_softmax(logits_comp.float(), dim=-1)
+            probs_comp = torch.exp(log_probs_comp)
+
+            log_p_x1_comp = log_probs_comp.gather(2, x_1.unsqueeze(-1)).squeeze(-1)
+            p_xt_comp = probs_comp.gather(2, x_t_comp.unsqueeze(-1)).squeeze(-1)
+
+            delta_comp = (x_1 == x_t_comp).float()
+
+            gkl_comp = -jump_coeff_comp * (
+                p_xt_comp - delta_comp + (1.0 - delta_comp) * log_p_x1_comp
+            )
+            gkl_comp_masked = gkl_comp * loss_mask
+            elbo_coupled = -gkl_comp_masked.sum(dim=1)
+
+            del logits_comp, log_probs_comp, probs_comp, gkl_comp, gkl_comp_masked
+            torch.cuda.empty_cache()
+
+            elbo_accum = elbo_accum + elbo_coupled
+            num_estimates += 1
+
+    elbo = elbo_accum / max(num_estimates, 1)
+    return elbo  # [B]
+
+
+async def train():
+    """Run FS-DFM ESPO training with browser execution."""
+    model_config = FSDFM_MODEL_CONFIG
+    espo_config = ESPO_FSDFM_CONFIG
+    vocab_size = model_config["vocab_size"]
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    compute_dtype = torch.bfloat16 if espo_config.get("bf16") else torch.float16
+
+    # Load GPT-2 tokenizer (native to FS-DFM)
+    from transformers import AutoTokenizer
+
+    logger.info("Loading GPT-2 tokenizer")
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # Flow matching scheduler
+    exponent = model_config.get("scheduler_exponent", 2.0)
+    scheduler = PolynomialConvexScheduler(exponent=exponent)
+
+    # ---------------------------------------------------------------
+    # Load policy model (LoRA, from SFT checkpoint)
+    # ---------------------------------------------------------------
+    sft_checkpoint = os.environ.get("FSDFM_SFT_CHECKPOINT", "")
+    logger.info("Loading FS-DFM 1.3B policy model")
+    policy_model = load_fsdfm_from_huggingface(
+        model_config, device=device, dtype=compute_dtype
+    )
+    policy_model = inject_lora(policy_model, model_config)
+
+    if sft_checkpoint and Path(sft_checkpoint).exists():
+        logger.info("Loading SFT checkpoint: %s", sft_checkpoint)
+        lora_path = Path(sft_checkpoint) / "lora_weights.pt"
+        if lora_path.exists():
+            load_lora_weights(policy_model, str(lora_path))
+        else:
+            logger.warning(
+                "lora_weights.pt not found at %s, starting from base LoRA init",
+                lora_path,
+            )
+    elif sft_checkpoint:
+        logger.warning(
+            "SFT checkpoint not found at %s, training from base LoRA init",
+            sft_checkpoint,
+        )
+
+    # ---------------------------------------------------------------
+    # Load reference model (frozen, on CPU to save VRAM)
+    # ---------------------------------------------------------------
+    logger.info("Loading FS-DFM 1.3B reference model (frozen, CPU)")
+    ref_model = load_fsdfm_from_huggingface(
+        model_config, device=torch.device("cpu"), dtype=compute_dtype
+    )
+    ref_model = inject_lora(ref_model, model_config)
+    if sft_checkpoint and Path(sft_checkpoint).exists():
+        lora_path = Path(sft_checkpoint) / "lora_weights.pt"
+        if lora_path.exists():
+            load_lora_weights(ref_model, str(lora_path))
+    ref_model.eval()
+    for p in ref_model.parameters():
+        p.requires_grad = False
+
+    # ---------------------------------------------------------------
+    # Training data and optimizer
+    # ---------------------------------------------------------------
+    train_file = resolve_data_path(DATA_CONFIG["train_file"])
+    shuffle_prompts = espo_config.get("shuffle_prompts", True)
+    prompts = load_prompts(
+        train_file,
+        max_samples=DATA_CONFIG.get("max_train_samples", 0),
+        shuffle=shuffle_prompts,
+    )
+
+    trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(
+        trainable_params,
+        lr=espo_config["learning_rate"],
+        weight_decay=espo_config.get("weight_decay", 0.01),
+    )
+
+    group_size = espo_config["group_size"]
+    kl_coeff = espo_config["kl_coeff"]
+    epsilon_low = espo_config.get("epsilon_low", 0.2)
+    epsilon_high = espo_config.get("epsilon_high", 0.2)
+    max_seq_length = model_config["max_seq_length"]
+    num_gen_steps = espo_config.get("num_generation_steps", 64)
+    gen_temperature = espo_config.get("generation_temperature", 1.0)
+    action_timeout = espo_config.get("action_timeout_s", 5.0)
+    grad_clip = espo_config.get("grad_clip", 1.0)
+    mu = espo_config.get("mu", 1)
+    num_mc = espo_config.get("num_mc_samples", 2)
+    coupled = espo_config.get("coupled_perturbation", True)
+    min_nonzero = espo_config.get("min_nonzero_for_update", 1)
+    max_steps = espo_config.get("early_stop_max_steps", 40)
+
+    # ---------------------------------------------------------------
+    # Start FormFactory server and browser
+    # ---------------------------------------------------------------
+    formfactory_dir = PROJECT_ROOT / "data" / "formfactory"
+    port = espo_config.get("formfactory_port", 5050)
+    ff_server = FormFactoryServer(formfactory_dir, port=port)
+    if not ff_server.start():
+        logger.error("Failed to start FormFactory server, aborting")
+        return
+
+    headless = espo_config.get("browser_headless", True)
+    browser_env = await BrowserEnvironment.create(headless=headless)
+
+    logger.info(
+        "Starting FS-DFM ESPO: %d prompts, G=%d, kl=%.4f, mu=%d, "
+        "M=%d, coupled=%s, eps=%.2f, T_gen=%d, temp=%.1f, max_steps=%d",
+        len(prompts),
+        group_size,
+        kl_coeff,
+        mu,
+        num_mc,
+        coupled,
+        epsilon_low,
+        num_gen_steps,
+        gen_temperature,
+        max_steps,
+    )
+
+    total_steps = 0
+    best_avg_reward = -1.0
+    best_step = -1
+    best_checkpoint_dir = Path("outputs/espo_fsdfm/best")
+
+    try:
+        for epoch in range(espo_config["num_epochs"]):
+            logger.info("Epoch %d/%d", epoch + 1, espo_config["num_epochs"])
+            epoch_rewards = []
+            epoch_kl = []
+
+            for i, prompt_data in enumerate(prompts):
+                if total_steps >= max_steps:
+                    logger.info(
+                        "EARLY STOP at step %d (max_steps=%d). "
+                        "best_reward=%.3f at step %d",
+                        total_steps, max_steps, best_avg_reward, best_step,
+                    )
+                    break
+
+                instruction = prompt_data.get(
+                    "instruction", prompt_data.get("condition", "")
+                )
+                form_url = prompt_data.get("url", "")
+                ground_truth_fields = prompt_data.get("ground_truth_fields", {})
+
+                if not instruction or not form_url:
+                    logger.warning("Skipping prompt %d: missing instruction or url", i)
+                    continue
+
+                # Periodic browser restart to reset DOM indices
+                if i > 0 and i % 10 == 0:
+                    logger.info("Periodic browser restart (prompt %d)", i)
+                    await browser_env.close()
+                    browser_env = await BrowserEnvironment.create(headless=headless)
+
+                # Tokenize instruction
+                inst_enc = tokenizer(
+                    instruction,
+                    add_special_tokens=True,
+                    truncation=True,
+                    max_length=max_seq_length // 2,
+                    return_tensors="pt",
+                )
+                prefix_ids = inst_enc["input_ids"].to(device)
+                prefix_len = prefix_ids.shape[1]
+                gen_length = max(1, max_seq_length - prefix_len)
+
+                # ==========================================================
+                # Phase 1: Generate G rollouts (no trajectory needed)
+                # ==========================================================
+                rollout_full_seqs = []
+                rollout_edit_masks = []
+                rollout_texts = []
+                policy_model.eval()
+                for g in range(group_size):
+                    response_ids = generate_with_prefix_conditioning(
+                        model=policy_model,
+                        prefix_ids=prefix_ids,
+                        gen_length=gen_length,
+                        config={
+                            **model_config,
+                            "num_generation_steps": num_gen_steps,
+                        },
+                        scheduler=scheduler,
+                        temperature=gen_temperature,
+                    )  # [1, gen_length]
+
+                    # Build full sequence and edit mask
+                    full_seq = torch.cat([prefix_ids, response_ids], dim=1)  # [1, L]
+                    edit_mask = torch.zeros(
+                        1, full_seq.shape[1], dtype=torch.bool, device=device
+                    )
+                    edit_mask[:, prefix_len:] = True
+
+                    rollout_full_seqs.append(full_seq)
+                    rollout_edit_masks.append(edit_mask)
+
+                    text = tokenizer.decode(
+                        response_ids[0], skip_special_tokens=True
+                    )
+                    rollout_texts.append(text)
+                policy_model.train()
+
+                # ==========================================================
+                # Phase 2: Execute each rollout in browser and score
+                # ==========================================================
+                rewards = []
+                for g, rollout_text in enumerate(rollout_texts):
+                    await browser_env.reset()
+
+                    try:
+                        await browser_env.tools.navigate(
+                            url=form_url,
+                            new_tab=False,
+                            browser_session=browser_env.browser_session,
+                        )
+                        await asyncio.sleep(0.5)
+                        element_map = await browser_env.get_element_map()
+                    except Exception as e:
+                        logger.warning("Navigation failed for rollout %d: %s", g, e)
+                        rewards.append(0.0)
+                        continue
+
+                    actions = parse_rollout_to_actions(rollout_text, element_map)
+                    if not actions:
+                        logger.warning(
+                            "No valid actions parsed from rollout %d. "
+                            "Generated text (first 300 chars): %.300s",
+                            g, rollout_text,
+                        )
+                        rewards.append(0.0)
+                        continue
+
+                    logger.info(
+                        "Rollout %d: %d actions parsed. Text (first 200 chars): %.200s",
+                        g, len(actions), rollout_text,
+                    )
+                    outcome = await browser_env.execute_actions(
+                        actions, timeout_per_action=action_timeout
+                    )
+                    reward = compute_online_reward(
+                        outcome,
+                        ground_truth_fields,
+                        weights=espo_config.get("reward_weights"),
+                    )
+                    rewards.append(reward)
+                    logger.info(
+                        "Rollout %d: reward=%.3f (actions_executed=%d/%d)",
+                        g, reward,
+                        outcome.actions_executed if hasattr(outcome, 'actions_executed') else -1,
+                        len(actions),
+                    )
+
+                epoch_rewards.extend(rewards)
+
+                # ==========================================================
+                # Phase 3: Check zero-reward skip
+                # ==========================================================
+                nonzero_count = sum(1 for r in rewards if r > 0)
+                if nonzero_count < min_nonzero:
+                    logger.info(
+                        "Step %d: skipping update (nonzero=%d < min=%d)",
+                        total_steps, nonzero_count, min_nonzero,
+                    )
+                    total_steps += 1
+                    continue
+
+                # ==========================================================
+                # Phase 4: Compute advantages
+                # ==========================================================
+                advantages = compute_grpo_advantages(rewards, group_size)
+                advantages_t = torch.tensor(
+                    advantages, dtype=torch.float32, device=device
+                )
+
+                # ==========================================================
+                # Phase 5: Cache old ELBO and ref ELBO (no gradients)
+                # ==========================================================
+                old_elbos = []
+                ref_elbos = []
+                L_resp = gen_length
+
+                with torch.no_grad():
+                    for g in range(group_size):
+                        old_elbo = compute_fsdfm_elbo(
+                            model=policy_model,
+                            x_1=rollout_full_seqs[g],
+                            edit_mask=rollout_edit_masks[g],
+                            scheduler=scheduler,
+                            vocab_size=vocab_size,
+                            num_mc=num_mc,
+                            coupled=coupled,
+                        )  # [1]
+                        old_elbos.append(old_elbo.detach())
+
+                        if kl_coeff > 0:
+                            # Move ref model to GPU
+                            ref_model.to(device)
+                            ref_elbo = compute_fsdfm_elbo(
+                                model=ref_model,
+                                x_1=rollout_full_seqs[g],
+                                edit_mask=rollout_edit_masks[g],
+                                scheduler=scheduler,
+                                vocab_size=vocab_size,
+                                num_mc=num_mc,
+                                coupled=coupled,
+                            )  # [1]
+                            ref_model.to("cpu")
+                            ref_elbos.append(ref_elbo.detach())
+
+                torch.cuda.empty_cache()
+
+                # ==========================================================
+                # Phase 6: Policy update (mu iterations)
+                # ==========================================================
+                total_loss_val = 0.0
+                total_kl_val = 0.0
+
+                for mu_iter in range(mu):
+                    optimizer.zero_grad()
+
+                    for g in range(group_size):
+                        adv_g = advantages_t[g]
+
+                        # Compute current ELBO (WITH gradients)
+                        current_elbo = compute_fsdfm_elbo(
+                            model=policy_model,
+                            x_1=rollout_full_seqs[g],
+                            edit_mask=rollout_edit_masks[g],
+                            scheduler=scheduler,
+                            vocab_size=vocab_size,
+                            num_mc=num_mc,
+                            coupled=coupled,
+                        )  # [1]
+
+                        # Sequence-level importance ratio
+                        log_ratio = (current_elbo - old_elbos[g]) / max(L_resp, 1)
+                        rho = torch.exp(log_ratio)
+
+                        # PPO-style clipping
+                        clipped_rho = torch.clamp(
+                            rho, 1.0 - epsilon_low, 1.0 + epsilon_high
+                        )
+
+                        # Surrogate loss
+                        surr1 = rho * adv_g
+                        surr2 = clipped_rho * adv_g
+                        policy_loss = -torch.min(surr1, surr2).mean()
+
+                        # k2 KL penalty
+                        kl_loss = torch.tensor(0.0, device=device)
+                        if kl_coeff > 0 and ref_elbos:
+                            kl_log_ratio = (current_elbo - ref_elbos[g]) / max(L_resp, 1)
+                            kl_loss = 0.5 * (kl_log_ratio ** 2).mean()
+                            total_kl_val += kl_loss.detach().item()
+
+                        rollout_loss = (policy_loss + kl_coeff * kl_loss) / group_size
+                        rollout_loss.backward()
+                        total_loss_val += rollout_loss.detach().item()
+
+                    torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
+                    optimizer.step()
+
+                torch.cuda.empty_cache()
+
+                total_steps += 1
+                avg_reward = sum(rewards) / len(rewards) if rewards else 0
+                avg_kl = total_kl_val / max(group_size * mu, 1)
+                epoch_kl.append(avg_kl)
+
+                # Track best checkpoint
+                if avg_reward > best_avg_reward:
+                    best_avg_reward = avg_reward
+                    best_step = total_steps
+                    best_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+                    save_lora_weights(
+                        policy_model,
+                        str(best_checkpoint_dir / "lora_weights.pt"),
+                    )
+                    tokenizer.save_pretrained(str(best_checkpoint_dir))
+                    logger.info(
+                        "New best checkpoint: avg_reward=%.3f at step %d",
+                        best_avg_reward, best_step,
+                    )
+
+                if total_steps % espo_config["logging_steps"] == 0:
+                    logger.info(
+                        "Step %d (prompt %d/%d): avg_reward=%.3f, "
+                        "loss=%.4f, kl=%.4f, best_reward=%.3f@%d",
+                        total_steps,
+                        i + 1,
+                        len(prompts),
+                        avg_reward,
+                        total_loss_val,
+                        avg_kl,
+                        best_avg_reward,
+                        best_step,
+                    )
+
+            if total_steps >= max_steps:
+                break
+
+            # Epoch summary
+            if epoch_rewards:
+                epoch_avg = sum(epoch_rewards) / len(epoch_rewards)
+                nonzero = sum(1 for r in epoch_rewards if r > 0)
+                logger.info(
+                    "Epoch %d complete: avg_reward=%.3f, "
+                    "nonzero_rewards=%d/%d, avg_kl=%.4f",
+                    epoch + 1,
+                    epoch_avg,
+                    nonzero,
+                    len(epoch_rewards),
+                    sum(epoch_kl) / len(epoch_kl) if epoch_kl else 0,
+                )
+
+        # Save final model
+        final_dir = Path("outputs/espo_fsdfm/final")
+        final_dir.mkdir(parents=True, exist_ok=True)
+        save_lora_weights(policy_model, str(final_dir / "lora_weights.pt"))
+        tokenizer.save_pretrained(str(final_dir))
+        logger.info(
+            "FS-DFM ESPO complete. Final saved to %s, best (%.3f@%d) at %s",
+            final_dir, best_avg_reward, best_step, best_checkpoint_dir,
+        )
+
+        persist_checkpoint(str(best_checkpoint_dir), "espo-fsdfm")
+
+    finally:
+        await browser_env.close()
+        ff_server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(train())

--- a/infra/training/flow_matching/espo_refusion_trainer.py
+++ b/infra/training/flow_matching/espo_refusion_trainer.py
@@ -1,0 +1,685 @@
+"""ReFusion ESPO trainer: Sequence-level ELBO policy optimization.
+
+Implements ESPO (Li et al., 2025, arXiv:2512.03759) for ReFusion 8B masked
+diffusion. Replaces the token-level per-step REINFORCE of Flow-GRPO with
+sequence-level ELBO importance ratios:
+
+    rho = exp((ELBO_theta(y) - ELBO_theta_old(y)) / L)
+
+where ELBO is computed by randomly re-masking the completed output and measuring
+cross-entropy at masked positions, weighted by L/l (importance weighting).
+
+Key differences from refusion_flow_grpo_trainer.py:
+    - No trajectory recording needed (only final generated sequence)
+    - ELBO replaces per-step unmasking log-probs
+    - Sequence-level importance ratio instead of per-step REINFORCE
+    - k2 quadratic KL estimator instead of k3 Schulman
+    - Multiple policy updates (mu) over same rollout batch (configurable)
+    - Coupled perturbation for ELBO variance reduction
+
+Reference: https://github.com/ML-GSAI/ESPO
+
+Usage:
+    uv run infra/training/flow_matching/espo_refusion_trainer.py
+"""
+
+import asyncio
+import json
+import logging
+import os
+import random
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+
+from infra.training.flow_matching.config import (
+    DATA_CONFIG,
+    ESPO_REFUSION_CONFIG,
+    FLOW_LLM_CONFIG,
+)
+from infra.training.flow_matching.flow_llm_model import FlowLLM
+from infra.training.shared.action_parser import parse_rollout_to_actions
+from infra.training.shared.browser_env import BrowserEnvironment
+from infra.training.shared.formfactory_server import FormFactoryServer
+from infra.training.shared.online_reward import compute_online_reward
+from infra.training.shared.reward_functions import compute_grpo_advantages
+from infra.training.shared.utils import persist_checkpoint, resolve_data_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def load_quantized_model(model_name: str, config: dict):
+    """Load ReFusion with 4-bit quantization."""
+    compute_dtype = (
+        torch.bfloat16
+        if config["bnb_4bit_compute_dtype"] == "bfloat16"
+        else torch.float16
+    )
+    trust_remote_code = config.get("trust_remote_code", True)
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=config["load_in_4bit"],
+        bnb_4bit_quant_type=config["bnb_4bit_quant_type"],
+        bnb_4bit_use_double_quant=config["bnb_4bit_use_double_quant"],
+        bnb_4bit_compute_dtype=compute_dtype,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        quantization_config=bnb_config,
+        device_map="auto",
+        torch_dtype=compute_dtype,
+        trust_remote_code=trust_remote_code,
+    )
+    return model
+
+
+def load_prompts(
+    file_path: str, max_samples: int = 0, shuffle: bool = False, seed: int = 42
+) -> list[dict]:
+    """Load prompts for ESPO rollouts."""
+    records = []
+    with open(file_path) as f:
+        for line in f:
+            records.append(json.loads(line))
+    if max_samples > 0:
+        records = records[:max_samples]
+    if shuffle:
+        rng = random.Random(seed)
+        rng.shuffle(records)
+        logger.info("Shuffled %d prompts with seed %d", len(records), seed)
+    logger.info("Loaded %d prompts for ReFusion ESPO", len(records))
+    return records
+
+
+def compute_masked_diffusion_elbo(
+    model,
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    condition_length: int,
+    mask_token_id: int,
+    num_mc: int = 2,
+    coupled: bool = True,
+) -> torch.Tensor:
+    """Compute the ELBO for a masked diffusion model via random re-masking.
+
+    For each MC sample:
+        1. Sample random mask count l from {1, ..., L_response}
+        2. Mask l random response positions
+        3. Forward pass, compute cross-entropy at masked positions
+        4. Weight by L_response / l (importance weighting)
+
+    If coupled=True, also compute the complement mask (unmask the masked
+    positions, mask the unmasked ones) and average the two estimates. This
+    halves ELBO variance (antithetic sampling).
+
+    Args:
+        model: ReFusion model (with gradients if training).
+        input_ids: [B, L] full sequence (prompt + response).
+        attention_mask: [B, L] attention mask.
+        condition_length: Number of prompt tokens (frozen).
+        mask_token_id: Token ID for masking (151670 for ReFusion).
+        num_mc: Number of MC samples for ELBO estimation.
+        coupled: Whether to use coupled (antithetic) perturbation.
+
+    Returns:
+        [B] ELBO values (higher = better fit, i.e. negative of the loss).
+    """
+    B, L = input_ids.shape
+    L_resp = L - condition_length
+    device = input_ids.device
+
+    if L_resp <= 0:
+        return torch.zeros(B, device=device)
+
+    # Response token positions
+    resp_indices = torch.arange(condition_length, L, device=device)
+
+    elbo_accum = torch.zeros(B, device=device)
+    num_estimates = 0
+
+    for mc_idx in range(num_mc):
+        # Sample random mask count l ~ Uniform({1, ..., L_resp})
+        l = torch.randint(1, L_resp + 1, (B,), device=device)
+
+        # Create random permutation for each batch element to select l positions
+        rand_perm = torch.rand(B, L_resp, device=device).argsort(dim=1)
+
+        # Build mask: True = mask this position
+        mask_indices = torch.zeros(B, L_resp, dtype=torch.bool, device=device)
+        for b in range(B):
+            mask_indices[b, rand_perm[b, :l[b]]] = True
+
+        # Apply mask to input_ids
+        masked_ids = input_ids.clone()
+        for b in range(B):
+            positions_to_mask = resp_indices[mask_indices[b]]
+            masked_ids[b, positions_to_mask] = mask_token_id
+
+        # Forward pass (no labels, no prompt_lengths -- raw logits)
+        outputs = model(input_ids=masked_ids, attention_mask=attention_mask)
+        logits = outputs.logits  # [B, L, V]
+
+        # Extract response logits
+        resp_logits = logits[:, condition_length:, :]  # [B, L_resp, V]
+        resp_targets = input_ids[:, condition_length:]  # [B, L_resp]
+
+        # Cross-entropy at masked positions only
+        # Flatten for cross_entropy, then reshape
+        ce_per_token = F.cross_entropy(
+            resp_logits.reshape(-1, resp_logits.shape[-1]),
+            resp_targets.reshape(-1),
+            reduction="none",
+        ).reshape(B, L_resp)  # [B, L_resp]
+
+        # Zero out non-masked positions
+        ce_masked = ce_per_token * mask_indices.float()
+
+        # Sum CE at masked positions, weight by L_resp / l
+        # p_mask = l / (L_resp + 1) for stratified sampling
+        # Importance weight = 1 / p_mask = (L_resp + 1) / l
+        # But for uniform l, the ELBO estimate is: sum(CE_masked) / l * L_resp
+        # Following ESPO: weight each token's CE by 1/p_mask where p_mask = l/(L_resp+1)
+        p_mask = l.float() / (L_resp + 1)  # [B]
+        elbo_sample = -(ce_masked.sum(dim=1) / l.float()) * L_resp  # [B]
+
+        # Delete large tensors
+        del outputs, logits, resp_logits, ce_per_token, ce_masked
+        torch.cuda.empty_cache()
+
+        elbo_accum = elbo_accum + elbo_sample
+        num_estimates += 1
+
+        # Coupled perturbation: complement mask
+        if coupled:
+            complement_mask = ~mask_indices
+            # l_comp = L_resp - l (number of newly masked positions)
+            l_comp = L_resp - l  # [B]
+
+            # Skip if any batch element has l_comp <= 0
+            if (l_comp <= 0).any():
+                continue
+
+            coupled_ids = input_ids.clone()
+            for b in range(B):
+                positions_to_mask = resp_indices[complement_mask[b]]
+                coupled_ids[b, positions_to_mask] = mask_token_id
+
+            coupled_outputs = model(
+                input_ids=coupled_ids, attention_mask=attention_mask
+            )
+            coupled_logits = coupled_outputs.logits[:, condition_length:, :]
+            coupled_ce = F.cross_entropy(
+                coupled_logits.reshape(-1, coupled_logits.shape[-1]),
+                resp_targets.reshape(-1),
+                reduction="none",
+            ).reshape(B, L_resp)
+
+            coupled_ce_masked = coupled_ce * complement_mask.float()
+            elbo_coupled = -(coupled_ce_masked.sum(dim=1) / l_comp.float()) * L_resp
+
+            del coupled_outputs, coupled_logits, coupled_ce, coupled_ce_masked
+            torch.cuda.empty_cache()
+
+            elbo_accum = elbo_accum + elbo_coupled
+            num_estimates += 1
+
+    # Average over all estimates
+    elbo = elbo_accum / max(num_estimates, 1)
+    return elbo  # [B]
+
+
+async def train():
+    """Run ReFusion ESPO training with browser execution."""
+    model_config = FLOW_LLM_CONFIG
+    espo_config = ESPO_REFUSION_CONFIG
+
+    # Load tokenizer
+    trust_remote_code = model_config.get("trust_remote_code", True)
+    logger.info("Loading tokenizer: %s", model_config["model_name"])
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_config["model_name"], trust_remote_code=trust_remote_code
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # Determine if loading from SFT checkpoint
+    sft_checkpoint = os.environ.get("FLOW_LLM_SFT_CHECKPOINT", "")
+    is_peft_checkpoint = sft_checkpoint and Path(sft_checkpoint).exists()
+
+    # ---------------------------------------------------------------
+    # Load policy model with QLoRA
+    # ---------------------------------------------------------------
+    if is_peft_checkpoint:
+        logger.info("Loading SFT checkpoint: %s", sft_checkpoint)
+        base_model = load_quantized_model(model_config["model_name"], model_config)
+        base_model.config.use_cache = False
+        base_model = prepare_model_for_kbit_training(
+            base_model,
+            use_gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        )
+        policy_model = PeftModel.from_pretrained(
+            base_model, sft_checkpoint, is_trainable=True
+        )
+        policy_model.train()
+    else:
+        if sft_checkpoint:
+            logger.warning(
+                "SFT checkpoint not found at %s, training from base model",
+                sft_checkpoint,
+            )
+        logger.info("Loading base model: %s", model_config["model_name"])
+        policy_model = load_quantized_model(model_config["model_name"], model_config)
+        policy_model.config.use_cache = False
+        policy_model = prepare_model_for_kbit_training(
+            policy_model,
+            use_gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        )
+        lora_config = LoraConfig(
+            r=model_config["lora_r"],
+            lora_alpha=model_config["lora_alpha"],
+            lora_dropout=model_config["lora_dropout"],
+            target_modules=model_config["lora_target_modules"],
+            task_type="CAUSAL_LM",
+        )
+        policy_model = get_peft_model(policy_model, lora_config)
+
+    policy_model.print_trainable_parameters()
+
+    # Wrap in FlowLLM for generation
+    mask_token_id = model_config.get("mask_token_id", 151670)
+    flow_policy = FlowLLM(policy_model, tokenizer, mask_token_id=mask_token_id)
+
+    # ---------------------------------------------------------------
+    # Load reference model (frozen, for KL penalty)
+    # ---------------------------------------------------------------
+    logger.info("Loading reference model (frozen)")
+    ref_base = load_quantized_model(model_config["model_name"], model_config)
+    if is_peft_checkpoint:
+        ref_model = PeftModel.from_pretrained(ref_base, sft_checkpoint)
+    else:
+        ref_model = ref_base
+    ref_model.eval()
+    for param in ref_model.parameters():
+        param.requires_grad = False
+
+    # ---------------------------------------------------------------
+    # Training data and optimizer
+    # ---------------------------------------------------------------
+    train_file = resolve_data_path(DATA_CONFIG["train_file"])
+    shuffle_prompts = espo_config.get("shuffle_prompts", True)
+    prompts = load_prompts(
+        train_file,
+        max_samples=DATA_CONFIG.get("max_train_samples", 0),
+        shuffle=shuffle_prompts,
+    )
+
+    trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(
+        trainable_params,
+        lr=espo_config["learning_rate"],
+        weight_decay=espo_config.get("weight_decay", 0.01),
+    )
+
+    group_size = espo_config["group_size"]
+    kl_coeff = espo_config["kl_coeff"]
+    epsilon_low = espo_config.get("epsilon_low", 0.2)
+    epsilon_high = espo_config.get("epsilon_high", 0.2)
+    max_seq_length = model_config["max_seq_length"]
+    num_gen_steps = espo_config.get("num_generation_steps", 64)
+    gen_temperature = espo_config.get("generation_temperature", 1.0)
+    action_timeout = espo_config.get("action_timeout_s", 5.0)
+    grad_clip = espo_config.get("grad_clip", 1.0)
+    mu = espo_config.get("mu", 1)
+    num_mc = espo_config.get("num_mc_samples", 2)
+    coupled = espo_config.get("coupled_perturbation", True)
+    min_nonzero = espo_config.get("min_nonzero_for_update", 1)
+    max_steps = espo_config.get("early_stop_max_steps", 40)
+
+    # ---------------------------------------------------------------
+    # Start FormFactory server and browser
+    # ---------------------------------------------------------------
+    formfactory_dir = PROJECT_ROOT / "data" / "formfactory"
+    port = espo_config.get("formfactory_port", 5050)
+    ff_server = FormFactoryServer(formfactory_dir, port=port)
+    if not ff_server.start():
+        logger.error("Failed to start FormFactory server, aborting")
+        return
+
+    headless = espo_config.get("browser_headless", True)
+    browser_env = await BrowserEnvironment.create(headless=headless)
+
+    logger.info(
+        "Starting ReFusion ESPO: %d prompts, G=%d, kl=%.4f, mu=%d, "
+        "M=%d, coupled=%s, eps=%.2f, T_gen=%d, temp=%.1f, max_steps=%d",
+        len(prompts),
+        group_size,
+        kl_coeff,
+        mu,
+        num_mc,
+        coupled,
+        epsilon_low,
+        num_gen_steps,
+        gen_temperature,
+        max_steps,
+    )
+
+    total_steps = 0
+    best_avg_reward = -1.0
+    best_step = -1
+    best_checkpoint_dir = Path("outputs/espo_refusion/best")
+
+    try:
+        for epoch in range(espo_config["num_epochs"]):
+            logger.info("Epoch %d/%d", epoch + 1, espo_config["num_epochs"])
+            epoch_rewards = []
+            epoch_kl = []
+
+            for i, prompt_data in enumerate(prompts):
+                if total_steps >= max_steps:
+                    logger.info(
+                        "EARLY STOP at step %d (max_steps=%d). "
+                        "best_reward=%.3f at step %d",
+                        total_steps, max_steps, best_avg_reward, best_step,
+                    )
+                    break
+
+                instruction = prompt_data.get(
+                    "instruction", prompt_data.get("condition", "")
+                )
+                form_url = prompt_data.get("url", "")
+                ground_truth_fields = prompt_data.get("ground_truth_fields", {})
+
+                if not instruction or not form_url:
+                    logger.warning("Skipping prompt %d: missing instruction or url", i)
+                    continue
+
+                # Periodic browser restart to reset DOM indices
+                if i > 0 and i % 10 == 0:
+                    logger.info("Periodic browser restart (prompt %d)", i)
+                    await browser_env.close()
+                    browser_env = await BrowserEnvironment.create(headless=headless)
+
+                # Tokenize condition
+                condition_enc = tokenizer(
+                    instruction,
+                    add_special_tokens=True,
+                    truncation=True,
+                    max_length=max_seq_length,
+                    return_tensors="pt",
+                ).to(flow_policy.device)
+
+                prompt_len = condition_enc["attention_mask"].sum().item()
+                gen_length = max(1, max_seq_length - prompt_len)
+
+                # ==========================================================
+                # Phase 1: Generate G rollouts (no trajectory needed)
+                # ==========================================================
+                rollout_sequences = []
+                rollout_texts = []
+                policy_model.eval()
+                for g in range(group_size):
+                    final_tokens = flow_policy.generate(
+                        condition_ids=condition_enc["input_ids"],
+                        condition_mask=condition_enc["attention_mask"],
+                        seq_length=gen_length,
+                        num_steps=num_gen_steps,
+                        temperature=gen_temperature,
+                    )  # [1, gen_length]
+                    # Build full sequence: prompt + generated response
+                    full_seq = torch.cat(
+                        [condition_enc["input_ids"], final_tokens], dim=1
+                    )  # [1, L]
+                    rollout_sequences.append(full_seq)
+                    text = tokenizer.decode(
+                        final_tokens[0], skip_special_tokens=True
+                    )
+                    rollout_texts.append(text)
+                policy_model.train()
+
+                # ==========================================================
+                # Phase 2: Execute each rollout in browser and score
+                # ==========================================================
+                rewards = []
+                for g, rollout_text in enumerate(rollout_texts):
+                    await browser_env.reset()
+
+                    try:
+                        await browser_env.tools.navigate(
+                            url=form_url,
+                            new_tab=False,
+                            browser_session=browser_env.browser_session,
+                        )
+                        await asyncio.sleep(0.5)
+                        element_map = await browser_env.get_element_map()
+                    except Exception as e:
+                        logger.warning("Navigation failed for rollout %d: %s", g, e)
+                        rewards.append(0.0)
+                        continue
+
+                    actions = parse_rollout_to_actions(rollout_text, element_map)
+                    if not actions:
+                        logger.warning(
+                            "No valid actions parsed from rollout %d. "
+                            "Generated text (first 300 chars): %.300s",
+                            g, rollout_text,
+                        )
+                        rewards.append(0.0)
+                        continue
+
+                    logger.info(
+                        "Rollout %d: %d actions parsed. Text (first 200 chars): %.200s",
+                        g, len(actions), rollout_text,
+                    )
+                    outcome = await browser_env.execute_actions(
+                        actions, timeout_per_action=action_timeout
+                    )
+                    reward = compute_online_reward(
+                        outcome,
+                        ground_truth_fields,
+                        weights=espo_config.get("reward_weights"),
+                    )
+                    rewards.append(reward)
+                    logger.info(
+                        "Rollout %d: reward=%.3f (actions_executed=%d/%d)",
+                        g, reward,
+                        outcome.actions_executed if hasattr(outcome, 'actions_executed') else -1,
+                        len(actions),
+                    )
+
+                epoch_rewards.extend(rewards)
+
+                # ==========================================================
+                # Phase 3: Check zero-reward skip
+                # ==========================================================
+                nonzero_count = sum(1 for r in rewards if r > 0)
+                if nonzero_count < min_nonzero:
+                    logger.info(
+                        "Step %d: skipping update (nonzero=%d < min=%d)",
+                        total_steps, nonzero_count, min_nonzero,
+                    )
+                    total_steps += 1
+                    continue
+
+                # ==========================================================
+                # Phase 4: Compute advantages
+                # ==========================================================
+                advantages = compute_grpo_advantages(rewards, group_size)
+                advantages_t = torch.tensor(
+                    advantages, dtype=torch.float32, device=flow_policy.device
+                )
+
+                # ==========================================================
+                # Phase 5: Build attention masks for full sequences
+                # ==========================================================
+                full_attention_masks = []
+                for seq in rollout_sequences:
+                    mask = torch.ones_like(seq, dtype=torch.long)
+                    full_attention_masks.append(mask)
+
+                # ==========================================================
+                # Phase 6: Cache old ELBO and ref ELBO (no gradients)
+                # ==========================================================
+                old_elbos = []
+                ref_elbos = []
+                L_resp = gen_length
+
+                with torch.no_grad():
+                    for g in range(group_size):
+                        old_elbo = compute_masked_diffusion_elbo(
+                            model=policy_model,
+                            input_ids=rollout_sequences[g],
+                            attention_mask=full_attention_masks[g],
+                            condition_length=prompt_len,
+                            mask_token_id=mask_token_id,
+                            num_mc=num_mc,
+                            coupled=coupled,
+                        )  # [1]
+                        old_elbos.append(old_elbo.detach())
+
+                        if kl_coeff > 0:
+                            ref_elbo = compute_masked_diffusion_elbo(
+                                model=ref_model,
+                                input_ids=rollout_sequences[g],
+                                attention_mask=full_attention_masks[g],
+                                condition_length=prompt_len,
+                                mask_token_id=mask_token_id,
+                                num_mc=num_mc,
+                                coupled=coupled,
+                            )  # [1]
+                            ref_elbos.append(ref_elbo.detach())
+
+                torch.cuda.empty_cache()
+
+                # ==========================================================
+                # Phase 7: Policy update (mu iterations)
+                # ==========================================================
+                total_loss_val = 0.0
+                total_kl_val = 0.0
+
+                for mu_iter in range(mu):
+                    optimizer.zero_grad()
+                    batch_loss = torch.tensor(0.0, device=flow_policy.device)
+
+                    for g in range(group_size):
+                        adv_g = advantages_t[g]
+
+                        # Compute current ELBO (WITH gradients)
+                        current_elbo = compute_masked_diffusion_elbo(
+                            model=policy_model,
+                            input_ids=rollout_sequences[g],
+                            attention_mask=full_attention_masks[g],
+                            condition_length=prompt_len,
+                            mask_token_id=mask_token_id,
+                            num_mc=num_mc,
+                            coupled=coupled,
+                        )  # [1]
+
+                        # Sequence-level importance ratio
+                        # rho = exp((ELBO_theta - ELBO_old) / L)
+                        log_ratio = (current_elbo - old_elbos[g]) / max(L_resp, 1)
+                        rho = torch.exp(log_ratio)
+
+                        # PPO-style clipping
+                        clipped_rho = torch.clamp(
+                            rho, 1.0 - epsilon_low, 1.0 + epsilon_high
+                        )
+
+                        # Surrogate loss: -min(rho * A, clipped_rho * A)
+                        surr1 = rho * adv_g
+                        surr2 = clipped_rho * adv_g
+                        policy_loss = -torch.min(surr1, surr2).mean()
+
+                        # k2 KL penalty: (1/2) * (ELBO_theta - ELBO_ref)^2 / L
+                        kl_loss = torch.tensor(0.0, device=flow_policy.device)
+                        if kl_coeff > 0 and ref_elbos:
+                            kl_log_ratio = (current_elbo - ref_elbos[g]) / max(L_resp, 1)
+                            kl_loss = 0.5 * (kl_log_ratio ** 2).mean()
+                            total_kl_val += kl_loss.detach().item()
+
+                        rollout_loss = (policy_loss + kl_coeff * kl_loss) / group_size
+                        rollout_loss.backward()
+                        total_loss_val += rollout_loss.detach().item()
+
+                    # Clip gradients and step
+                    torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
+                    optimizer.step()
+
+                torch.cuda.empty_cache()
+
+                total_steps += 1
+                avg_reward = sum(rewards) / len(rewards) if rewards else 0
+                avg_kl = total_kl_val / max(group_size * mu, 1)
+                epoch_kl.append(avg_kl)
+
+                # Track best checkpoint
+                if avg_reward > best_avg_reward:
+                    best_avg_reward = avg_reward
+                    best_step = total_steps
+                    best_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+                    policy_model.save_pretrained(str(best_checkpoint_dir))
+                    tokenizer.save_pretrained(str(best_checkpoint_dir))
+                    logger.info(
+                        "New best checkpoint: avg_reward=%.3f at step %d",
+                        best_avg_reward, best_step,
+                    )
+
+                if total_steps % espo_config["logging_steps"] == 0:
+                    logger.info(
+                        "Step %d (prompt %d/%d): avg_reward=%.3f, "
+                        "loss=%.4f, kl=%.4f, best_reward=%.3f@%d",
+                        total_steps,
+                        i + 1,
+                        len(prompts),
+                        avg_reward,
+                        total_loss_val,
+                        avg_kl,
+                        best_avg_reward,
+                        best_step,
+                    )
+
+            if total_steps >= max_steps:
+                break
+
+            # Epoch summary
+            if epoch_rewards:
+                epoch_avg = sum(epoch_rewards) / len(epoch_rewards)
+                nonzero = sum(1 for r in epoch_rewards if r > 0)
+                logger.info(
+                    "Epoch %d complete: avg_reward=%.3f, "
+                    "nonzero_rewards=%d/%d, avg_kl=%.4f",
+                    epoch + 1,
+                    epoch_avg,
+                    nonzero,
+                    len(epoch_rewards),
+                    sum(epoch_kl) / len(epoch_kl) if epoch_kl else 0,
+                )
+
+        # Save final model
+        final_dir = Path("outputs/espo_refusion/final")
+        final_dir.mkdir(parents=True, exist_ok=True)
+        policy_model.save_pretrained(str(final_dir))
+        tokenizer.save_pretrained(str(final_dir))
+        logger.info(
+            "ReFusion ESPO complete. Final saved to %s, best (%.3f@%d) at %s",
+            final_dir, best_avg_reward, best_step, best_checkpoint_dir,
+        )
+
+        persist_checkpoint(str(best_checkpoint_dir), "espo-refusion")
+
+    finally:
+        await browser_env.close()
+        ff_server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(train())

--- a/infra/training/flow_matching/flow_llm_model.py
+++ b/infra/training/flow_matching/flow_llm_model.py
@@ -213,3 +213,135 @@ class FlowLLM:
             current = torch.where(is_unmasked, current, predicted)
 
         return current
+
+    @torch.no_grad()
+    def generate_with_trajectory(
+        self,
+        condition_ids: torch.Tensor,
+        condition_mask: torch.Tensor,
+        seq_length: int,
+        num_steps: int = 10,
+        temperature: float = 0.7,
+    ) -> UnmaskingTrajectory:
+        """Generate via iterative unmasking, recording the trajectory.
+
+        Same logic as generate() but stores (masked_state, unmasked_positions,
+        unmasked_tokens) at each denoising step for Flow-GRPO training.
+
+        Args:
+            condition_ids: [B, L_c] prompt token IDs.
+            condition_mask: [B, L_c] attention mask for prompt.
+            seq_length: Number of response tokens to generate.
+            num_steps: Number of denoising steps (T).
+            temperature: Gumbel noise temperature (0 = greedy).
+
+        Returns:
+            UnmaskingTrajectory with T steps and final tokens.
+        """
+        self.model.eval()
+        B = condition_ids.shape[0]
+        L_c = condition_ids.shape[1]
+        device = condition_ids.device
+
+        trajectory = UnmaskingTrajectory(condition_length=L_c)
+
+        # Start with fully masked response tokens
+        current = torch.full(
+            (B, seq_length), self.mask_token_id, dtype=torch.long, device=device
+        )
+        is_unmasked = torch.zeros(B, seq_length, dtype=torch.bool, device=device)
+
+        for step in range(num_steps):
+            t_next = (step + 1) / num_steps
+            t_current = step / num_steps
+            num_to_unmask = int(t_next * seq_length) - int(t_current * seq_length)
+
+            if num_to_unmask <= 0 and step < num_steps - 1:
+                continue
+
+            # Build full input
+            input_ids = torch.cat([condition_ids, current], dim=1)
+            attn_mask = torch.cat(
+                [condition_mask, torch.ones(B, seq_length, device=device, dtype=torch.long)],
+                dim=1,
+            )
+
+            # Record the masked state BEFORE this step's unmasking
+            step_record = UnmaskingTrajectoryStep(
+                step_index=step,
+                masked_state=input_ids.clone(),
+                attention_mask=attn_mask.clone(),
+                newly_unmasked_indices=[[] for _ in range(B)],
+                unmasked_tokens=[[] for _ in range(B)],
+            )
+
+            # Forward pass
+            outputs = self.model(input_ids=input_ids, attention_mask=attn_mask)
+            logits = outputs.logits[:, L_c:, :]  # [B, seq_length, V]
+
+            # Gumbel noise for sampling diversity
+            if temperature > 0:
+                gumbel_noise = -torch.log(-torch.log(
+                    torch.rand_like(logits, dtype=torch.float64).clamp(min=1e-10)
+                )).float()
+                perturbed_logits = logits / temperature + gumbel_noise
+            else:
+                perturbed_logits = logits
+
+            predicted = perturbed_logits.argmax(dim=-1)  # [B, seq_length]
+
+            # Confidence
+            probs = F.softmax(logits, dim=-1)
+            confidences = probs.gather(2, predicted.unsqueeze(-1)).squeeze(-1)
+            confidences[is_unmasked] = -float("inf")
+
+            if num_to_unmask > 0:
+                remaining_masked = (~is_unmasked).sum(dim=-1).min().item()
+                k = min(num_to_unmask, int(remaining_masked))
+                if k > 0:
+                    _, top_indices = confidences.topk(k, dim=-1)
+                    for b in range(B):
+                        for idx in top_indices[b]:
+                            idx_val = idx.item()
+                            current[b, idx_val] = predicted[b, idx_val]
+                            is_unmasked[b, idx_val] = True
+                            step_record.newly_unmasked_indices[b].append(idx_val)
+                            step_record.unmasked_tokens[b].append(predicted[b, idx_val].item())
+
+            # Only record steps that actually unmasked something
+            if any(len(indices) > 0 for indices in step_record.newly_unmasked_indices):
+                trajectory.steps.append(step_record)
+
+        # Final pass: fill remaining masked positions
+        if not is_unmasked.all():
+            input_ids = torch.cat([condition_ids, current], dim=1)
+            attn_mask = torch.cat(
+                [condition_mask, torch.ones(B, seq_length, device=device, dtype=torch.long)],
+                dim=1,
+            )
+
+            # Record this final step too
+            final_step = UnmaskingTrajectoryStep(
+                step_index=num_steps,
+                masked_state=input_ids.clone(),
+                attention_mask=attn_mask.clone(),
+                newly_unmasked_indices=[[] for _ in range(B)],
+                unmasked_tokens=[[] for _ in range(B)],
+            )
+
+            outputs = self.model(input_ids=input_ids, attention_mask=attn_mask)
+            logits = outputs.logits[:, L_c:, :]
+            predicted = logits.argmax(dim=-1)
+
+            for b in range(B):
+                for pos in range(seq_length):
+                    if not is_unmasked[b, pos]:
+                        current[b, pos] = predicted[b, pos]
+                        final_step.newly_unmasked_indices[b].append(pos)
+                        final_step.unmasked_tokens[b].append(predicted[b, pos].item())
+
+            if any(len(indices) > 0 for indices in final_step.newly_unmasked_indices):
+                trajectory.steps.append(final_step)
+
+        trajectory.final_tokens = current
+        return trajectory

--- a/infra/training/flow_matching/fsdfm_flow_grpo_trainer.py
+++ b/infra/training/flow_matching/fsdfm_flow_grpo_trainer.py
@@ -1,0 +1,451 @@
+"""FS-DFM Flow-GRPO trainer: Proper discrete policy gradients for flow matching.
+
+Implements Flow-GRPO (Liu et al., 2025) adapted for discrete flow matching
+with the Poisson jump process.  Unlike the advantage-weighted flow loss in
+fsdfm_online_grpo_trainer.py, this computes proper per-step log-probabilities
+aligned with the actual generation process, enabling PPO-style clipped policy
+gradients.
+
+Key innovation -- discrete analog of continuous Flow-GRPO:
+    Continuous: SDE step gives Gaussian policy N(mu, sigma^2 dt I)
+                log-prob = Gaussian log-density
+    Discrete:   Euler step gives categorical per-position distribution
+                P(stay) = exp(-lambda * dt)
+                P(jump to j) = (1 - exp(-lambda * dt)) * p(j) / (1 - p(cur))
+                log-prob = sum of per-position log-probs over response tokens
+
+Architecture:
+    1. Generate G rollouts via discrete Euler solver, recording trajectories
+    2. Execute rollouts in headless browser against FormFactory
+    3. Compute group-relative advantages from browser rewards
+    4. For each rollout, iterate over ALL trajectory steps (denoising reduction):
+       a. Recompute policy log-prob at that step (with gradients)
+       b. Recompute old/reference log-prob (detached)
+       c. PPO-style clipped surrogate objective on per-step log-ratios
+       d. KL penalty from Schulman k3 approximation
+    5. Average loss over steps and rollouts, backprop, update LoRA params
+
+Reference: github.com/yifan123/flow_grpo (continuous version for images)
+
+Usage:
+    uv run infra/training/flow_matching/fsdfm_flow_grpo_trainer.py
+"""
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+import torch
+
+from infra.training.flow_matching.config import (
+    DATA_CONFIG,
+    FLOW_GRPO_FSDFM_CONFIG,
+    FSDFM_MODEL_CONFIG,
+)
+from infra.training.flow_matching.fsdfm_model import (
+    PolynomialConvexScheduler,
+    compute_discrete_step_log_prob,
+    generate_with_prefix_conditioning_trajectory,
+    inject_lora,
+    load_fsdfm_from_huggingface,
+    load_lora_weights,
+    save_lora_weights,
+)
+from infra.training.shared.action_parser import parse_rollout_to_actions
+from infra.training.shared.browser_env import BrowserEnvironment
+from infra.training.shared.formfactory_server import FormFactoryServer
+from infra.training.shared.online_reward import compute_online_reward
+from infra.training.shared.reward_functions import compute_grpo_advantages
+from infra.training.shared.utils import persist_checkpoint, resolve_data_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def load_prompts(file_path: str, max_samples: int = 0) -> list[dict]:
+    """Load prompts for Flow-GRPO rollouts."""
+    records = []
+    with open(file_path) as f:
+        for line in f:
+            records.append(json.loads(line))
+    if max_samples > 0:
+        records = records[:max_samples]
+    logger.info("Loaded %d prompts for FS-DFM Flow-GRPO", len(records))
+    return records
+
+
+async def train():
+    """Run FS-DFM Flow-GRPO training with browser execution."""
+    model_config = FSDFM_MODEL_CONFIG
+    grpo_config = FLOW_GRPO_FSDFM_CONFIG
+    vocab_size = model_config["vocab_size"]
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    compute_dtype = torch.bfloat16 if grpo_config.get("bf16") else torch.float16
+
+    # Load GPT-2 tokenizer (native to FS-DFM)
+    from transformers import AutoTokenizer
+
+    logger.info("Loading GPT-2 tokenizer")
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # Flow matching scheduler
+    exponent = model_config.get("scheduler_exponent", 2.0)
+    scheduler = PolynomialConvexScheduler(exponent=exponent)
+
+    # ---------------------------------------------------------------
+    # Load policy model (LoRA, from SFT checkpoint)
+    # ---------------------------------------------------------------
+    sft_checkpoint = os.environ.get("FSDFM_SFT_CHECKPOINT", "")
+    logger.info("Loading FS-DFM 1.3B policy model")
+    policy_model = load_fsdfm_from_huggingface(
+        model_config, device=device, dtype=compute_dtype
+    )
+    policy_model = inject_lora(policy_model, model_config)
+
+    if sft_checkpoint and Path(sft_checkpoint).exists():
+        logger.info("Loading SFT checkpoint: %s", sft_checkpoint)
+        lora_path = Path(sft_checkpoint) / "lora_weights.pt"
+        if lora_path.exists():
+            load_lora_weights(policy_model, str(lora_path))
+        else:
+            logger.warning(
+                "lora_weights.pt not found at %s, starting from base LoRA init",
+                lora_path,
+            )
+    elif sft_checkpoint:
+        logger.warning(
+            "SFT checkpoint not found at %s, training from base LoRA init",
+            sft_checkpoint,
+        )
+
+    # ---------------------------------------------------------------
+    # Load reference model (frozen, for KL penalty)
+    # ---------------------------------------------------------------
+    logger.info("Loading FS-DFM 1.3B reference model (frozen)")
+    ref_model = load_fsdfm_from_huggingface(
+        model_config, device=device, dtype=compute_dtype
+    )
+    ref_model = inject_lora(ref_model, model_config)
+    if sft_checkpoint and Path(sft_checkpoint).exists():
+        lora_path = Path(sft_checkpoint) / "lora_weights.pt"
+        if lora_path.exists():
+            load_lora_weights(ref_model, str(lora_path))
+    ref_model.eval()
+    for p in ref_model.parameters():
+        p.requires_grad = False
+
+    # ---------------------------------------------------------------
+    # Training data and optimizer
+    # ---------------------------------------------------------------
+    train_file = resolve_data_path(DATA_CONFIG["train_file"])
+    prompts = load_prompts(
+        train_file,
+        max_samples=DATA_CONFIG.get("max_train_samples", 0),
+    )
+
+    trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(
+        trainable_params, lr=grpo_config["learning_rate"]
+    )
+
+    group_size = grpo_config["group_size"]
+    kl_coeff = grpo_config["kl_coeff"]
+    clip_range = grpo_config["clip_range"]
+    adv_clip_max = grpo_config.get("adv_clip_max", 5.0)
+    max_seq_length = model_config["max_seq_length"]
+    num_gen_steps = grpo_config.get("num_generation_steps", 10)
+    gen_temperature = grpo_config.get("generation_temperature", 1.0)
+    action_timeout = grpo_config.get("action_timeout_s", 5.0)
+    grad_clip = grpo_config.get("grad_clip", 1.0)
+    dt = 1.0 / num_gen_steps
+
+    # ---------------------------------------------------------------
+    # Start FormFactory server and browser
+    # ---------------------------------------------------------------
+    formfactory_dir = PROJECT_ROOT / "data" / "formfactory"
+    port = grpo_config.get("formfactory_port", 5050)
+    ff_server = FormFactoryServer(formfactory_dir, port=port)
+    if not ff_server.start():
+        logger.error("Failed to start FormFactory server, aborting")
+        return
+
+    headless = grpo_config.get("browser_headless", True)
+    browser_env = await BrowserEnvironment.create(headless=headless)
+
+    logger.info(
+        "Starting FS-DFM Flow-GRPO: %d prompts, G=%d, kl=%.3f, clip=%.2f, "
+        "T_gen=%d, temp=%.1f",
+        len(prompts),
+        group_size,
+        kl_coeff,
+        clip_range,
+        num_gen_steps,
+        gen_temperature,
+    )
+
+    total_steps = 0
+    try:
+        for epoch in range(grpo_config["num_epochs"]):
+            logger.info("Epoch %d/%d", epoch + 1, grpo_config["num_epochs"])
+            epoch_rewards = []
+            epoch_kl = []
+            epoch_clipfrac = []
+
+            for i, prompt_data in enumerate(prompts):
+                instruction = prompt_data.get(
+                    "instruction", prompt_data.get("condition", "")
+                )
+                form_url = prompt_data.get("url", "")
+                ground_truth_fields = prompt_data.get("ground_truth_fields", {})
+
+                if not instruction or not form_url:
+                    logger.warning("Skipping prompt %d: missing instruction or url", i)
+                    continue
+
+                # Periodic browser restart to reset DOM indices
+                if i > 0 and i % 10 == 0:
+                    logger.info("Periodic browser restart (prompt %d)", i)
+                    await browser_env.close()
+                    browser_env = await BrowserEnvironment.create(headless=headless)
+
+                # Tokenize instruction
+                inst_enc = tokenizer(
+                    instruction,
+                    add_special_tokens=True,
+                    truncation=True,
+                    max_length=max_seq_length // 2,
+                    return_tensors="pt",
+                )
+                prefix_ids = inst_enc["input_ids"].to(device)
+                prefix_len = prefix_ids.shape[1]
+                gen_length = max(1, max_seq_length - prefix_len)
+
+                # ==========================================================
+                # Phase 1: Generate G rollouts with trajectory recording
+                # ==========================================================
+                trajectories = []
+                rollout_texts = []
+                policy_model.eval()
+                for g in range(group_size):
+                    trajectory = generate_with_prefix_conditioning_trajectory(
+                        model=policy_model,
+                        prefix_ids=prefix_ids,
+                        gen_length=gen_length,
+                        config={
+                            **model_config,
+                            "num_generation_steps": num_gen_steps,
+                        },
+                        scheduler=scheduler,
+                        temperature=gen_temperature,
+                    )
+                    trajectories.append(trajectory)
+                    # Decode only the response portion
+                    response_ids = trajectory.final_tokens[0, prefix_len:]
+                    text = tokenizer.decode(response_ids, skip_special_tokens=True)
+                    rollout_texts.append(text)
+                policy_model.train()
+
+                # ==========================================================
+                # Phase 2: Execute each rollout in browser and score
+                # ==========================================================
+                rewards = []
+                for g, rollout_text in enumerate(rollout_texts):
+                    await browser_env.reset()
+
+                    try:
+                        await browser_env.tools.navigate(
+                            url=form_url,
+                            new_tab=False,
+                            browser_session=browser_env.browser_session,
+                        )
+                        await asyncio.sleep(0.5)
+                        element_map = await browser_env.get_element_map()
+                    except Exception as e:
+                        logger.warning("Navigation failed for rollout %d: %s", g, e)
+                        rewards.append(0.0)
+                        continue
+
+                    actions = parse_rollout_to_actions(rollout_text, element_map)
+                    if not actions:
+                        logger.debug("No valid actions parsed from rollout %d", g)
+                        rewards.append(0.0)
+                        continue
+
+                    outcome = await browser_env.execute_actions(
+                        actions, timeout_per_action=action_timeout
+                    )
+                    reward = compute_online_reward(
+                        outcome,
+                        ground_truth_fields,
+                        weights=grpo_config.get("reward_weights"),
+                    )
+                    rewards.append(reward)
+
+                epoch_rewards.extend(rewards)
+
+                # ==========================================================
+                # Phase 3: Compute group-relative advantages
+                # ==========================================================
+                advantages = compute_grpo_advantages(rewards, group_size)
+                advantages_t = torch.tensor(
+                    advantages, dtype=torch.float32, device=device
+                )
+
+                # ==========================================================
+                # Phase 4: Policy gradient update over ALL trajectory steps
+                # ==========================================================
+                # Following the reference implementation (train_sd3.py), we
+                # iterate over every timestep in the trajectory and accumulate
+                # gradients before a single optimizer step.
+                optimizer.zero_grad()
+                total_loss = torch.tensor(0.0, device=device, requires_grad=False)
+                total_kl = torch.tensor(0.0, device=device)
+                total_clipfrac = 0.0
+                valid_terms = 0
+
+                for g in range(group_size):
+                    traj = trajectories[g]
+                    adv_g = torch.clamp(
+                        advantages_t[g], -adv_clip_max, adv_clip_max
+                    )
+
+                    if len(traj.steps) == 0:
+                        continue
+
+                    # Response mask from the trajectory edit_mask (float)
+                    response_mask = traj.edit_mask.float()  # [1, L]
+
+                    for step in traj.steps:
+                        # Current policy log-prob (WITH gradients)
+                        log_prob = compute_discrete_step_log_prob(
+                            model=policy_model,
+                            x_t=step.x_t,
+                            x_next=step.x_next,
+                            t_scalar=step.t_value,
+                            dt=dt,
+                            scheduler=scheduler,
+                            vocab_size=vocab_size,
+                            response_mask=response_mask,
+                        )  # [1]
+
+                        # Old policy log-prob (detached -- same weights since
+                        # we haven't updated yet for this prompt)
+                        with torch.no_grad():
+                            old_log_prob = compute_discrete_step_log_prob(
+                                model=policy_model,
+                                x_t=step.x_t,
+                                x_next=step.x_next,
+                                t_scalar=step.t_value,
+                                dt=dt,
+                                scheduler=scheduler,
+                                vocab_size=vocab_size,
+                                response_mask=response_mask,
+                            )  # [1]
+
+                        # PPO clipped surrogate loss
+                        ratio = torch.exp(log_prob - old_log_prob)  # [1]
+                        unclipped = -adv_g * ratio
+                        clipped = -adv_g * torch.clamp(
+                            ratio, 1.0 - clip_range, 1.0 + clip_range
+                        )
+                        policy_loss = torch.maximum(unclipped, clipped).mean()
+
+                        # Track clip fraction
+                        with torch.no_grad():
+                            clip_frac = (
+                                (torch.abs(ratio - 1.0) > clip_range).float().mean()
+                            )
+                            total_clipfrac += clip_frac.item()
+
+                        # KL penalty (Schulman k3: r - log(r) - 1 >= 0)
+                        kl_loss = torch.tensor(0.0, device=device)
+                        if kl_coeff > 0:
+                            with torch.no_grad():
+                                ref_log_prob = compute_discrete_step_log_prob(
+                                    model=ref_model,
+                                    x_t=step.x_t,
+                                    x_next=step.x_next,
+                                    t_scalar=step.t_value,
+                                    dt=dt,
+                                    scheduler=scheduler,
+                                    vocab_size=vocab_size,
+                                    response_mask=response_mask,
+                                )  # [1]
+                            log_r = ref_log_prob - log_prob
+                            kl_loss = (torch.exp(log_r) - log_r - 1).mean()
+                            total_kl = total_kl + kl_loss.detach()
+
+                        step_loss = policy_loss + kl_coeff * kl_loss
+                        total_loss = total_loss + step_loss
+                        valid_terms += 1
+
+                # Average loss and backprop
+                if valid_terms > 0:
+                    loss = total_loss / valid_terms
+                    if loss.requires_grad:
+                        loss.backward()
+                        torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
+                        optimizer.step()
+
+                total_steps += 1
+                avg_reward = sum(rewards) / len(rewards) if rewards else 0
+                avg_kl = (total_kl / max(valid_terms, 1)).item()
+                avg_clipfrac = total_clipfrac / max(valid_terms, 1)
+                epoch_kl.append(avg_kl)
+                epoch_clipfrac.append(avg_clipfrac)
+
+                if total_steps % grpo_config["logging_steps"] == 0:
+                    loss_val = (total_loss / max(valid_terms, 1)).item()
+                    logger.info(
+                        "  Step %d (prompt %d/%d): avg_reward=%.3f, "
+                        "loss=%.4f, kl=%.4f, clipfrac=%.3f",
+                        total_steps,
+                        i + 1,
+                        len(prompts),
+                        avg_reward,
+                        loss_val,
+                        avg_kl,
+                        avg_clipfrac,
+                    )
+
+            # Epoch summary
+            if epoch_rewards:
+                epoch_avg = sum(epoch_rewards) / len(epoch_rewards)
+                nonzero = sum(1 for r in epoch_rewards if r > 0)
+                logger.info(
+                    "Epoch %d complete: avg_reward=%.3f, "
+                    "nonzero_rewards=%d/%d, avg_kl=%.4f, avg_clipfrac=%.3f",
+                    epoch + 1,
+                    epoch_avg,
+                    nonzero,
+                    len(epoch_rewards),
+                    sum(epoch_kl) / len(epoch_kl) if epoch_kl else 0,
+                    sum(epoch_clipfrac) / len(epoch_clipfrac) if epoch_clipfrac else 0,
+                )
+
+        # Save final model
+        final_dir = Path("outputs/fsdfm_flow_grpo/final")
+        final_dir.mkdir(parents=True, exist_ok=True)
+        save_lora_weights(policy_model, str(final_dir / "lora_weights.pt"))
+        tokenizer.save_pretrained(str(final_dir))
+        logger.info("FS-DFM Flow-GRPO complete. Model saved to %s", final_dir)
+
+        persist_checkpoint(str(final_dir.parent), "fsdfm-flow-grpo")
+
+    finally:
+        await browser_env.close()
+        ff_server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(train())

--- a/infra/training/flow_matching/fsdfm_flow_grpo_trainer.py
+++ b/infra/training/flow_matching/fsdfm_flow_grpo_trainer.py
@@ -274,10 +274,18 @@ async def train():
 
                     actions = parse_rollout_to_actions(rollout_text, element_map)
                     if not actions:
-                        logger.debug("No valid actions parsed from rollout %d", g)
+                        logger.warning(
+                            "No valid actions parsed from rollout %d. "
+                            "Generated text (first 300 chars): %.300s",
+                            g, rollout_text,
+                        )
                         rewards.append(0.0)
                         continue
 
+                    logger.info(
+                        "Rollout %d: %d actions parsed. Text (first 200 chars): %.200s",
+                        g, len(actions), rollout_text,
+                    )
                     outcome = await browser_env.execute_actions(
                         actions, timeout_per_action=action_timeout
                     )
@@ -287,6 +295,12 @@ async def train():
                         weights=grpo_config.get("reward_weights"),
                     )
                     rewards.append(reward)
+                    logger.info(
+                        "Rollout %d: reward=%.3f (actions_executed=%d/%d)",
+                        g, reward,
+                        outcome.actions_executed if hasattr(outcome, 'actions_executed') else -1,
+                        len(actions),
+                    )
 
                 epoch_rewards.extend(rewards)
 

--- a/infra/training/flow_matching/refusion_flow_grpo_trainer.py
+++ b/infra/training/flow_matching/refusion_flow_grpo_trainer.py
@@ -302,10 +302,18 @@ async def train():
 
                     actions = parse_rollout_to_actions(rollout_text, element_map)
                     if not actions:
-                        logger.debug("No valid actions parsed from rollout %d", g)
+                        logger.warning(
+                            "No valid actions parsed from rollout %d. "
+                            "Generated text (first 300 chars): %.300s",
+                            g, rollout_text,
+                        )
                         rewards.append(0.0)
                         continue
 
+                    logger.info(
+                        "Rollout %d: %d actions parsed. Text (first 200 chars): %.200s",
+                        g, len(actions), rollout_text,
+                    )
                     outcome = await browser_env.execute_actions(
                         actions, timeout_per_action=action_timeout
                     )
@@ -315,6 +323,12 @@ async def train():
                         weights=grpo_config.get("reward_weights"),
                     )
                     rewards.append(reward)
+                    logger.info(
+                        "Rollout %d: reward=%.3f (actions_executed=%d/%d)",
+                        g, reward,
+                        outcome.actions_executed if hasattr(outcome, 'actions_executed') else -1,
+                        len(actions),
+                    )
 
                 epoch_rewards.extend(rewards)
 

--- a/infra/training/flow_matching/refusion_flow_grpo_trainer.py
+++ b/infra/training/flow_matching/refusion_flow_grpo_trainer.py
@@ -1,0 +1,458 @@
+"""ReFusion Flow-GRPO trainer: Masked diffusion policy gradients for ReFusion 8B.
+
+Implements Flow-GRPO (Liu et al., 2025) adapted for ReFusion's iterative
+unmasking process.  Unlike the existing online_flow_llm_grpo_trainer.py
+which uses autoregressive log-probs, this computes per-step log-probabilities
+at the positions that were actually unmasked during generation, aligning the
+policy gradient with the masked diffusion trajectory.
+
+Key innovation -- masked diffusion analog of continuous Flow-GRPO:
+    Continuous: SDE step gives Gaussian policy N(mu, sigma^2 dt I)
+                log-prob = Gaussian log-density
+    ReFusion:   Each unmasking step predicts tokens for masked positions,
+                unmasks top-k most confident.
+                log-prob = sum of log_softmax at newly-unmasked positions
+
+Architecture:
+    1. Generate G rollouts via iterative unmasking, recording trajectories
+    2. Execute rollouts in headless browser against FormFactory
+    3. Compute group-relative advantages from browser rewards
+    4. For each rollout, iterate over ALL trajectory steps (denoising reduction):
+       a. Recompute policy log-prob at newly-unmasked positions (with gradients)
+       b. Recompute old/reference log-prob (detached)
+       c. PPO-style clipped surrogate objective on per-step log-ratios
+       d. KL penalty from Schulman k3 approximation
+    5. Average loss over steps and rollouts, backprop, update LoRA params
+
+Reference: github.com/yifan123/flow_grpo (continuous version for images)
+
+Usage:
+    uv run infra/training/flow_matching/refusion_flow_grpo_trainer.py
+"""
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+
+from infra.training.flow_matching.config import (
+    DATA_CONFIG,
+    FLOW_GRPO_REFUSION_CONFIG,
+    FLOW_LLM_CONFIG,
+)
+from infra.training.flow_matching.flow_llm_model import (
+    FlowLLM,
+    compute_unmasking_step_log_prob,
+)
+from infra.training.shared.action_parser import parse_rollout_to_actions
+from infra.training.shared.browser_env import BrowserEnvironment
+from infra.training.shared.formfactory_server import FormFactoryServer
+from infra.training.shared.online_reward import compute_online_reward
+from infra.training.shared.reward_functions import compute_grpo_advantages
+from infra.training.shared.utils import persist_checkpoint, resolve_data_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def load_quantized_model(model_name: str, config: dict):
+    """Load ReFusion with 4-bit quantization."""
+    compute_dtype = (
+        torch.bfloat16
+        if config["bnb_4bit_compute_dtype"] == "bfloat16"
+        else torch.float16
+    )
+    trust_remote_code = config.get("trust_remote_code", True)
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=config["load_in_4bit"],
+        bnb_4bit_quant_type=config["bnb_4bit_quant_type"],
+        bnb_4bit_use_double_quant=config["bnb_4bit_use_double_quant"],
+        bnb_4bit_compute_dtype=compute_dtype,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        quantization_config=bnb_config,
+        device_map="auto",
+        torch_dtype=compute_dtype,
+        trust_remote_code=trust_remote_code,
+    )
+    return model
+
+
+def load_prompts(file_path: str, max_samples: int = 0) -> list[dict]:
+    """Load prompts for Flow-GRPO rollouts."""
+    records = []
+    with open(file_path) as f:
+        for line in f:
+            records.append(json.loads(line))
+    if max_samples > 0:
+        records = records[:max_samples]
+    logger.info("Loaded %d prompts for ReFusion Flow-GRPO", len(records))
+    return records
+
+
+async def train():
+    """Run ReFusion Flow-GRPO training with browser execution."""
+    model_config = FLOW_LLM_CONFIG
+    grpo_config = FLOW_GRPO_REFUSION_CONFIG
+
+    # Load tokenizer
+    trust_remote_code = model_config.get("trust_remote_code", True)
+    logger.info("Loading tokenizer: %s", model_config["model_name"])
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_config["model_name"], trust_remote_code=trust_remote_code
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # Determine if loading from SFT checkpoint
+    sft_checkpoint = os.environ.get("FLOW_LLM_SFT_CHECKPOINT", "")
+    is_peft_checkpoint = sft_checkpoint and Path(sft_checkpoint).exists()
+
+    # ---------------------------------------------------------------
+    # Load policy model with QLoRA
+    # ---------------------------------------------------------------
+    if is_peft_checkpoint:
+        logger.info("Loading SFT checkpoint: %s", sft_checkpoint)
+        base_model = load_quantized_model(model_config["model_name"], model_config)
+        base_model.config.use_cache = False
+        base_model = prepare_model_for_kbit_training(
+            base_model,
+            use_gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        )
+        policy_model = PeftModel.from_pretrained(
+            base_model, sft_checkpoint, is_trainable=True
+        )
+        policy_model.train()
+    else:
+        if sft_checkpoint:
+            logger.warning(
+                "SFT checkpoint not found at %s, training from base model",
+                sft_checkpoint,
+            )
+        logger.info("Loading base model: %s", model_config["model_name"])
+        policy_model = load_quantized_model(model_config["model_name"], model_config)
+        policy_model.config.use_cache = False
+        policy_model = prepare_model_for_kbit_training(
+            policy_model,
+            use_gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        )
+        lora_config = LoraConfig(
+            r=model_config["lora_r"],
+            lora_alpha=model_config["lora_alpha"],
+            lora_dropout=model_config["lora_dropout"],
+            target_modules=model_config["lora_target_modules"],
+            task_type="CAUSAL_LM",
+        )
+        policy_model = get_peft_model(policy_model, lora_config)
+
+    policy_model.print_trainable_parameters()
+
+    # Wrap in FlowLLM for generation
+    mask_token_id = model_config.get("mask_token_id", 151670)
+    flow_policy = FlowLLM(policy_model, tokenizer, mask_token_id=mask_token_id)
+
+    # ---------------------------------------------------------------
+    # Load reference model (frozen, for KL penalty)
+    # ---------------------------------------------------------------
+    logger.info("Loading reference model (frozen)")
+    ref_base = load_quantized_model(model_config["model_name"], model_config)
+    if is_peft_checkpoint:
+        ref_model = PeftModel.from_pretrained(ref_base, sft_checkpoint)
+    else:
+        ref_model = ref_base
+    ref_model.eval()
+    for param in ref_model.parameters():
+        param.requires_grad = False
+
+    # ---------------------------------------------------------------
+    # Training data and optimizer
+    # ---------------------------------------------------------------
+    train_file = resolve_data_path(DATA_CONFIG["train_file"])
+    prompts = load_prompts(
+        train_file,
+        max_samples=DATA_CONFIG.get("max_train_samples", 0),
+    )
+
+    trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(
+        trainable_params, lr=grpo_config["learning_rate"]
+    )
+
+    group_size = grpo_config["group_size"]
+    kl_coeff = grpo_config["kl_coeff"]
+    clip_range = grpo_config["clip_range"]
+    adv_clip_max = grpo_config.get("adv_clip_max", 5.0)
+    max_seq_length = model_config["max_seq_length"]
+    num_gen_steps = grpo_config.get("num_generation_steps", 10)
+    gen_temperature = grpo_config.get("generation_temperature", 0.7)
+    action_timeout = grpo_config.get("action_timeout_s", 5.0)
+    grad_clip = grpo_config.get("grad_clip", 1.0)
+
+    # ---------------------------------------------------------------
+    # Start FormFactory server and browser
+    # ---------------------------------------------------------------
+    formfactory_dir = PROJECT_ROOT / "data" / "formfactory"
+    port = grpo_config.get("formfactory_port", 5050)
+    ff_server = FormFactoryServer(formfactory_dir, port=port)
+    if not ff_server.start():
+        logger.error("Failed to start FormFactory server, aborting")
+        return
+
+    headless = grpo_config.get("browser_headless", True)
+    browser_env = await BrowserEnvironment.create(headless=headless)
+
+    logger.info(
+        "Starting ReFusion Flow-GRPO: %d prompts, G=%d, kl=%.3f, clip=%.2f, "
+        "T_gen=%d, temp=%.1f",
+        len(prompts),
+        group_size,
+        kl_coeff,
+        clip_range,
+        num_gen_steps,
+        gen_temperature,
+    )
+
+    total_steps = 0
+    try:
+        for epoch in range(grpo_config["num_epochs"]):
+            logger.info("Epoch %d/%d", epoch + 1, grpo_config["num_epochs"])
+            epoch_rewards = []
+            epoch_kl = []
+            epoch_clipfrac = []
+
+            for i, prompt_data in enumerate(prompts):
+                instruction = prompt_data.get(
+                    "instruction", prompt_data.get("condition", "")
+                )
+                form_url = prompt_data.get("url", "")
+                ground_truth_fields = prompt_data.get("ground_truth_fields", {})
+
+                if not instruction or not form_url:
+                    logger.warning("Skipping prompt %d: missing instruction or url", i)
+                    continue
+
+                # Periodic browser restart to reset DOM indices
+                if i > 0 and i % 10 == 0:
+                    logger.info("Periodic browser restart (prompt %d)", i)
+                    await browser_env.close()
+                    browser_env = await BrowserEnvironment.create(headless=headless)
+
+                # Tokenize condition
+                condition_enc = tokenizer(
+                    instruction,
+                    add_special_tokens=True,
+                    truncation=True,
+                    max_length=max_seq_length,
+                    return_tensors="pt",
+                ).to(flow_policy.device)
+
+                prompt_len = condition_enc["attention_mask"].sum().item()
+                gen_length = max(1, max_seq_length - prompt_len)
+
+                # ==========================================================
+                # Phase 1: Generate G rollouts with trajectory recording
+                # ==========================================================
+                trajectories = []
+                rollout_texts = []
+                policy_model.eval()
+                for g in range(group_size):
+                    trajectory = flow_policy.generate_with_trajectory(
+                        condition_ids=condition_enc["input_ids"],
+                        condition_mask=condition_enc["attention_mask"],
+                        seq_length=gen_length,
+                        num_steps=num_gen_steps,
+                        temperature=gen_temperature,
+                    )
+                    trajectories.append(trajectory)
+                    text = tokenizer.decode(
+                        trajectory.final_tokens[0], skip_special_tokens=True
+                    )
+                    rollout_texts.append(text)
+                policy_model.train()
+
+                # ==========================================================
+                # Phase 2: Execute each rollout in browser and score
+                # ==========================================================
+                rewards = []
+                for g, rollout_text in enumerate(rollout_texts):
+                    await browser_env.reset()
+
+                    try:
+                        await browser_env.tools.navigate(
+                            url=form_url,
+                            new_tab=False,
+                            browser_session=browser_env.browser_session,
+                        )
+                        await asyncio.sleep(0.5)
+                        element_map = await browser_env.get_element_map()
+                    except Exception as e:
+                        logger.warning("Navigation failed for rollout %d: %s", g, e)
+                        rewards.append(0.0)
+                        continue
+
+                    actions = parse_rollout_to_actions(rollout_text, element_map)
+                    if not actions:
+                        logger.debug("No valid actions parsed from rollout %d", g)
+                        rewards.append(0.0)
+                        continue
+
+                    outcome = await browser_env.execute_actions(
+                        actions, timeout_per_action=action_timeout
+                    )
+                    reward = compute_online_reward(
+                        outcome,
+                        ground_truth_fields,
+                        weights=grpo_config.get("reward_weights"),
+                    )
+                    rewards.append(reward)
+
+                epoch_rewards.extend(rewards)
+
+                # ==========================================================
+                # Phase 3: Compute group-relative advantages
+                # ==========================================================
+                advantages = compute_grpo_advantages(rewards, group_size)
+                advantages_t = torch.tensor(
+                    advantages, dtype=torch.float32, device=flow_policy.device
+                )
+
+                # ==========================================================
+                # Phase 4: Policy gradient update over trajectory steps
+                # ==========================================================
+                optimizer.zero_grad()
+                total_loss = torch.tensor(0.0, device=flow_policy.device, requires_grad=False)
+                total_kl = torch.tensor(0.0, device=flow_policy.device)
+                total_clipfrac = 0.0
+                valid_terms = 0
+
+                for g in range(group_size):
+                    traj = trajectories[g]
+                    adv_g = torch.clamp(
+                        advantages_t[g], -adv_clip_max, adv_clip_max
+                    )
+
+                    if len(traj.steps) == 0:
+                        continue
+
+                    for step in traj.steps:
+                        # Current policy log-prob (WITH gradients)
+                        log_prob = compute_unmasking_step_log_prob(
+                            model=policy_model,
+                            step=step,
+                            condition_length=traj.condition_length,
+                        )  # [B]
+
+                        # Old policy log-prob (detached)
+                        with torch.no_grad():
+                            old_log_prob = compute_unmasking_step_log_prob(
+                                model=policy_model,
+                                step=step,
+                                condition_length=traj.condition_length,
+                            )  # [B]
+
+                        # PPO clipped surrogate loss
+                        ratio = torch.exp(log_prob - old_log_prob)  # [B]
+                        unclipped = -adv_g * ratio
+                        clipped = -adv_g * torch.clamp(
+                            ratio, 1.0 - clip_range, 1.0 + clip_range
+                        )
+                        policy_loss = torch.maximum(unclipped, clipped).mean()
+
+                        # Track clip fraction
+                        with torch.no_grad():
+                            clip_frac = (
+                                (torch.abs(ratio - 1.0) > clip_range).float().mean()
+                            )
+                            total_clipfrac += clip_frac.item()
+
+                        # KL penalty (Schulman k3)
+                        kl_loss = torch.tensor(0.0, device=flow_policy.device)
+                        if kl_coeff > 0:
+                            with torch.no_grad():
+                                ref_log_prob = compute_unmasking_step_log_prob(
+                                    model=ref_model,
+                                    step=step,
+                                    condition_length=traj.condition_length,
+                                )  # [B]
+                            log_r = ref_log_prob - log_prob
+                            kl_loss = (torch.exp(log_r) - log_r - 1).mean()
+                            total_kl = total_kl + kl_loss.detach()
+
+                        step_loss = policy_loss + kl_coeff * kl_loss
+                        total_loss = total_loss + step_loss
+                        valid_terms += 1
+
+                # Average loss and backprop
+                if valid_terms > 0:
+                    loss = total_loss / valid_terms
+                    if loss.requires_grad:
+                        loss.backward()
+                        torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
+                        optimizer.step()
+
+                total_steps += 1
+                avg_reward = sum(rewards) / len(rewards) if rewards else 0
+                avg_kl = (total_kl / max(valid_terms, 1)).item()
+                avg_clipfrac = total_clipfrac / max(valid_terms, 1)
+                epoch_kl.append(avg_kl)
+                epoch_clipfrac.append(avg_clipfrac)
+
+                if total_steps % grpo_config["logging_steps"] == 0:
+                    loss_val = (total_loss / max(valid_terms, 1)).item()
+                    logger.info(
+                        "  Step %d (prompt %d/%d): avg_reward=%.3f, "
+                        "loss=%.4f, kl=%.4f, clipfrac=%.3f",
+                        total_steps,
+                        i + 1,
+                        len(prompts),
+                        avg_reward,
+                        loss_val,
+                        avg_kl,
+                        avg_clipfrac,
+                    )
+
+            # Epoch summary
+            if epoch_rewards:
+                epoch_avg = sum(epoch_rewards) / len(epoch_rewards)
+                nonzero = sum(1 for r in epoch_rewards if r > 0)
+                logger.info(
+                    "Epoch %d complete: avg_reward=%.3f, "
+                    "nonzero_rewards=%d/%d, avg_kl=%.4f, avg_clipfrac=%.3f",
+                    epoch + 1,
+                    epoch_avg,
+                    nonzero,
+                    len(epoch_rewards),
+                    sum(epoch_kl) / len(epoch_kl) if epoch_kl else 0,
+                    sum(epoch_clipfrac) / len(epoch_clipfrac) if epoch_clipfrac else 0,
+                )
+
+        # Save final model
+        final_dir = Path("outputs/refusion_flow_grpo/final")
+        final_dir.mkdir(parents=True, exist_ok=True)
+        policy_model.save_pretrained(str(final_dir))
+        tokenizer.save_pretrained(str(final_dir))
+        logger.info("ReFusion Flow-GRPO complete. Model saved to %s", final_dir)
+
+        persist_checkpoint(str(final_dir), "refusion-flow-grpo")
+
+    finally:
+        await browser_env.close()
+        ff_server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(train())

--- a/infra/training/flow_matching/refusion_flow_grpo_trainer.py
+++ b/infra/training/flow_matching/refusion_flow_grpo_trainer.py
@@ -19,10 +19,9 @@ Architecture:
     3. Compute group-relative advantages from browser rewards
     4. For each rollout, iterate over ALL trajectory steps (denoising reduction):
        a. Recompute policy log-prob at newly-unmasked positions (with gradients)
-       b. Recompute old/reference log-prob (detached)
-       c. PPO-style clipped surrogate objective on per-step log-ratios
-       d. KL penalty from Schulman k3 approximation
-    5. Average loss over steps and rollouts, backprop, update LoRA params
+       b. REINFORCE loss: -advantage * log_prob (per-step backward)
+       c. KL penalty from Schulman k3 approximation
+    5. Gradient accumulation across steps, single optimizer.step()
 
 Reference: github.com/yifan123/flow_grpo (continuous version for images)
 
@@ -194,7 +193,6 @@ async def train():
 
     group_size = grpo_config["group_size"]
     kl_coeff = grpo_config["kl_coeff"]
-    clip_range = grpo_config["clip_range"]
     adv_clip_max = grpo_config.get("adv_clip_max", 5.0)
     max_seq_length = model_config["max_seq_length"]
     num_gen_steps = grpo_config.get("num_generation_steps", 10)
@@ -216,12 +214,11 @@ async def train():
     browser_env = await BrowserEnvironment.create(headless=headless)
 
     logger.info(
-        "Starting ReFusion Flow-GRPO: %d prompts, G=%d, kl=%.3f, clip=%.2f, "
+        "Starting ReFusion Flow-GRPO: %d prompts, G=%d, kl=%.3f, "
         "T_gen=%d, temp=%.1f",
         len(prompts),
         group_size,
         kl_coeff,
-        clip_range,
         num_gen_steps,
         gen_temperature,
     )
@@ -232,7 +229,6 @@ async def train():
             logger.info("Epoch %d/%d", epoch + 1, grpo_config["num_epochs"])
             epoch_rewards = []
             epoch_kl = []
-            epoch_clipfrac = []
 
             for i, prompt_data in enumerate(prompts):
                 instruction = prompt_data.get(
@@ -333,11 +329,27 @@ async def train():
                 # ==========================================================
                 # Phase 4: Policy gradient update over trajectory steps
                 # ==========================================================
+                # REINFORCE with per-step gradient accumulation. We backward()
+                # after each step to release activation memory immediately,
+                # preventing OOM from accumulated autograd graphs.
+                #
+                # Note: old_log_prob was removed because with a single
+                # optimization step per prompt, the policy weights are
+                # identical when computing log_prob and old_log_prob, making
+                # ratio = exp(0) = 1.0 always (PPO clipping has no effect).
                 optimizer.zero_grad()
-                total_loss = torch.tensor(0.0, device=flow_policy.device, requires_grad=False)
-                total_kl = torch.tensor(0.0, device=flow_policy.device)
-                total_clipfrac = 0.0
+                total_loss_val = 0.0
+                total_kl_val = 0.0
                 valid_terms = 0
+
+                # Count total terms for loss normalization
+                for g in range(group_size):
+                    traj = trajectories[g]
+                    if len(traj.steps) > 0:
+                        valid_terms += len(traj.steps)
+
+                if valid_terms == 0:
+                    valid_terms = 1  # avoid division by zero
 
                 for g in range(group_size):
                     traj = trajectories[g]
@@ -356,28 +368,8 @@ async def train():
                             condition_length=traj.condition_length,
                         )  # [B]
 
-                        # Old policy log-prob (detached)
-                        with torch.no_grad():
-                            old_log_prob = compute_unmasking_step_log_prob(
-                                model=policy_model,
-                                step=step,
-                                condition_length=traj.condition_length,
-                            )  # [B]
-
-                        # PPO clipped surrogate loss
-                        ratio = torch.exp(log_prob - old_log_prob)  # [B]
-                        unclipped = -adv_g * ratio
-                        clipped = -adv_g * torch.clamp(
-                            ratio, 1.0 - clip_range, 1.0 + clip_range
-                        )
-                        policy_loss = torch.maximum(unclipped, clipped).mean()
-
-                        # Track clip fraction
-                        with torch.no_grad():
-                            clip_frac = (
-                                (torch.abs(ratio - 1.0) > clip_range).float().mean()
-                            )
-                            total_clipfrac += clip_frac.item()
+                        # REINFORCE policy loss (ratio=1 simplification)
+                        policy_loss = (-adv_g * log_prob).mean()
 
                         # KL penalty (Schulman k3)
                         kl_loss = torch.tensor(0.0, device=flow_policy.device)
@@ -390,39 +382,35 @@ async def train():
                                 )  # [B]
                             log_r = ref_log_prob - log_prob
                             kl_loss = (torch.exp(log_r) - log_r - 1).mean()
-                            total_kl = total_kl + kl_loss.detach()
+                            total_kl_val += kl_loss.detach().item()
 
-                        step_loss = policy_loss + kl_coeff * kl_loss
-                        total_loss = total_loss + step_loss
-                        valid_terms += 1
+                        step_loss = (policy_loss + kl_coeff * kl_loss) / valid_terms
+                        # Per-step backward to release activations immediately
+                        step_loss.backward()
+                        total_loss_val += step_loss.detach().item()
 
-                # Average loss and backprop
-                if valid_terms > 0:
-                    loss = total_loss / valid_terms
-                    if loss.requires_grad:
-                        loss.backward()
-                        torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
-                        optimizer.step()
+                # Clip gradients and step
+                if total_loss_val != 0.0:
+                    torch.nn.utils.clip_grad_norm_(trainable_params, grad_clip)
+                    optimizer.step()
+
+                torch.cuda.empty_cache()
 
                 total_steps += 1
                 avg_reward = sum(rewards) / len(rewards) if rewards else 0
-                avg_kl = (total_kl / max(valid_terms, 1)).item()
-                avg_clipfrac = total_clipfrac / max(valid_terms, 1)
+                avg_kl = total_kl_val / max(valid_terms, 1)
                 epoch_kl.append(avg_kl)
-                epoch_clipfrac.append(avg_clipfrac)
 
                 if total_steps % grpo_config["logging_steps"] == 0:
-                    loss_val = (total_loss / max(valid_terms, 1)).item()
                     logger.info(
                         "  Step %d (prompt %d/%d): avg_reward=%.3f, "
-                        "loss=%.4f, kl=%.4f, clipfrac=%.3f",
+                        "loss=%.4f, kl=%.4f",
                         total_steps,
                         i + 1,
                         len(prompts),
                         avg_reward,
-                        loss_val,
+                        total_loss_val,
                         avg_kl,
-                        avg_clipfrac,
                     )
 
             # Epoch summary
@@ -431,13 +419,12 @@ async def train():
                 nonzero = sum(1 for r in epoch_rewards if r > 0)
                 logger.info(
                     "Epoch %d complete: avg_reward=%.3f, "
-                    "nonzero_rewards=%d/%d, avg_kl=%.4f, avg_clipfrac=%.3f",
+                    "nonzero_rewards=%d/%d, avg_kl=%.4f",
                     epoch + 1,
                     epoch_avg,
                     nonzero,
                     len(epoch_rewards),
                     sum(epoch_kl) / len(epoch_kl) if epoch_kl else 0,
-                    sum(epoch_clipfrac) / len(epoch_clipfrac) if epoch_clipfrac else 0,
                 )
 
         # Save final model


### PR DESCRIPTION
## Summary

- Implement Flow-GRPO (Liu et al., 2025) for two diffusion language models: FS-DFM 1.3B (discrete Poisson flow) and ReFusion 8B (masked diffusion). Extends GRPO-style policy gradient optimization from autoregressive LLMs to flow/diffusion-based language models.
- Add stratified train/val/test split (992/124/124, seed=42) for FormFactory dataset.
- Fix all 10 training configs to use the full 992-sample train split.
- Systematic debugging across 18 Flow-GRPO versions (v1-v13, v15-v18) with comprehensive findings on diffusion model fragility under token-level online RL.
- **NEW (v19): Implement ESPO (ELBO-based Sequence-Level Policy Optimization)** for both models -- replaces token-level per-step REINFORCE with sequence-level ELBO importance ratios.

## Key Results

### GRPO vs SFT: Controlled Evaluation (16 comparisons, val+test, n=124 each)

| Model | GRPO Config | Split | SFT | GRPO | Delta pp | Delta % Rwd |
|-------|------------|-------|-----|------|----------|-------------|
| FS-DFM | v13 DCE | val | 77.4%/0.160 | 73.4%/0.166 | -4.0 | +3.8 |
| FS-DFM | v13 DCE | **test** | 68.5%/0.146 | **73.4%/0.159** | **+4.9** | **+8.9** |
| FS-DFM | v16 GDPO | val | 77.4%/0.160 | 72.6%/0.151 | -4.8 | -5.4 |
| FS-DFM | v16 GDPO | test | 68.5%/0.146 | 65.3%/0.143 | -3.2 | -2.3 |
| FS-DFM | v17 wd1+k2 | val | 77.4%/0.160 | 62.1%/0.129 | -15.3 | -19.4 |
| FS-DFM | v17 wd1+k2 | test | 68.5%/0.146 | 67.7%/0.145 | -0.8 | -0.7 |
| FS-DFM | v18 mu=1 | val | 77.4%/0.160 | 71.0%/0.150 | -6.4 | -6.3 |
| FS-DFM | v18 mu=1 | **test** | 68.5%/0.146 | **70.2%/0.148** | **+1.7** | **+1.4** |
| ReFusion | v13 (kl=0) | val | 62.9%/0.255 | 58.1%/0.242 | -4.8 | -5.1 |
| ReFusion | v13 (kl=0) | test | 60.5%/0.267 | 55.6%/0.233 | -4.9 | -12.7 |
| ReFusion | v15 (kl=0.04) | val | 62.9%/0.255 | 58.1%/0.245 | -4.8 | -4.0 |
| ReFusion | v15 (kl=0.04) | test | 60.5%/0.267 | 57.3%/0.250 | -3.2 | -6.5 |
| ReFusion | v17 wd1+k2 | val | 62.9%/0.255 | 45.2%/0.171 | -17.7 | -32.9 |
| ReFusion | v17 wd1+k2 | test | 60.5%/0.267 | 42.7%/0.143 | -17.8 | -46.4 |
| ReFusion | v18 mu=1 | val | 62.9%/0.255 | 57.3%/0.253 | -5.6 | -0.8 |
| ReFusion | v18 mu=1 | test | 60.5%/0.267 | 54.8%/0.264 | -5.7 | -1.1 |

**14/16 show degradation.** Only FS-DFM v13 (+4.9pp) and v18 (+1.7pp) on test improve -- neither generalizes across splits or models.

### Key Findings

1. **Token-level diffu-GRPO is fundamentally fragile**: All 18 iterations collapse in step 40-55 regardless of architecture, loss, KL (0-0.04), variance reduction (GDPO), or state-of-the-art stabilization (wd1+k2+multi-epoch+ref reset).
2. **v17 train-eval gap confirmed by v18 ablation**: v18 (mu=1) removes only multi-epoch from v17 and dramatically recovers eval (FS-DFM +8.9pp val, ReFusion +12.1pp test vs v17), confirming mu>1 as the cause.
3. **Token-level improvements are neutral at mu=1**: v18 (wd1+k2, mu=1) is roughly comparable to v13 (neither wd1 nor k2), exhausting the token-level solution space.
4. **ESPO paradigm shift (v19, implemented)**: Sequence-level ELBO importance ratios replace token-level per-step REINFORCE. ESPO achieves +62pp on Countdown (LLaDA-8B). Pending evaluation on FormFactory.

### v19 ESPO Implementation

- `espo_refusion_trainer.py`: ReFusion ESPO -- ELBO via random re-masking, k2 KL, coupled perturbation
- `espo_fsdfm_trainer.py`: FS-DFM ESPO -- ELBO via GKL loss as variational proxy, same sequence-level framework
- Hyperparameters: G=4, lr=1e-5, beta=3e-3, eps=0.2, mu=1, M=2 MC samples, T=64 gen steps
- Anyscale job configs for both training + eval

### Full-data SFT Baselines (n=124, test split)

| Model | Nonzero Rate | Avg Reward |
|-------|-------------|------------|
| Qwen3-8B SFT (AR) | 96.8% | 0.456 |
| FS-DFM 1.3B SFT | 68.5% | 0.146 |
| ReFusion 8B SFT | 60.5% | 0.267 |

## Files Changed

**New ESPO implementations (v19):**
- `flow_matching/espo_refusion_trainer.py` -- ReFusion ESPO (masked diffusion ELBO)
- `flow_matching/espo_fsdfm_trainer.py` -- FS-DFM ESPO (GKL-based ELBO proxy)
- `flow_matching/config.py` -- ESPO_REFUSION_CONFIG, ESPO_FSDFM_CONFIG
- 4 Anyscale job configs (2 training + 2 eval)

**Existing Flow-GRPO (v1-v18):**
- `flow_matching/fsdfm_flow_grpo_trainer.py` -- FS-DFM Flow-GRPO trainer
- `flow_matching/refusion_flow_grpo_trainer.py` -- ReFusion Flow-GRPO trainer
- `flow_matching/flow_llm_model.py` -- FlowLLM model with trajectory generation
- `flow_matching/config.py` -- All v13-v18 config with env-var overrides
- Anyscale job configs for Flow-GRPO training + eval

**Training pipeline improvements:**
- `shared/formfactory_preprocessor.py` -- stratified train/val/test split
- All training/eval YAML configs updated for proper data splits
- Early stopping, dataset shuffling, zero-reward batch skipping
- wd1 bidirectional weighting, k2 KL estimator, multi-epoch, reference resets

## Test plan

- [x] All 3 SFT re-training jobs complete on full 992 train split
- [x] v1-v9: CTMC log-prob GRPO fails for FS-DFM (0% across 9 versions)
- [x] v10: Normalization fix recovers AR GRPO but diffusion still collapses
- [x] v11 DCE: First-ever nonzero FS-DFM GRPO rewards
- [x] v12: kl=0 still collapses, ruling out KL as cause
- [x] v13: Shuffling + early stop + zero-reward skip produce first evaluable checkpoints
- [x] v13 2x2 cross-split eval: FS-DFM +4.9pp test, -4.0pp val; ReFusion -4.8pp/-4.9pp
- [x] v15: kl=0.04 produces identical dynamics to v13 kl=0 (KL has no effect)
- [x] v16: GDPO variance reduction degrades both splits (variance is not the problem)
- [x] v17: wd1+k2+mu+ref reset -- competitive training, worst eval (train-eval gap)
- [x] v18: mu=1 ablation confirms multi-epoch as cause of v17 degradation
- [x] v18 eval: 16 controlled comparisons, 14/16 degradation exhausts token-level paradigm
- [ ] v19 ESPO training: run espo-refusion and espo-fsdfm jobs
- [ ] v19 ESPO eval: run eval-espo-refusion and eval-espo-fsdfm on val+test splits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Flow-GRPO and ESPO training for FS-DFM 1.3B and ReFusion 8B, with exact trajectory log-probs, sequence-level ELBO, and end-to-end Anyscale train/eval jobs on FormFactory. Improves training stability and fixes dataset/runtime issues.

- **New Features**
  - Flow-GRPO trainers for FS-DFM and ReFusion with exact per-step trajectory log-probs (Poisson jumps, masked diffusion), PPO clipping, and KL; added FLOW_GRPO_FSDFM/REFUSION configs.
  - ESPO trainers for both models (sequence-level ELBO, k2 KL, PPO-style clipping) with env-driven hyperparameters.
  - Trajectory recording + step log-prob primitives in FS-DFM and FlowLLM (UnmaskingTrajectory); new Anyscale jobs for train and eval across Flow-GRPO and ESPO.

- **Bug Fixes**
  - Add git to containers and download FormFactory at runtime in all train/eval jobs.
  - VRAM/NaN stability: float32 softmax, NaN-safe multinomial, delete large tensors early, remove redundant old_log_prob, per-step backward, CPU swap for FS-DFM ref model; added debug logs for unparseable outputs.
  - Stratified train/val/test split and configs fixed to use the full 992-sample train set.

<sup>Written for commit 662a7d61133ea23835d4831df4862dce22672c69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Flow-GRPO and ESPO training approaches for FSDFM and ReFusion models
  * Introduced new training and evaluation job configurations for multiple model variants
  * Enhanced training pipelines with automatic dataset pre-loading

* **Chores**
  * Updated container environments with additional system dependencies
  * Expanded job submission registry with new training workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->