### PR TITLE
fix(browser): add per-request timeout to CDP polling

### DIFF
--- a/src/openbrowser/browser/watchdogs/local_browser_watchdog.py
+++ b/src/openbrowser/browser/watchdogs/local_browser_watchdog.py
@@ -387,11 +387,12 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		import aiohttp
 
 		start_time = asyncio.get_event_loop().time()
+		request_timeout = aiohttp.ClientTimeout(total=2)
 
 		while asyncio.get_event_loop().time() - start_time < timeout:
 			try:
 				async with aiohttp.ClientSession() as session:
-					async with session.get(f'http://localhost:{port}/json/version') as resp:
+					async with session.get(f'http://localhost:{port}/json/version', timeout=request_timeout) as resp:
 						if resp.status == 200:
 							# Chrome is ready
 							return f'http://localhost:{port}/'
@@ -399,7 +400,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 							# Chrome is starting up and returning 502/500 errors
 							await asyncio.sleep(0.1)
 			except Exception:
-				# Connection error - Chrome might not be ready yet
+				# Connection error or request timeout - Chrome might not be ready yet
 				await asyncio.sleep(0.1)
 
 		raise TimeoutError(f'Browser did not start within {timeout} seconds')


### PR DESCRIPTION
## Summary
- Add 2-second per-request timeout to `_wait_for_cdp_url()` CDP polling in `local_browser_watchdog.py`
- Fixes race condition where Chrome accepts TCP connections before its HTTP handler is ready, causing `BrowserStartEvent timed out after 30.0s`
- Reproduces on Ubuntu 24.04 with aiohttp 3.13.3 and both Playwright Chromium and system Chrome

## Root cause
`session.get()` had no per-request timeout. When Chrome binds the port but can't serve HTTP yet, the first aiohttp GET hangs indefinitely (default 300s timeout). The 30-second bus event timeout fires on that single stuck request, cancels the handler chain, and kills the browser launch.

## Test plan
- [x] Verified fix on Ubuntu 24.04 with Playwright Chromium 145.0.7632.6
- [ ] Verify CDP connects on first or second retry with the 2s timeout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 2-second per-request timeout to CDP polling in _wait_for_cdp_url so stuck requests fail fast and the browser launch doesn’t hit the 30s timeout. This prevents a race where Chrome accepts TCP before its HTTP handler is ready.

- **Bug Fixes**
  - Set aiohttp ClientTimeout(total=2) on GET /json/version during CDP polling.
  - Retries quickly instead of hanging up to 300s, avoiding “BrowserStartEvent timed out” on affected Linux setups.

<sup>Written for commit 01dfac189f61d6420f7615276d93f57f20293d8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser readiness detection with timeout handling and enhanced error messaging to better indicate browser initialization status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->