### PR TITLE
chore(docker): bump openbrowser version to 0.1.29

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,7 +50,7 @@ RUN cd backend && uv pip install -e . --system
 COPY pyproject.toml .
 COPY src/ src/
 COPY README.md .
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.28
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.29
 RUN uv pip install -e . --system
 
 # Install python-xlib for the X11 key grabber daemon (kiosk security)


### PR DESCRIPTION
## Summary
- Bump `SETUPTOOLS_SCM_PRETEND_VERSION` from 0.1.28 to 0.1.29 in backend Dockerfile to match the latest PyPI release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated backend Dockerfile to set SETUPTOOLS_SCM_PRETEND_VERSION to 0.1.29, matching the latest OpenBrowser release on PyPI. Ensures Docker builds report the correct package version.

<sup>Written for commit 71878aea1410160f923ef89a2c00967277fb1d7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration version to 0.1.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->