### PR TITLE
feat: persist local auth state and clean managed cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "openbrowser",
       "version": "0.1.39",
-      "description": "Browser automation MCP server with progressive disclosure design -- uses 3.2x fewer tokens than Playwright MCP across 6 tasks. Single execute_code tool runs Python with async browser functions. Includes CLI daemon for Bash-based workflows and compact description mode for token optimization.",
+    "description": "Browser automation MCP server with progressive disclosure design -- uses 3.2x fewer tokens than Playwright MCP across 6 tasks. Single execute_code tool runs Python with async browser functions, persisted login sessions, CLI daemon workflows, and compact description mode for token optimization.",
       "source": "./plugin",
       "category": "development",
       "tags": [

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-**Saved Cookies and Scheduled Tasks is available in the cloud-hosted version. Join the waitlist for early access: https://openbrowser.me** :
+**Cloud dashboard for saved cookies and scheduled tasks is available in the hosted version. Join the waitlist for early access: https://openbrowser.me** :
 
 https://github.com/user-attachments/assets/b17f97f3-f9f8-4707-8e39-abbbbe1a693b
 
@@ -70,10 +70,13 @@ OpenBrowser is a framework for intelligent browser automation. It combines direc
 - **CodeAgent Architecture** - LLM writes Python code in a persistent Jupyter-like namespace for browser automation
 - **Raw CDP Communication** - Direct Chrome DevTools Protocol for maximum control and speed
 - **Vision Support** - Screenshot analysis for visual understanding of pages
-- **12+ LLM Providers** - OpenAI, Anthropic, Google, Groq, AWS Bedrock, Azure OpenAI, Ollama, and more
-- **MCP Server** - Model Context Protocol support for Claude Desktop integration
-- **CLI Daemon** - Persistent browser daemon with `-c` flag for direct code execution from Bash
-- **Video Recording** - Record browser sessions as video files
+- **15 LLM Providers** - OpenAI, Anthropic, Google, Groq, AWS Bedrock, Azure, Ollama, DeepSeek, Cerebras, OpenRouter, OCI, and more
+- **MCP Server** - Model Context Protocol for Claude Desktop, Claude Code, Codex, OpenCode, and other AI assistants, with reusable saved login sessions
+- **CLI Daemon** - Persistent browser daemon with `-c` flag for direct code execution from Bash, saved login state, and 10-minute auto-shutdown
+- **Workflow Recording** - Record, replay, and export browser sessions to Jupyter notebooks or API crawler code
+- **Video Recording** - Record browser sessions as video files with ffmpeg
+- **Cloud Platform** - Full-stack web UI with real-time VNC streaming, saved logins (KMS-encrypted), scheduled workflows (EventBridge + SQS), and email notifications (SES)
+- **Plugin System** - Claude Code plugin with 6 guided skills (web scraping, form filling, e2e testing, page analysis, accessibility audit, file download)
 
 ## Installation
 
@@ -387,6 +390,8 @@ For OpenClaw plugin documentation, see [docs.openclaw.ai/tools/plugin](https://d
 
 OpenBrowser includes an MCP (Model Context Protocol) server that exposes browser automation as tools for AI assistants like Claude. Listed on the [MCP Registry](https://registry.modelcontextprotocol.io/?q=openbrowser) as `me.openbrowser/openbrowser-ai`. No external LLM API keys required -- the MCP client provides the intelligence.
 
+By default, MCP sessions reuse `~/.config/openbrowser/profiles/default` and save cookies plus origin storage to `~/.config/openbrowser/profiles/default/storage_state.json`, so logins survive MCP restarts. OpenBrowser also auto-cleans disposable Chromium caches in managed profiles, which keeps disk usage down without deleting cookies or login state.
+
 ### Quick Setup
 
 **Claude Code**: add to your project's `.mcp.json`:
@@ -448,8 +453,10 @@ The MCP server exposes a single `execute_code` tool that runs Python code in a p
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `OPENBROWSER_HEADLESS` | Run browser without GUI | `false` |
+| `OPENBROWSER_HEADLESS` | Run browser without GUI | `true` |
 | `OPENBROWSER_ALLOWED_DOMAINS` | Comma-separated domain whitelist | (none) |
+| `OPENBROWSER_USER_DATA_DIR` | Chrome profile directory for persistent MCP sessions | `~/.config/openbrowser/profiles/default` |
+| `OPENBROWSER_STORAGE_STATE` | JSON file used to save and restore cookies plus localStorage | `~/.config/openbrowser/profiles/default/storage_state.json` |
 | `OPENBROWSER_COMPACT_DESCRIPTION` | Minimal tool description (~500 tokens) | `false` |
 | `OPENBROWSER_MAX_OUTPUT` | Max output characters per execution | `10000` |
 
@@ -542,6 +549,8 @@ uvx openbrowser-ai --mcp
 ```
 
 The `-c` flag connects to a persistent browser daemon over a Unix socket (localhost TCP on Windows). Variables persist across calls while the daemon is running. The daemon starts automatically on first use and shuts down after 10 minutes of inactivity.
+
+The CLI daemon stores its browser profile in `~/.config/openbrowser/profiles/daemon` and also writes `storage_state.json` there, so cookies and login sessions survive daemon restarts. One-shot `-p` runs use `~/.config/openbrowser/profiles/cli` with the same storage-state behavior. Managed profiles automatically clear disposable browser caches on startup and shutdown while keeping auth state.
 
 ## Project Structure
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openbrowser",
   "version": "0.1.39",
-  "description": "AI-powered browser automation -- lets Claude control real web browsers to navigate, click, type, extract content, and automate workflows",
+  "description": "AI-powered browser automation -- lets Claude control real web browsers to navigate, click, type, extract content, automate workflows, and reuse saved login sessions",
   "author": {
     "name": "OpenBrowser Team",
     "email": "billy.enrizky@gmail.com"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,6 +2,8 @@
 
 AI-powered browser automation for Claude Code. Control real web browsers directly from Claude -- navigate websites, fill forms, extract data, inspect accessibility trees, and automate multi-step workflows.
 
+Local OpenBrowser sessions persist cookies and login state by default. The CLI daemon saves them in `~/.config/openbrowser/profiles/daemon/storage_state.json`, and the MCP server saves them in `~/.config/openbrowser/profiles/default/storage_state.json` unless you override those paths. Managed profiles also auto-clean disposable Chromium caches so they do not grow like normal long-lived Chrome profiles.
+
 ## Prerequisites
 
 - **Chrome or Chromium** installed on your system
@@ -61,6 +63,8 @@ Add to your project's `.mcp.json`:
 ## Available Tool
 
 The MCP server exposes a single `execute_code` tool that runs Python code in a persistent namespace with browser automation functions. The LLM writes Python code to navigate, interact, and extract data.
+
+Authenticated browser state is also persisted, so once a user logs in, later MCP calls can keep using the same cookies and localStorage.
 
 **Functions** (all async, use `await`):
 
@@ -134,6 +138,8 @@ openbrowser-ai daemon start|stop|status|restart
 
 Variables persist across `-c` calls while the daemon is running. The daemon starts automatically on first use and shuts down after 10 minutes of inactivity.
 
+The CLI daemon uses `~/.config/openbrowser/profiles/daemon` as its default browser profile and writes a matching `storage_state.json`, so saved logins survive daemon restarts.
+
 ## Configuration
 
 Optional environment variables:
@@ -142,6 +148,8 @@ Optional environment variables:
 |----------|-------------|
 | `OPENBROWSER_HEADLESS` | Set to `true` to run browser without GUI |
 | `OPENBROWSER_ALLOWED_DOMAINS` | Comma-separated domain whitelist |
+| `OPENBROWSER_USER_DATA_DIR` | Chrome profile directory for saved MCP sessions |
+| `OPENBROWSER_STORAGE_STATE` | JSON file for saving and restoring cookies plus localStorage |
 | `OPENBROWSER_COMPACT_DESCRIPTION` | Set to `true` for minimal tool description (~500 tokens) |
 | `OPENBROWSER_MAX_OUTPUT` | Maximum output characters per execution (default: 10,000) |
 | `ANONYMIZED_TELEMETRY` | Set to `false` to disable anonymized usage telemetry (default: `true`) |

--- a/plugin/skills/accessibility-audit/SKILL.md
+++ b/plugin/skills/accessibility-audit/SKILL.md
@@ -14,6 +14,8 @@ Audit web pages for accessibility issues following WCAG 2.1 guidelines using Pyt
 
 All code runs via `openbrowser-ai -c`. The daemon starts automatically and persists variables across calls. All browser functions are async -- use `await`.
 
+The CLI daemon also persists cookies and login state in `~/.config/openbrowser/profiles/daemon/storage_state.json`, so authenticated sessions can be reused across later runs.
+
 ## Setup
 
 Before running, verify openbrowser-ai is installed:

--- a/plugin/skills/e2e-testing/SKILL.md
+++ b/plugin/skills/e2e-testing/SKILL.md
@@ -13,6 +13,8 @@ Simulate real user interactions and verify web application behavior using Python
 
 All code runs via `openbrowser-ai -c`. The daemon starts automatically and persists variables across calls. All browser functions are async -- use `await`.
 
+The CLI daemon also persists cookies and login state in `~/.config/openbrowser/profiles/daemon/storage_state.json`, so authenticated sessions can be reused across later runs.
+
 ## Setup
 
 Before running, verify openbrowser-ai is installed:

--- a/plugin/skills/file-download/SKILL.md
+++ b/plugin/skills/file-download/SKILL.md
@@ -13,6 +13,8 @@ Download files from websites using the browser's authenticated session. Handles 
 
 All code runs via `openbrowser-ai -c`. The daemon starts automatically and persists variables across calls. All browser functions are async -- use `await`.
 
+The CLI daemon also persists cookies and login state in `~/.config/openbrowser/profiles/daemon/storage_state.json`, so authenticated sessions can be reused across later runs.
+
 ## Setup
 
 Before running, verify openbrowser-ai is installed:

--- a/plugin/skills/form-filling/SKILL.md
+++ b/plugin/skills/form-filling/SKILL.md
@@ -13,6 +13,8 @@ Automate filling web forms including login, registration, checkout, and multi-st
 
 All code runs via `openbrowser-ai -c`. The daemon starts automatically and persists variables across calls. All browser functions are async -- use `await`.
 
+The CLI daemon also persists cookies and login state in `~/.config/openbrowser/profiles/daemon/storage_state.json`, so authenticated sessions can be reused across later runs.
+
 ## Setup
 
 Before running, verify openbrowser-ai is installed:

--- a/plugin/skills/page-analysis/SKILL.md
+++ b/plugin/skills/page-analysis/SKILL.md
@@ -13,6 +13,8 @@ Analyze and understand web page content, structure, and interactive elements usi
 
 All code runs via `openbrowser-ai -c`. The daemon starts automatically and persists variables across calls. All browser functions are async -- use `await`.
 
+The CLI daemon also persists cookies and login state in `~/.config/openbrowser/profiles/daemon/storage_state.json`, so authenticated sessions can be reused across later runs.
+
 ## Setup
 
 Before running, verify openbrowser-ai is installed:

--- a/plugin/skills/web-scraping/SKILL.md
+++ b/plugin/skills/web-scraping/SKILL.md
@@ -13,6 +13,8 @@ Extract structured data from websites using Python code execution with browser a
 
 All code runs via `openbrowser-ai -c`. The daemon starts automatically and persists variables across calls. All browser functions are async -- use `await`.
 
+The CLI daemon also persists cookies and login state in `~/.config/openbrowser/profiles/daemon/storage_state.json`, so authenticated sessions can be reused across later runs.
+
 ## Setup
 
 Before running, verify openbrowser-ai is installed:

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "me.openbrowser/openbrowser-ai",
-  "description": "AI browser automation. Write async Python to navigate, click, type, and extract data.",
+  "description": "AI browser automation. Write async Python to navigate, click, type, extract data, and reuse saved login sessions.",
   "repository": {
     "url": "https://github.com/billy-enrizky/openbrowser-ai.git",
     "source": "github"
@@ -36,6 +36,20 @@
           "isRequired": false,
           "isSecret": false,
           "default": ""
+        },
+        {
+          "name": "OPENBROWSER_USER_DATA_DIR",
+          "description": "Chrome profile directory for persistent browser sessions",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "~/.config/openbrowser/profiles/default"
+        },
+        {
+          "name": "OPENBROWSER_STORAGE_STATE",
+          "description": "JSON file used to save and restore cookies plus localStorage between MCP restarts",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "~/.config/openbrowser/profiles/default/storage_state.json"
         },
         {
           "name": "OPENBROWSER_COMPACT_DESCRIPTION",

--- a/src/openbrowser/browser/watchdogs/local_browser_watchdog.py
+++ b/src/openbrowser/browser/watchdogs/local_browser_watchdog.py
@@ -19,6 +19,7 @@ from openbrowser.browser.events import (
 	BrowserStopEvent,
 )
 from openbrowser.browser.watchdog_base import BaseWatchdog
+from openbrowser.config import is_openbrowser_managed_profile_dir
 from openbrowser.observability import observe_debug
 
 if TYPE_CHECKING:
@@ -39,6 +40,20 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 	# Events this watchdog emits
 	EMITS: ClassVar[list[type[BaseEvent[Any]]]] = []
+
+	# Disposable Chromium caches that can be safely cleared without removing
+	# cookies, login databases, local storage, or IndexedDB.
+	CACHE_PATHS: ClassVar[tuple[str, ...]] = (
+		'GraphiteDawnCache',
+		'GrShaderCache',
+		'ShaderCache',
+		'Default/Cache',
+		'Default/Code Cache',
+		'Default/GPUCache',
+		'Default/DawnGraphiteCache',
+		'Default/DawnWebGPUCache',
+		'Default/Shared Dictionary',
+	)
 
 	# Private state for subprocess management
 	_subprocess: psutil.Process | None = PrivateAttr(default=None)
@@ -70,6 +85,15 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		if self._subprocess:
 			await self._cleanup_process(self._subprocess)
 			self._subprocess = None
+
+		active_user_data_dir = self.browser_session.browser_profile.user_data_dir or self._original_user_data_dir
+		profile_directory = self.browser_session.browser_profile.profile_directory or 'Default'
+		cleared_bytes = self._cleanup_profile_cache(active_user_data_dir, profile_directory)
+		if cleared_bytes > 0:
+			self.logger.info(
+				f'[LocalBrowserWatchdog] Cleared {cleared_bytes / (1024 * 1024):.1f} MB of browser cache '
+				f'from managed profile {active_user_data_dir}'
+			)
 
 		# Clean up temp directories if any were created
 		for temp_dir in self._temp_dirs_to_cleanup:
@@ -114,6 +138,16 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			if killed:
 				self.logger.info(
 					f'[LocalBrowserWatchdog] Killed stale Chrome process(es) holding profile lock on {self._original_user_data_dir}'
+				)
+
+			cleared_bytes = self._cleanup_profile_cache(
+				self._original_user_data_dir,
+				profile.profile_directory or 'Default',
+			)
+			if cleared_bytes > 0:
+				self.logger.info(
+					f'[LocalBrowserWatchdog] Cleared {cleared_bytes / (1024 * 1024):.1f} MB of browser cache '
+					f'from managed profile {self._original_user_data_dir}'
 				)
 
 		for attempt in range(max_retries):
@@ -453,6 +487,56 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				shutil.rmtree(temp_path, ignore_errors=True)
 		except Exception as e:
 			self.logger.debug(f'Failed to cleanup temp dir {temp_dir}: {e}')
+
+	@classmethod
+	def _iter_cache_paths(cls, user_data_dir: str | Path, profile_directory: str = 'Default') -> list[Path]:
+		"""Return the managed cache paths eligible for cleanup."""
+		root = Path(user_data_dir).expanduser()
+		profile_cache_paths: list[Path] = []
+
+		for relative_path in cls.CACHE_PATHS:
+			if relative_path.startswith('Default/'):
+				relative_path = relative_path.replace('Default/', f'{profile_directory}/', 1)
+			profile_cache_paths.append(root / relative_path)
+
+		return profile_cache_paths
+
+	@staticmethod
+	def _get_path_size_bytes(path: Path) -> int:
+		"""Return the recursive size of a file or directory in bytes."""
+		try:
+			if path.is_file():
+				return path.stat().st_size
+			if path.is_dir():
+				return sum(
+					child.stat().st_size for child in path.rglob('*') if child.exists() and not child.is_dir()
+				)
+		except OSError:
+			return 0
+		return 0
+
+	@classmethod
+	def _cleanup_profile_cache(cls, user_data_dir: str | Path | None, profile_directory: str = 'Default') -> int:
+		"""Delete disposable browser caches for OpenBrowser-managed profiles only."""
+		if not user_data_dir or not is_openbrowser_managed_profile_dir(user_data_dir):
+			return 0
+
+		total_cleared_bytes = 0
+
+		for cache_path in cls._iter_cache_paths(user_data_dir, profile_directory):
+			if not cache_path.exists():
+				continue
+
+			total_cleared_bytes += cls._get_path_size_bytes(cache_path)
+			try:
+				if cache_path.is_dir():
+					shutil.rmtree(cache_path, ignore_errors=True)
+				else:
+					cache_path.unlink(missing_ok=True)
+			except OSError:
+				continue
+
+		return total_cleared_bytes
 
 	@staticmethod
 	async def _kill_stale_chrome_for_profile(user_data_dir: str) -> bool:

--- a/src/openbrowser/cli.py
+++ b/src/openbrowser/cli.py
@@ -306,7 +306,7 @@ import click
 
 os.environ['OPENBROWSER_LOGGING_LEVEL'] = 'result'
 
-from openbrowser.config import CONFIG
+from openbrowser.config import CONFIG, apply_managed_browser_profile_defaults
 
 # Set USER_DATA_DIR now that CONFIG is imported
 USER_DATA_DIR = CONFIG.OPENBROWSER_PROFILES_DIR / 'cli'
@@ -347,6 +347,7 @@ def get_default_config() -> dict[str, Any]:
 			'keep_alive': browser_profile.get('keep_alive', True),
 			'ignore_https_errors': browser_profile.get('ignore_https_errors', False),
 			'user_data_dir': browser_profile.get('user_data_dir'),
+			'storage_state': browser_profile.get('storage_state'),
 			'allowed_domains': browser_profile.get('allowed_domains'),
 			'wait_between_actions': browser_profile.get('wait_between_actions'),
 			'is_mobile': browser_profile.get('is_mobile'),
@@ -538,8 +539,8 @@ async def run_prompt_mode(prompt: str, ctx: click.Context, debug: bool = False):
 		browser_config = config.get('browser', {})
 		# Remove None values from browser_config
 		browser_config = {k: v for k, v in browser_config.items() if v is not None}
-		# Create BrowserProfile with user_data_dir
-		profile = BrowserProfile(user_data_dir=str(USER_DATA_DIR), **browser_config)
+		browser_config = apply_managed_browser_profile_defaults(browser_config, USER_DATA_DIR)
+		profile = BrowserProfile(**browser_config)
 		browser_session = BrowserSession(
 			browser_profile=profile,
 		)

--- a/src/openbrowser/code_use/descriptions.py
+++ b/src/openbrowser/code_use/descriptions.py
@@ -7,7 +7,7 @@ dependency-free (no openbrowser imports) so the CLI -c fast path can
 load it without pulling in heavy packages.
 """
 
-EXECUTE_CODE_DESCRIPTION_COMPACT = """Execute Python code with browser automation. All functions are async (use await). Use print() to return output. Variables persist between calls.
+EXECUTE_CODE_DESCRIPTION_COMPACT = """Execute Python code with browser automation. All functions are async (use await). Use print() to return output. Variables and browser login state persist between calls.
 
 ## Core Functions
 - `await navigate(url, new_tab=False)` -- Go to URL
@@ -28,7 +28,7 @@ json, asyncio, Path, csv, re, datetime, requests (pre-imported)
 Optional: numpy/np, pandas/pd, BeautifulSoup, PdfReader
 """
 
-EXECUTE_CODE_DESCRIPTION = """Execute Python code in a persistent namespace with browser automation functions. All functions are async -- use `await`. Use print() to return output. Variables persist between calls.
+EXECUTE_CODE_DESCRIPTION = """Execute Python code in a persistent namespace with browser automation functions. All functions are async -- use `await`. Use print() to return output. Variables and browser login state persist between calls.
 
 ## Navigation
 

--- a/src/openbrowser/config.py
+++ b/src/openbrowser/config.py
@@ -237,6 +237,8 @@ class FlatEnvConfig(BaseSettings):
 	OPENBROWSER_HEADLESS: bool | None = Field(default=None)
 	OPENBROWSER_ALLOWED_DOMAINS: str | None = Field(default=None)
 	OPENBROWSER_LLM_MODEL: str | None = Field(default=None)
+	OPENBROWSER_USER_DATA_DIR: str | None = Field(default=None)
+	OPENBROWSER_STORAGE_STATE: str | None = Field(default=None)
 
 	# Proxy env vars
 	OPENBROWSER_PROXY_URL: str | None = Field(default=None)
@@ -517,6 +519,12 @@ class Config:
 			domains = [d.strip() for d in env_config.OPENBROWSER_ALLOWED_DOMAINS.split(',') if d.strip()]
 			config['browser_profile']['allowed_domains'] = domains
 
+		if env_config.OPENBROWSER_USER_DATA_DIR:
+			config['browser_profile']['user_data_dir'] = env_config.OPENBROWSER_USER_DATA_DIR
+
+		if env_config.OPENBROWSER_STORAGE_STATE:
+			config['browser_profile']['storage_state'] = env_config.OPENBROWSER_STORAGE_STATE
+
 		# Proxy settings (Chromium) -> consolidated `proxy` dict
 		proxy_dict: dict[str, Any] = {}
 		if env_config.OPENBROWSER_PROXY_URL:
@@ -560,3 +568,37 @@ def get_default_profile(config: dict[str, Any]) -> dict[str, Any]:
 def get_default_llm(config: dict[str, Any]) -> dict[str, Any]:
 	"""Get default LLM config from config dict."""
 	return config.get('llm', {})
+
+
+def is_openbrowser_managed_profile_dir(path: str | Path | None) -> bool:
+	"""Return True when the path lives under OpenBrowser's managed profiles dir."""
+	if not path:
+		return False
+
+	try:
+		resolved = Path(path).expanduser().resolve()
+	except OSError:
+		resolved = Path(path).expanduser()
+
+	try:
+		return resolved.is_relative_to(CONFIG.OPENBROWSER_PROFILES_DIR)
+	except ValueError:
+		return False
+
+
+def apply_managed_browser_profile_defaults(
+	profile_data: dict[str, Any], default_user_data_dir: str | Path | None = None
+) -> dict[str, Any]:
+	"""Fill in managed persistence defaults for OpenBrowser-owned browser profiles."""
+	resolved_profile = dict(profile_data)
+
+	if default_user_data_dir and not resolved_profile.get('user_data_dir'):
+		resolved_profile['user_data_dir'] = str(Path(default_user_data_dir).expanduser())
+
+	if not resolved_profile.get('storage_state') and is_openbrowser_managed_profile_dir(
+		resolved_profile.get('user_data_dir')
+	):
+		user_data_dir = Path(str(resolved_profile['user_data_dir'])).expanduser()
+		resolved_profile['storage_state'] = str(user_data_dir / 'storage_state.json')
+
+	return resolved_profile

--- a/src/openbrowser/daemon/server.py
+++ b/src/openbrowser/daemon/server.py
@@ -69,20 +69,23 @@ class DaemonServer:
     def _build_browser_profile(self):
         """Build a BrowserProfile from config with daemon defaults."""
         from openbrowser.browser import BrowserProfile
-        from openbrowser.config import get_default_profile, load_openbrowser_config
+        from openbrowser.config import CONFIG, apply_managed_browser_profile_defaults, get_default_profile, load_openbrowser_config
 
         config = load_openbrowser_config()
         profile_config = get_default_profile(config)
-        profile_data = {
-            'downloads_path': str(Path.home() / 'Downloads' / 'openbrowser-daemon'),
-            'wait_between_actions': 0.5,
-            'keep_alive': True,
-            'user_data_dir': '~/.config/openbrowser/profiles/daemon',
-            'device_scale_factor': 1.0,
-            'disable_security': False,
-            'headless': True,
-            **profile_config,
-        }
+        profile_data = apply_managed_browser_profile_defaults(
+            {
+                'downloads_path': str(Path.home() / 'Downloads' / 'openbrowser-daemon'),
+                'wait_between_actions': 0.5,
+                'keep_alive': True,
+                'user_data_dir': '~/.config/openbrowser/profiles/daemon',
+                'device_scale_factor': 1.0,
+                'disable_security': False,
+                'headless': True,
+                **profile_config,
+            },
+            CONFIG.OPENBROWSER_PROFILES_DIR / 'daemon',
+        )
         return BrowserProfile(**profile_data)
 
     async def _ensure_executor(self):

--- a/src/openbrowser/mcp/manifest.json
+++ b/src/openbrowser/mcp/manifest.json
@@ -4,8 +4,8 @@
   "name": "openbrowser",
   "display_name": "OpenBrowser AI Browser Automation",
   "version": "0.1.29",
-  "description": "CodeAgent MCP server -- execute Python code with browser automation functions in a persistent namespace",
-  "long_description": "OpenBrowser CodeAgent exposes a single execute_code tool that runs Python code in a persistent namespace with browser automation functions. Write multi-step workflows in Python with full access to navigate, click, type, evaluate JS, and more.\n\n### Key Features:\n- **Code Execution**: Write Python code with async browser functions (await navigate, click, evaluate, etc.)\n- **Persistent Namespace**: Variables and state persist between execute_code calls\n- **Browser Automation**: Full browser control via CodeAgent functions\n- **JavaScript Evaluation**: Run JS in page context via evaluate()\n- **Data Libraries**: numpy, pandas, matplotlib, BeautifulSoup available\n- **Standard Libraries**: json, csv, re, datetime, requests, asyncio, Path\n\n### Use Cases:\n- Web scraping with Python data processing\n- Automated testing with assertions\n- Research and information gathering\n- Form filling and multi-step workflows\n- DOM extraction via evaluate() + Python post-processing",
+  "description": "CodeAgent MCP server -- execute Python code with browser automation functions, persistent namespace, and saved login sessions",
+  "long_description": "OpenBrowser CodeAgent exposes a single execute_code tool that runs Python code in a persistent namespace with browser automation functions. Write multi-step workflows in Python with full access to navigate, click, type, evaluate JS, and more.\n\n### Key Features:\n- **Code Execution**: Write Python code with async browser functions (await navigate, click, evaluate, etc.)\n- **Persistent Namespace**: Variables and state persist between execute_code calls\n- **Saved Login Sessions**: Cookies and browser storage are saved to disk so authenticated sessions survive MCP restarts\n- **Browser Automation**: Full browser control via CodeAgent functions\n- **JavaScript Evaluation**: Run JS in page context via evaluate()\n- **Data Libraries**: numpy, pandas, matplotlib, BeautifulSoup available\n- **Standard Libraries**: json, csv, re, datetime, requests, asyncio, Path\n\n### Use Cases:\n- Web scraping with Python data processing\n- Automated testing with assertions\n- Research and information gathering\n- Form filling and multi-step workflows\n- DOM extraction via evaluate() + Python post-processing",
   "icon": "icon.png",
   "homepage": "https://github.com/billy-enrizky/openbrowser-ai",
   "documentation": "https://github.com/billy-enrizky/openbrowser-ai",
@@ -27,7 +27,9 @@
       "args": ["openbrowser-ai", "--mcp"],
       "env": {
         "OPENBROWSER_HEADLESS": "${user_config.headless}",
-        "OPENBROWSER_ALLOWED_DOMAINS": "${user_config.allowed_domains}"
+        "OPENBROWSER_ALLOWED_DOMAINS": "${user_config.allowed_domains}",
+        "OPENBROWSER_USER_DATA_DIR": "${user_config.user_data_dir}",
+        "OPENBROWSER_STORAGE_STATE": "${user_config.storage_state}"
       }
     }
   },
@@ -83,6 +85,13 @@
       "title": "User Data Directory",
       "description": "Chrome profile directory for persistent sessions (cookies, localStorage, etc)",
       "default": "${HOME}/.config/openbrowser/profiles/default",
+      "required": false
+    },
+    "storage_state": {
+      "type": "string",
+      "title": "Storage State Path",
+      "description": "Optional JSON file path used to save and reload cookies plus localStorage across MCP restarts",
+      "default": "${HOME}/.config/openbrowser/profiles/default/storage_state.json",
       "required": false
     },
     "disable_security": {

--- a/src/openbrowser/mcp/server.py
+++ b/src/openbrowser/mcp/server.py
@@ -81,7 +81,7 @@ logging.disable(logging.CRITICAL)
 # Import openbrowser modules
 from openbrowser.browser import BrowserProfile, BrowserSession
 from openbrowser.code_use.namespace import create_namespace
-from openbrowser.config import get_default_profile, load_openbrowser_config
+from openbrowser.config import CONFIG, apply_managed_browser_profile_defaults, get_default_profile, load_openbrowser_config
 from openbrowser.tools.service import CodeAgentTools
 from openbrowser.code_use.executor import DEFAULT_MAX_OUTPUT_CHARS, CodeExecutor
 
@@ -306,16 +306,19 @@ class OpenBrowserServer:
 	def _build_browser_profile(self):
 		"""Build a BrowserProfile from config with MCP defaults."""
 		profile_config = get_default_profile(self.config)
-		profile_data = {
-			'downloads_path': str(Path.home() / 'Downloads' / 'openbrowser-mcp'),
-			'wait_between_actions': 0.5,
-			'keep_alive': True,
-			'user_data_dir': '~/.config/openbrowser/profiles/default',
-			'device_scale_factor': 1.0,
-			'disable_security': False,
-			'headless': True,
-			**profile_config,
-		}
+		profile_data = apply_managed_browser_profile_defaults(
+			{
+				'downloads_path': str(Path.home() / 'Downloads' / 'openbrowser-mcp'),
+				'wait_between_actions': 0.5,
+				'keep_alive': True,
+				'user_data_dir': '~/.config/openbrowser/profiles/default',
+				'device_scale_factor': 1.0,
+				'disable_security': False,
+				'headless': True,
+				**profile_config,
+			},
+			CONFIG.OPENBROWSER_PROFILES_DIR / 'default',
+		)
 		return BrowserProfile(**profile_data)
 
 	async def _ensure_namespace(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,10 +7,16 @@ from pathlib import Path
 from unittest.mock import patch
 
 from openbrowser.config import (
+    CONFIG,
     _get_env_bool_cached,
+    _get_env_cached,
+    _get_path_cached,
+    _config_cache,
+    apply_managed_browser_profile_defaults,
     create_default_config,
     get_default_llm,
     get_default_profile,
+    is_openbrowser_managed_profile_dir,
     load_and_migrate_config,
     load_openbrowser_config,
 )
@@ -55,14 +61,8 @@ class TestConfig:
             config_path = Path(tmpdir) / "config.json"
             with patch.dict(os.environ, {"OPENBROWSER_CONFIG_PATH": str(config_path)}):
                 # Clear caches to pick up the new env var
-                from openbrowser.config import (
-                    _config_cache,
-                    _get_env_bool_cached,
-                    _get_env_cached,
-                    _get_path_cached,
-                )
-
                 _config_cache.clear()
+                CONFIG._env_config = None
                 _get_env_cached.cache_clear()
                 _get_env_bool_cached.cache_clear()
                 _get_path_cached.cache_clear()
@@ -72,6 +72,26 @@ class TestConfig:
                 assert "browser_profile" in result
                 assert "llm" in result
                 assert "agent" in result
+
+    def test_load_openbrowser_config_applies_user_data_env_overrides(self):
+        """OPENBROWSER_USER_DATA_DIR and OPENBROWSER_STORAGE_STATE override browser profile config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            env = {
+                "OPENBROWSER_CONFIG_PATH": str(config_path),
+                "OPENBROWSER_USER_DATA_DIR": "/tmp/custom-profile",
+                "OPENBROWSER_STORAGE_STATE": "/tmp/custom-profile/state.json",
+            }
+            with patch.dict(os.environ, env, clear=False):
+                _config_cache.clear()
+                CONFIG._env_config = None
+                _get_env_cached.cache_clear()
+                _get_env_bool_cached.cache_clear()
+                _get_path_cached.cache_clear()
+
+                result = load_openbrowser_config()
+                assert result["browser_profile"]["user_data_dir"] == "/tmp/custom-profile"
+                assert result["browser_profile"]["storage_state"] == "/tmp/custom-profile/state.json"
 
     def test_env_bool_cached_true_values(self):
         """_get_env_bool_cached recognizes true/yes/1."""
@@ -107,6 +127,42 @@ class TestConfig:
         # Default profile should be marked default=True
         for profile in config.browser_profile.values():
             assert profile.default is True
+
+    def test_apply_managed_browser_profile_defaults_adds_storage_state(self):
+        """Managed OpenBrowser profile dirs get a sibling storage_state.json path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "openbrowser-config"
+            env = {"OPENBROWSER_CONFIG_DIR": str(config_dir)}
+            with patch.dict(os.environ, env, clear=False):
+                _config_cache.clear()
+                CONFIG._env_config = None
+                _get_env_cached.cache_clear()
+                _get_env_bool_cached.cache_clear()
+                _get_path_cached.cache_clear()
+
+                profile_dir = config_dir / "profiles" / "daemon"
+                result = apply_managed_browser_profile_defaults({}, profile_dir)
+                assert result["user_data_dir"] == str(profile_dir)
+                assert result["storage_state"] == str(profile_dir / "storage_state.json")
+                assert is_openbrowser_managed_profile_dir(profile_dir) is True
+
+    def test_apply_managed_browser_profile_defaults_skips_external_storage_state(self):
+        """External Chrome profiles are respected without auto-injecting storage_state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "openbrowser-config"
+            external_dir = Path(tmpdir) / "external-chrome-profile"
+            env = {"OPENBROWSER_CONFIG_DIR": str(config_dir)}
+            with patch.dict(os.environ, env, clear=False):
+                _config_cache.clear()
+                CONFIG._env_config = None
+                _get_env_cached.cache_clear()
+                _get_env_bool_cached.cache_clear()
+                _get_path_cached.cache_clear()
+
+                result = apply_managed_browser_profile_defaults({"user_data_dir": str(external_dir)})
+                assert result["user_data_dir"] == str(external_dir)
+                assert "storage_state" not in result
+                assert is_openbrowser_managed_profile_dir(external_dir) is False
 
     def test_load_and_migrate_config_creates_fresh(self):
         """load_and_migrate_config creates fresh config if file missing."""

--- a/tests/test_daemon_server_coverage.py
+++ b/tests/test_daemon_server_coverage.py
@@ -111,6 +111,8 @@ class TestDaemonServerBuildProfile:
                     result = daemon_server._build_browser_profile()
                     assert result is mock_profile
                     mock_profile_class.assert_called_once()
+                    _, kwargs = mock_profile_class.call_args
+                    assert kwargs["storage_state"].endswith("profiles/daemon/storage_state.json")
 
 
 class TestDaemonServerIsConnectionError:

--- a/tests/test_local_browser_watchdog.py
+++ b/tests/test_local_browser_watchdog.py
@@ -11,6 +11,7 @@ import psutil
 import pytest
 from bubus import EventBus
 from openbrowser.browser.session import BrowserSession
+from openbrowser.config import CONFIG, _config_cache, _get_env_bool_cached, _get_env_cached, _get_path_cached
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,55 @@ class TestCleanupTempDir:
         os.rmdir(tmpdir)  # cleanup
 
 
+class TestCleanupProfileCache:
+    """Tests for managed profile cache cleanup."""
+
+    def test_skips_non_managed_profile_dirs(self):
+        from openbrowser.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir) / 'Default' / 'Cache'
+            cache_dir.mkdir(parents=True)
+            (cache_dir / 'data.bin').write_bytes(b'x' * 1024)
+
+            cleared = LocalBrowserWatchdog._cleanup_profile_cache(tmpdir)
+
+            assert cleared == 0
+            assert cache_dir.exists()
+
+    def test_removes_only_known_cache_dirs_for_managed_profiles(self):
+        from openbrowser.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / 'config'
+            managed_profile = config_dir / 'profiles' / 'daemon'
+            cache_dir = managed_profile / 'Default' / 'Cache'
+            code_cache_dir = managed_profile / 'Default' / 'Code Cache'
+            cookies_file = managed_profile / 'Default' / 'Cookies'
+
+            cache_dir.mkdir(parents=True)
+            code_cache_dir.mkdir(parents=True)
+            cookies_file.parent.mkdir(parents=True, exist_ok=True)
+
+            (cache_dir / 'data.bin').write_bytes(b'a' * 2048)
+            (code_cache_dir / 'data.bin').write_bytes(b'b' * 1024)
+            cookies_file.write_bytes(b'keep-me')
+
+            with patch.dict(os.environ, {'OPENBROWSER_CONFIG_DIR': str(config_dir)}, clear=False):
+                _config_cache.clear()
+                CONFIG._env_config = None
+                _get_env_cached.cache_clear()
+                _get_env_bool_cached.cache_clear()
+                _get_path_cached.cache_clear()
+
+                cleared = LocalBrowserWatchdog._cleanup_profile_cache(managed_profile)
+
+            assert cleared >= 3072
+            assert not cache_dir.exists()
+            assert not code_cache_dir.exists()
+            assert cookies_file.exists()
+
+
 @pytest.mark.asyncio
 class TestCleanupProcess:
     """Tests for _cleanup_process static method."""
@@ -255,6 +305,18 @@ class TestOnBrowserKillEvent:
         event = MagicMock()
         # Should not raise
         await watchdog.on_BrowserKillEvent(event)
+
+    async def test_kill_cleans_managed_profile_cache(self):
+        watchdog, session = _make_watchdog()
+        session.browser_profile.user_data_dir = '/managed/profile'
+        session.browser_profile.profile_directory = 'Default'
+
+        event = MagicMock()
+
+        with patch.object(type(watchdog), '_cleanup_profile_cache', return_value=4096) as mock_cleanup:
+            await watchdog.on_BrowserKillEvent(event)
+
+        mock_cleanup.assert_called_once_with('/managed/profile', 'Default')
 
 
 @pytest.mark.asyncio
@@ -463,6 +525,24 @@ class TestLaunchBrowser:
                         process, cdp_url = await watchdog._launch_browser(max_retries=1)
 
         assert cdp_url == 'http://localhost:9222/'
+
+    async def test_cleans_managed_profile_cache_before_launch(self):
+        watchdog, session = _make_watchdog()
+        session.browser_profile.executable_path = '/custom/chrome'
+        session.browser_profile.profile_directory = 'Default'
+
+        mock_subprocess = MagicMock()
+        mock_subprocess.pid = 12345
+
+        with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock, return_value=mock_subprocess):
+            with patch('psutil.Process', return_value=MagicMock()):
+                with patch.object(type(watchdog), '_wait_for_cdp_url', new_callable=AsyncMock, return_value='http://localhost:9222/'):
+                    with patch.object(type(watchdog), '_kill_stale_chrome_for_profile', new_callable=AsyncMock, return_value=False):
+                        with patch.object(type(watchdog), '_cleanup_profile_cache', return_value=8192) as mock_cleanup:
+                            process, cdp_url = await watchdog._launch_browser(max_retries=1)
+
+        assert cdp_url == 'http://localhost:9222/'
+        mock_cleanup.assert_called_once_with(str(session.browser_profile.user_data_dir), 'Default')
 
     async def test_retries_with_temp_dir_on_profile_error(self):
         watchdog, session = _make_watchdog()

--- a/tests/test_mcp_server_deep_coverage.py
+++ b/tests/test_mcp_server_deep_coverage.py
@@ -624,6 +624,7 @@ class TestBuildBrowserProfile:
         assert profile.keep_alive is True
         assert profile.disable_security is False
         assert profile.headless is True
+        assert str(profile.storage_state).endswith('profiles/default/storage_state.json')
 
     def test_build_profile_merges_config(self, server_instance):
         """Lines 308-318: config values are merged into profile."""


### PR DESCRIPTION
## Summary

- persist local CLI, daemon, and MCP auth state by default with managed `storage_state.json` paths
- auto-clean disposable Chromium caches for OpenBrowser-managed profiles without deleting cookies or login storage
- document the new saved-login and cache-cleanup behavior across README, plugin metadata, and CLI-first skills
- add focused coverage for config overrides, MCP/daemon profile defaults, and local browser watchdog cache cleanup

## Changes

- `src/openbrowser/config.py`: add `OPENBROWSER_USER_DATA_DIR` and `OPENBROWSER_STORAGE_STATE` overrides plus managed-profile helpers
- `src/openbrowser/cli.py`, `src/openbrowser/daemon/server.py`, `src/openbrowser/mcp/server.py`: apply managed profile defaults so local auth state persists automatically
- `src/openbrowser/browser/watchdogs/local_browser_watchdog.py`: clean disposable Chromium caches on startup/shutdown for managed profiles only
- `src/openbrowser/mcp/manifest.json`, `server.json`, `README.md`, `plugin/README.md`, plugin metadata and skills: document saved-login persistence and managed cache cleanup
- `tests/test_config.py`, `tests/test_daemon_server_coverage.py`, `tests/test_local_browser_watchdog.py`, `tests/test_mcp_server_deep_coverage.py`: verify new defaults and cleanup behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist local login sessions for CLI, daemon, and MCP by default using managed profile directories and a saved storage_state.json. Add automatic cleanup of disposable Chromium caches for managed profiles without deleting cookies or login data.

- **New Features**
  - Managed persistence by default: CLI (`profiles/cli`), daemon (`profiles/daemon`), MCP (`profiles/default`) with storage_state.json saved beside each profile.
  - Env overrides: OPENBROWSER_USER_DATA_DIR and OPENBROWSER_STORAGE_STATE; exposed in `server.json` and the plugin’s user config.
  - Watchdog cache cleanup: clears safe Chromium caches on start/stop for managed profiles only; keeps cookies, localStorage, and login DBs.
  - Updated docs, plugin metadata, and tool descriptions to note saved-login behavior; added tests for config overrides and cache cleanup.

<sup>Written for commit 8ed3a32651c14d28c6d37e54abcb7ce94eedea33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser sessions now persist authentication credentials and cookies across runs for seamless workflows.
  * CLI Daemon includes automatic cache cleanup for optimized disk usage.

* **Documentation**
  * Expanded provider support documentation (15 LLM Providers).
  * Added comprehensive guides for MCP Server, Plugin System, Cloud Platform integration, Workflow and Video Recording capabilities.
  * Clarified session persistence behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->