### PR TITLE
fix(code-agent): handle index=None in action wrapper

### DIFF
--- a/src/openbrowser/code_use/namespace.py
+++ b/src/openbrowser/code_use/namespace.py
@@ -560,6 +560,15 @@ def create_namespace(
 						if i < len(field_names):
 							kwargs[field_names[i]] = arg
 
+				# Guard: catch index=None before Pydantic validation for a clear error
+				if 'index' in kwargs and kwargs['index'] is None:
+					field_info = par_model.model_fields.get('index')
+					if field_info and field_info.is_required():
+						raise ValueError(
+							f'{act_name}() requires a valid element index, got index=None. '
+							f'Read the current browser state and use an [i_N] index from the DOM tree.'
+						)
+
 				# Create params from kwargs
 				try:
 					params = par_model(**kwargs)

--- a/src/openbrowser/code_use/system_prompt.md
+++ b/src/openbrowser/code_use/system_prompt.md
@@ -564,6 +564,7 @@ await done(text=final_summary, success=True, files_to_display=['products.json'])
 7. Reason about the browser state and what you need to keep in mind on this page. E.g. popups, dynamic content, closed shadow DOM, iframes, scroll to load more...
 8. If selectors fail, simply try different once. Print many and then try different strategies.
 9. **NEVER put N/A or empty string in results** - You must extract the information fully. If data is missing, try alternative selectors or approaches. Only report missing data if truly unavailable after multiple attempts.
+10. **NEVER pass index=None** to click(), input_text(), or other element actions. Always read the browser state first and use actual `[i_N]` indices from the DOM tree.
 ---
 
 ## Available Libraries


### PR DESCRIPTION
## Summary
- Add pre-validation guard in namespace.py action wrapper that catches `index=None` for required-index actions (click, input_text, etc.) and returns a clear, actionable error message instead of raw Pydantic ValidationError
- Add critical rule #10 to system_prompt.md preventing LLM from generating `index=None`

## Test plan
- [x] Verified `is_required()` correctly distinguishes required vs Optional index fields
- [x] Tested guard fires for `input_text(index=None)` with clear error message
- [x] Tested guard skips `scroll(index=None)` (Optional field)
- [x] Tested guard skips valid integer indices
- [x] Tested guard skips when index kwarg not provided
- [x] Module imports succeed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pre-validation guard in action_wrapper to catch index=None on actions that require an index and return a clear error instead of a Pydantic ValidationError. Also add a system prompt rule to never pass index=None and to use real [i_N] indices from the DOM.

<sup>Written for commit e3b757750c90ea6293cc7316ba0771ab2174721d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid element indices with clearer error messages.

* **Documentation**
  * Updated guidance on proper element index usage in element actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->