### PR TITLE
fix(mcp): add mcp-name for registry ownership, bump to 0.1.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ https://github.com/user-attachments/assets/632128f6-3d09-497f-9e7d-e29b9cb65e0f
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Tests](https://github.com/billy-enrizky/openbrowser-ai/actions/workflows/test.yml/badge.svg)](https://github.com/billy-enrizky/openbrowser-ai/actions)
 
+<!-- mcp-name: me.openbrowser/openbrowser-ai -->
+
 **AI-powered browser automation using CodeAgent and CDP (Chrome DevTools Protocol)**
 
 OpenBrowser is a framework for intelligent browser automation. It combines direct CDP communication with a CodeAgent architecture, where the LLM writes Python code executed in a persistent namespace, to navigate, interact with, and extract information from web pages autonomously.

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/billy-enrizky/openbrowser-ai.git",
     "source": "github"
   },
-  "version": "0.1.30",
+  "version": "0.1.31",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "openbrowser-ai",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- Add `mcp-name: me.openbrowser/openbrowser-ai` HTML comment to README.md (required by MCP registry for PyPI package ownership validation)
- Bump server.json version to 0.1.31

## Context

MCP registry rejected v0.1.30 publish because the PyPI README didn't contain the required `mcp-name` metadata. This is a one-time requirement for establishing the link between the PyPI package and the MCP registry namespace.

## Test plan

- [ ] Release v0.1.31 triggers PyPI publish with updated README
- [ ] `mcp-publisher publish` succeeds after PyPI has v0.1.31

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mcp-name: me.openbrowser/openbrowser-ai` to the README so the MCP registry can verify ownership of the `openbrowser-ai` PyPI package. Bumps version to 0.1.31 in server.json and for the PyPI publish.

- **Migration**
  - Publish 0.1.31 to PyPI so the README includes the metadata.
  - After PyPI has 0.1.31, run `mcp-publisher publish`.

<sup>Written for commit b3b9be3d698734c39a1ba0fa074587632c86d90e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

