### PR TITLE
ci: auto-sync Claude Code plugin version on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,3 +117,43 @@ jobs:
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+  sync-plugin-version:
+    name: Sync Claude Code Plugin Version
+    needs: publish-to-pypi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update plugin version to match release
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          python3 -c "
+          import json
+          path = 'plugin/.claude-plugin/plugin.json'
+          with open(path) as f:
+              data = json.load(f)
+          if data['version'] != '${VERSION}':
+              data['version'] = '${VERSION}'
+              with open(path, 'w') as f:
+                  json.dump(data, f, indent=2)
+                  f.write('\n')
+              print(f'Updated plugin version to ${VERSION}')
+          else:
+              print(f'Plugin already at ${VERSION}, no update needed')
+          "
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugin/.claude-plugin/plugin.json
+          git diff --cached --quiet && echo "No changes to commit" || \
+            git commit -m "chore(plugin): sync version to ${GITHUB_REF_NAME#v}" && \
+            git push origin main

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openbrowser",
-  "version": "0.6.0",
+  "version": "0.1.31",
   "description": "AI-powered browser automation -- lets Claude control real web browsers to navigate, click, type, extract content, and automate workflows",
   "author": {
     "name": "OpenBrowser Team",


### PR DESCRIPTION
## Summary

- Add `sync-plugin-version` job to publish workflow that auto-updates `plugin/.claude-plugin/plugin.json` to match the release tag after PyPI publish
- Align plugin version from independent scheme (0.6.0) to match package version (0.1.31)

Users who install the OpenBrowser plugin via Claude Code marketplace will now always get the plugin version matching the latest PyPI release. No more drift between package capabilities and plugin skills.

## How it works

On every GitHub release:
1. PyPI publish completes
2. New `sync-plugin-version` job checks out `main`
3. Updates `plugin.json` version to match the release tag
4. Commits and pushes back to `main` (no-op if already in sync)

## Test plan

- [x] Verify workflow YAML is valid
- [x] Next release (v0.1.32+) should auto-commit plugin version bump to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-sync the Claude Code plugin version with PyPI releases to prevent drift. Also align the plugin to `0.1.31` to match the current package.

- **New Features**
  - Add `sync-plugin-version` job to the publish workflow: on `release`, after `publish-to-pypi`, update `plugin/.claude-plugin/plugin.json` to the release tag and commit to `main` (no-op if already in sync).

<sup>Written for commit f330ba8473a51c52381a3808e89a5a9cc729f9d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 0.1.31

<!-- end of auto-generated comment: release notes by coderabbit.ai -->