### PR TITLE
docs(readme): update Walmart scraping demo video URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 **Automating Walmart Product Scraping:**
 
-https://github.com/user-attachments/assets/ae5d74ce-0ac6-46b0-b02b-ff5518b4b20d
-
+https://github.com/user-attachments/assets/c517c739-9199-47b0-bac7-c2c642a21094
 
 **OpenBrowserAI Automatic Flight Booking:**
 


### PR DESCRIPTION
## Summary
- Update Walmart scraping demo video link in README

## Test plan
- [ ] Verify video link loads correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README to replace the Walmart scraping demo video with the new GitHub asset URL. Ensures the demo link loads correctly.

<sup>Written for commit 333358e576d97b09375fbd0e86621b37da41d8d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated asset reference to ensure correct external resource loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->