### PR TITLE
fix(ci): remove broken coverage-badge step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest tests/ -v --tb=short -m "not integration" --cov=src/openbrowser --cov-report=xml --cov-report=term-missing
+          pytest tests/ -v --tb=short -m "not integration" --cov=src/openbrowser --cov-branch --cov-report=xml --cov-report=term-missing
         env:
           PYTHONPATH: ${{ github.workspace }}
 
@@ -71,6 +71,7 @@ jobs:
         uses: codecov/codecov-action@v5
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,12 +76,6 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
-      - name: Generate coverage badge
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.ref == 'refs/heads/main'
-        uses: tj-actions/coverage-badge-py@v2
-        with:
-          output: coverage-badge.svg
-
       - name: Add coverage PR comment
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.event_name == 'pull_request'
         uses: MishaKav/pytest-coverage-comment@main

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,11 @@ terraform/*_override.tf.json
 
 data/formfactory/
 
+# Test coverage artifacts
+.coverage
+coverage.xml
+coverage-badge.svg
+
 # Extension build artifacts and secrets
 *.pem
 *.crx


### PR DESCRIPTION
## Summary
- Remove `Generate coverage badge` step that fails with `ModuleNotFoundError: No module named 'pkg_resources'` (setuptools>=71 removed it)
- Codecov already provides a hosted badge, making this step redundant

## Test plan
- [ ] CI passes without the coverage-badge step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the failing coverage-badge CI step and switched to Codecov’s hosted badge. Enabled branch coverage in `pytest`, added the Codecov token to `codecov/codecov-action@v5`, and ignored coverage artifacts in .gitignore.

<sup>Written for commit 378fd8ab860e1216273ee7baa9f0b3a5080a7685. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

