### PR TITLE
fix(readme): remove production deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,10 +517,6 @@ uv run python benchmarks/cdp_benchmark.py            # Chrome DevTools MCP
 
 Results are written to `benchmarks/*_results.json`. See [full comparison](https://docs.openbrowser.me/comparison) for methodology.
 
-## Production deployment
-
-AWS production infrastructure (VPC, EC2 backend, API Gateway, Cognito, DynamoDB, ECR, S3 + CloudFront) is defined in Terraform. See **[infra/production/terraform/README.md](infra/production/terraform/README.md)** for architecture, prerequisites, and step-by-step deploy (ECR -> build/push image -> `terraform apply`).
-
 ## Contributing
 
 Contributions are welcome! Please:


### PR DESCRIPTION
## Summary
- Remove production deployment section from README that references infra/production/ (only exists on csc490 remote)

## Test plan
- [ ] Verify README no longer references infra/production paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Production deployment” section from the README that referenced infra/production/, which only exists on the csc490 remote. This removes a broken link and prevents confusion in the origin repo.

<sup>Written for commit d37dd82d314f82858d122c3e089aa5acce86e34d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed production deployment documentation section from README, including references to AWS production infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->