### PR TITLE
fix: replace undeclared aiohttp with httpx in CDP polling

### DIFF
--- a/src/openbrowser/browser/watchdogs/local_browser_watchdog.py
+++ b/src/openbrowser/browser/watchdogs/local_browser_watchdog.py
@@ -384,24 +384,23 @@ class LocalBrowserWatchdog(BaseWatchdog):
 	@staticmethod
 	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
 		"""Wait for the browser to start and return the CDP URL."""
-		import aiohttp
+		import httpx
 
 		start_time = asyncio.get_event_loop().time()
-		request_timeout = aiohttp.ClientTimeout(total=2)
 
-		while asyncio.get_event_loop().time() - start_time < timeout:
-			try:
-				async with aiohttp.ClientSession() as session:
-					async with session.get(f'http://localhost:{port}/json/version', timeout=request_timeout) as resp:
-						if resp.status == 200:
-							# Chrome is ready
-							return f'http://localhost:{port}/'
-						else:
-							# Chrome is starting up and returning 502/500 errors
-							await asyncio.sleep(0.1)
-			except Exception:
-				# Connection error or request timeout - Chrome might not be ready yet
-				await asyncio.sleep(0.1)
+		async with httpx.AsyncClient(timeout=httpx.Timeout(2.0)) as client:
+			while asyncio.get_event_loop().time() - start_time < timeout:
+				try:
+					resp = await client.get(f'http://localhost:{port}/json/version')
+					if resp.status_code == 200:
+						# Chrome is ready
+						return f'http://localhost:{port}/'
+					else:
+						# Chrome is starting up and returning 502/500 errors
+						await asyncio.sleep(0.1)
+				except Exception:
+					# Connection error or request timeout - Chrome might not be ready yet
+					await asyncio.sleep(0.1)
 
 		raise TimeoutError(f'Browser did not start within {timeout} seconds')
 


### PR DESCRIPTION
## Summary

- Fixes #95: `No module named 'aiohttp'` breaking every MCP `execute_code` call
- `_wait_for_cdp_url()` in `local_browser_watchdog.py` used `aiohttp` for HTTP polling during browser startup, but `aiohttp` was never a declared dependency
- Replaced with `httpx` which is already a base dependency (`httpx>=0.28.1`) -- zero new deps needed
- Affects all installations, not just `[mcp]` extra

## Test plan

- [x] `LocalBrowserWatchdog` imports cleanly
- [x] `_wait_for_cdp_url` correctly raises `TimeoutError` on dead port
- [x] Zero `aiohttp` references remain in source tree
- [x] 29 unit tests pass
- [x] MCP server import chain (`OpenBrowserServer`) works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced CDP startup polling in the local browser watchdog from `aiohttp` to `httpx` to fix import errors and restore MCP `execute_code` calls without adding new deps.

- **Bug Fixes**
  - Use `httpx.AsyncClient` with a 2s timeout to poll `/json/version` and return the CDP URL when ready.
  - Removed all `aiohttp` usage; `httpx` is already required, so installs no longer fail.

<sup>Written for commit 8d312c01f00cdb617c79bbad72c9bfa14d19c248. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal HTTP client implementation to improve efficiency while maintaining existing functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->