### PR TITLE
fix(ci): correct mcp-publisher download URL and DNS auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,8 +93,9 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -sSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher-linux-amd64 -o mcp-publisher
+          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
           chmod +x mcp-publisher
+          ./mcp-publisher --help
 
       - name: Update server.json version
         run: |
@@ -112,7 +113,7 @@ jobs:
           cat server.json
 
       - name: Authenticate to MCP Registry
-        run: ./mcp-publisher login github-oidc
+        run: ./mcp-publisher login dns --domain=openbrowser.me --private-key=${{ secrets.MCP_DNS_PRIVATE_KEY }}
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary

- Fix mcp-publisher binary download URL: `mcp-publisher_linux_amd64.tar.gz` (tarball with underscores), not `mcp-publisher-linux-amd64` (raw binary with hyphens)
- Switch from `github-oidc` auth (gives `io.github.*` namespace) to DNS auth with `MCP_DNS_PRIVATE_KEY` secret for `me.openbrowser/*` namespace

## Test plan

- [ ] Re-run publish workflow after merge to verify mcp-publisher installs correctly
- [ ] Verify DNS auth succeeds with the stored secret

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish workflow by installing the correct `mcp-publisher` build and switching registry auth to DNS for the `me.openbrowser/*` namespace. This unblocks installs and ensures publishes land under the right domain.

- **Bug Fixes**
  - Download and extract `mcp-publisher_linux_amd64.tar.gz`, then verify with `--help`.
  - Replace `github-oidc` login with `dns --domain=openbrowser.me --private-key=${{ secrets.MCP_DNS_PRIVATE_KEY }}` to avoid the `io.github.*` namespace.

<sup>Written for commit 1009d35dd81bd1b909e26f27b2e68c8c5b3d588f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment workflow to use an updated extraction and authentication process for the publishing tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->