### PR TITLE
chore(docker): bump openbrowser version to 0.1.28

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,7 +50,7 @@ RUN cd backend && uv pip install -e . --system
 COPY pyproject.toml .
 COPY src/ src/
 COPY README.md .
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.27
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.28
 RUN uv pip install -e . --system
 
 # Install python-xlib for the X11 key grabber daemon (kiosk security)


### PR DESCRIPTION
## Summary
- Bump `SETUPTOOLS_SCM_PRETEND_VERSION` from 0.1.27 to 0.1.28 in Dockerfile
- Accompanies the CDP timeout fix from PR #83

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update backend Dockerfile to use OpenBrowser 0.1.28 via SETUPTOOLS_SCM_PRETEND_VERSION. Ensures the image includes the CDP timeout fix from PR #83.

<sup>Written for commit efbec41e7ab01ef2200243fc682b3388c36e246d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

