### PR TITLE
fix: shorten MCP server description

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "me.openbrowser/openbrowser-ai",
-  "description": "AI browser automation. Write async Python to navigate, click, type, extract data, and reuse saved login sessions.",
+  "description": "AI browser automation. Write async Python to navigate, click, type, and extract data.",
   "repository": {
     "url": "https://github.com/billy-enrizky/openbrowser-ai.git",
     "source": "github"


### PR DESCRIPTION
## Summary

- shorten the MCP registry `server.json` description to stay within the registry's 100-character limit
- fix the root cause of the `v0.1.40` MCP publish failure

## Changes

- `server.json`: replace the overlong top-level description with an 85-character version that still describes the MCP server clearly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened the MCP registry `server.json` description to meet the 100-character limit, unblocking the v0.1.40 publish. The new 85-character text keeps the server purpose clear.

<sup>Written for commit a4190e0bcbf5f844fc6f3eac97c89b5e7ca1ebb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

