### PR TITLE
fix(ci): Codecov integration and coverage artifacts gitignore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest tests/ -v --tb=short -m "not integration" --cov=src/openbrowser --cov-report=xml --cov-report=term-missing
+          pytest tests/ -v --tb=short -m "not integration" --cov=src/openbrowser --cov-branch --cov-report=xml --cov-report=term-missing
         env:
           PYTHONPATH: ${{ github.workspace }}
 
@@ -71,6 +71,7 @@ jobs:
         uses: codecov/codecov-action@v5
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,11 @@ terraform/*_override.tf.json
 
 data/formfactory/
 
+# Test coverage artifacts
+.coverage
+coverage.xml
+coverage-badge.svg
+
 # Extension build artifacts and secrets
 *.pem
 *.crx


### PR DESCRIPTION
## Summary
- Add `CODECOV_TOKEN` and `--cov-branch` to test workflow for authenticated Codecov uploads with branch coverage
- Add `.coverage`, `coverage.xml`, `coverage-badge.svg` to `.gitignore` (local test artifacts)

## Test plan
- [ ] CI passes with Codecov upload step
- [ ] Coverage report appears on Codecov dashboard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate Codecov uploads and enable branch coverage in CI; ignore local coverage artifacts to keep the repo clean. Adds CODECOV_TOKEN to the `codecov/codecov-action@v5` step, enables pytest branch coverage, and gitignores .coverage, coverage.xml, and coverage-badge.svg.

<sup>Written for commit dc0a5c26f34546ce2433dac95bd18af7d30483a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

