### PR TITLE
fix(docker): bump openbrowser to 0.1.38, use pip for QEMU compat

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,19 +42,19 @@ RUN pip install uv
 COPY backend/pyproject.toml backend/
 COPY backend/README.md backend/
 
-# Install backend dependencies
-RUN cd backend && uv pip install -e . --system
+# Install backend dependencies (pip used instead of uv for QEMU cross-compile compat)
+RUN cd backend && pip install -e .
 
 # Copy and install openbrowser from local path
 # Set version via environment variable since .git is not available
 COPY pyproject.toml .
 COPY src/ src/
 COPY README.md .
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.29
-RUN uv pip install -e . --system
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.38
+RUN pip install -e .
 
 # Install python-xlib for the X11 key grabber daemon (kiosk security)
-RUN uv pip install python-xlib --system
+RUN pip install python-xlib
 
 # Install Playwright and browsers (chromium works better in Docker)
 RUN playwright install chromium


### PR DESCRIPTION
## Summary

- Bump `SETUPTOOLS_SCM_PRETEND_VERSION` from 0.1.29 to 0.1.38 in backend Dockerfile
- Switch from `uv pip install --system` to `pip install` for QEMU cross-compile compatibility on ARM hosts with Podman

## Changes

- `backend/Dockerfile`: Version bump and pip install switch (uv segfaults under QEMU x86_64 emulation on ARM Mac)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `openbrowser` to 0.1.38 and switches backend Docker installs from `uv` to `pip` to fix QEMU cross-compile failures on ARM/Podman. This avoids `uv` segfaults by using `pip install -e .` for the backend, project, and `python-xlib`.

<sup>Written for commit 6478d8c1b3e4d9ffc3fc08527f936f2e55eb7ec7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend build tooling and dependency installation process
  * Version bumped to 0.1.38

<!-- end of auto-generated comment: release notes by coderabbit.ai -->