### PR TITLE
docs(readme): add PyPI monthly downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://github.com/user-attachments/assets/632128f6-3d09-497f-9e7d-e29b9cb65e0f
 
 
 [![PyPI version](https://badge.fury.io/py/openbrowser-ai.svg)](https://pypi.org/project/openbrowser-ai/)
+[![Downloads](https://img.shields.io/pypi/dm/openbrowser-ai?color=brightgreen&label=downloads)](https://pepy.tech/projects/openbrowser-ai)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Tests](https://github.com/billy-enrizky/openbrowser-ai/actions/workflows/test.yml/badge.svg)](https://github.com/billy-enrizky/openbrowser-ai/actions)


### PR DESCRIPTION
## Summary
- Add dynamic PyPI monthly downloads badge (shields.io) linking to pepy.tech stats
- Currently showing 3,000+ monthly downloads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dynamic PyPI monthly downloads badge to the README to highlight package usage. The badge uses shields.io and links to pepy.tech stats, displayed alongside existing badges.

<sup>Written for commit d3346a73afa9648927ce0de1a4998f56bd27f247. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a downloads badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->