### PR TITLE
fix: resolve merge conflict markers in service.py

### DIFF
--- a/src/openbrowser/tools/service.py
+++ b/src/openbrowser/tools/service.py
@@ -1447,11 +1447,7 @@ class CodeAgentTools(Tools[Context]):
 			'Complete task.',
 			param_model=DoneAction,
 		)
-<<<<<<< HEAD
 		async def done(params: DoneAction, file_system: FileSystem | None = None):
-=======
-		async def done(params: DoneAction, file_system: FileSystem = None):
->>>>>>> origin/main
 			user_message = params.text
 
 			len_text = len(params.text)


### PR DESCRIPTION
## Summary

- Remove unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from `src/openbrowser/tools/service.py:1450`
- Retain `FileSystem | None` union syntax (Python 3.10+, project requires 3.12+)

## Test plan

- [x] CI should pass (the ImportError at conftest.py load is resolved)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed merge conflict markers in src/openbrowser/tools/service.py to fix a syntax error. Kept the FileSystem | None union for the done() parameter to match Python 3.12 and unblock CI.

<sup>Written for commit 3f19a8d2d0133a207e6db0c772395d8c90bd2638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined type definitions in the code agent tools module for improved type consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->