### PR TITLE
chore: remove unused env vars and fix comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ export AWS_DEFAULT_REGION="us-west-2"
 # Azure OpenAI
 export AZURE_OPENAI_API_KEY="..."
 export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
-
-# Browser-Use LLM (external service)
-export BROWSER_USE_API_KEY="..."
 ```
 
 ### BrowserProfile Options

--- a/backend/env.example
+++ b/backend/env.example
@@ -22,7 +22,6 @@ MAX_CONCURRENT_AGENTS=10
 # DATABASE_ECHO=false
 
 # LLM API Keys (set these for the agents to work)
-# BROWSER_USE_API_KEY=your_browser_use_key
 # OPENAI_API_KEY=your_openai_key
 # ANTHROPIC_API_KEY=your_anthropic_key
 # GOOGLE_API_KEY=your_google_key

--- a/examples/ui/command_line.py
+++ b/examples/ui/command_line.py
@@ -17,7 +17,7 @@ import asyncio
 import os
 import sys
 
-# Ensure local repository (browser_use) is accessible
+# Ensure local repository (openbrowser) is accessible
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- Removed unused BROWSER_USE_API_KEY from README env vars section and backend/env.example
- Fixed stale comment in examples/ui/command_line.py to match project name

## Test plan
- [ ] Verify no code references the removed env var

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused BROWSER_USE_API_KEY env var from README and backend/env.example. Also fixed a stale comment in examples/ui/command_line.py to use the correct project name.

<sup>Written for commit 8ad7b217ff88c31313c90f2d0033785231574d49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined configuration documentation by removing external API key references
  * Updated repository name references in code comments for improved accuracy

* **Chores**
  * Removed outdated example API key entries from environment setup files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->