### PR TITLE
fix: update MCP server test for headless=true default

### DIFF
--- a/tests/test_mcp_server_deep_coverage.py
+++ b/tests/test_mcp_server_deep_coverage.py
@@ -623,7 +623,7 @@ class TestBuildBrowserProfile:
         assert profile is not None
         assert profile.keep_alive is True
         assert profile.disable_security is False
-        assert profile.headless is False
+        assert profile.headless is True
 
     def test_build_profile_merges_config(self, server_instance):
         """Lines 308-318: config values are merged into profile."""


### PR DESCRIPTION
## Summary

- Fix CI failure from #116: `test_build_profile_has_mcp_defaults` expected `headless=False`, now expects `True`

## Changes

- `tests/test_mcp_server_deep_coverage.py` - assertion update (1 line)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update MCP server test to expect headless=True by default, matching the profile’s new default and fixing CI failures.

<sup>Written for commit 420da3320517a5c74d1dac397ab5e209fac87322. Summary will update on new commits. <a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/117?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

