### PR TITLE
chore(docker): bump openbrowser version to 0.1.27

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,7 +50,7 @@ RUN cd backend && uv pip install -e . --system
 COPY pyproject.toml .
 COPY src/ src/
 COPY README.md .
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.26
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.27
 RUN uv pip install -e . --system
 
 # Install python-xlib for the X11 key grabber daemon (kiosk security)


### PR DESCRIPTION
## Summary
- Bump SETUPTOOLS_SCM_PRETEND_VERSION from 0.1.26 to 0.1.27 in backend Dockerfile to match latest PyPI release

## Test plan
- [x] Backend deployed and health check passed with this image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump SETUPTOOLS_SCM_PRETEND_VERSION to 0.1.27 in the backend Dockerfile to match the latest PyPI release and include the index=None guard fix.

<sup>Written for commit 6673c445703e2a18ea7fa3e5fdca3010d1b77114. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service version to 0.1.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->