### PR TITLE
feat: default headless=true for MCP, daemon, CLI, plugin

### DIFF
--- a/server.json
+++ b/server.json
@@ -28,7 +28,7 @@
           "description": "Run browser in headless mode (true/false)",
           "isRequired": false,
           "isSecret": false,
-          "default": "false"
+          "default": "true"
         },
         {
           "name": "OPENBROWSER_ALLOWED_DOMAINS",

--- a/src/openbrowser/browser/profile.py
+++ b/src/openbrowser/browser/profile.py
@@ -371,7 +371,7 @@ class BrowserLaunchArgs(BaseModel):
 		validation_alias=AliasChoices('browser_binary_path', 'chrome_binary_path'),
 		description='Path to the chromium-based browser executable to use.',
 	)
-	headless: bool | None = Field(default=None, description='Whether to run the browser in headless or windowed mode.')
+	headless: bool | None = Field(default=True, description='Whether to run the browser in headless or windowed mode.')
 	args: list[CliArgStr] = Field(
 		default_factory=list, description='List of *extra* CLI args to pass to the browser when launching.'
 	)
@@ -1105,9 +1105,9 @@ async function initialize(checkInitialized, magic) {{
 		has_screen_available = bool(display_size)
 		self.screen = self.screen or display_size or ViewportSize(width=1920, height=1080)
 
-		# if no headless preference specified, prefer headful if there is a display available
+		# if no headless preference specified, default to headless
 		if self.headless is None:
-			self.headless = not has_screen_available
+			self.headless = True
 
 		# Determine viewport behavior based on mode and user preferences
 		user_provided_viewport = self.viewport is not None

--- a/src/openbrowser/config.py
+++ b/src/openbrowser/config.py
@@ -302,7 +302,7 @@ def create_default_config() -> DBStyleConfigJSON:
 	agent_id = str(uuid4())
 
 	# Create default browser profile entry
-	new_config.browser_profile[profile_id] = BrowserProfileEntry(id=profile_id, default=True, headless=False, user_data_dir=None)
+	new_config.browser_profile[profile_id] = BrowserProfileEntry(id=profile_id, default=True, headless=True, user_data_dir=None)
 
 	# Create default LLM entry
 	new_config.llm[llm_id] = LLMEntry(id=llm_id, default=True, model='gpt-4.1-mini', api_key='your-openai-api-key-here')

--- a/src/openbrowser/daemon/server.py
+++ b/src/openbrowser/daemon/server.py
@@ -80,7 +80,7 @@ class DaemonServer:
             'user_data_dir': '~/.config/openbrowser/profiles/daemon',
             'device_scale_factor': 1.0,
             'disable_security': False,
-            'headless': False,
+            'headless': True,
             **profile_config,
         }
         return BrowserProfile(**profile_data)

--- a/src/openbrowser/mcp/manifest.json
+++ b/src/openbrowser/mcp/manifest.json
@@ -67,8 +67,8 @@
     "headless": {
       "type": "boolean",
       "title": "Headless Mode",
-      "description": "Run browser without GUI (faster but no visual feedback). Set to false to see the browser in action",
-      "default": false,
+      "description": "Run browser without GUI (faster, less memory). Set to false to see the browser window",
+      "default": true,
       "required": false
     },
     "stealth": {

--- a/src/openbrowser/mcp/server.py
+++ b/src/openbrowser/mcp/server.py
@@ -313,7 +313,7 @@ class OpenBrowserServer:
 			'user_data_dir': '~/.config/openbrowser/profiles/default',
 			'device_scale_factor': 1.0,
 			'disable_security': False,
-			'headless': False,
+			'headless': True,
 			**profile_config,
 		}
 		return BrowserProfile(**profile_data)

--- a/tests/test_browser_profile.py
+++ b/tests/test_browser_profile.py
@@ -223,7 +223,7 @@ class TestBrowserConnectArgs:
 class TestBrowserLaunchArgs:
     def test_defaults(self):
         args = BrowserLaunchArgs()
-        assert args.headless is None
+        assert args.headless is True
         assert args.executable_path is None
         assert args.devtools is False
 


### PR DESCRIPTION
## Summary
- All browser entry points now default to headless mode (was headful/auto-detect)
- BrowserProfile, MCP server, daemon server, DXT manifest, MCP registry, default config all changed
- Users opt into headful via `--no-headless`, `OPENBROWSER_HEADLESS=false`, or config file

## Changed files (7)
- `src/openbrowser/browser/profile.py` - field default `None` -> `True`, fallback logic
- `src/openbrowser/mcp/server.py` - MCP `_build_browser_profile`
- `src/openbrowser/mcp/manifest.json` - DXT manifest user_config default
- `src/openbrowser/daemon/server.py` - daemon `_build_browser_profile`
- `src/openbrowser/config.py` - `create_default_config`
- `server.json` - MCP registry env var default
- `tests/test_browser_profile.py` - test assertion update

## Test plan
- [x] 7611 unit tests pass (1 pre-existing failure unrelated)
- [x] E2E verified: daemon launches Chrome with `--headless=new`, navigates to example.com
- [x] User config override (`headless: false`) still respected
- [x] `OPENBROWSER_HEADLESS=true` env var override works
- [x] Fresh install path defaults to `headless=True`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default browser mode is now headless across MCP, daemon, CLI, and plugin. This makes fresh installs lighter and more consistent in CI and server environments.

- **New Features**
  - Set `headless=True` by default in `BrowserLaunchArgs`, MCP and daemon profile builders, and `create_default_config`.
  - Updated MCP manifest and registry defaults to `true`; tests adjusted.

- **Migration**
  - To run headful, use `--no-headless`, set `OPENBROWSER_HEADLESS=false`, or set `headless: false` in your config.
  - Existing user configs with `headless: false` continue to work.

<sup>Written for commit 664149c96917c9bf7e9400f18274f28cadb27148. Summary will update on new commits. <a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/116?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Browser now launches in headless mode by default. Users can override this setting in their configuration if needed.

* **Tests**
  * Updated test assertions to reflect new default browser launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->