### PR TITLE
docs(skills): enforce mandatory daemon cleanup across all 6 plugin skills

### DIFF
--- a/plugin/skills/accessibility-audit/SKILL.md
+++ b/plugin/skills/accessibility-audit/SKILL.md
@@ -382,3 +382,29 @@ EOF
 - ARIA misuse is often worse than no ARIA at all.
 - The heading check catches the most common structural issues.
 - Missing form labels are the most common form accessibility failure.
+
+## Cleanup
+
+This step is **mandatory**. Run it after the task finishes, whether the audit succeeded or failed. Without it, the daemon keeps Chrome running until its 10-minute idle timeout, leaving a stale browser process, a locked profile, and (on macOS/Linux desktop) a visible window.
+
+Stop the daemon, then verify it is gone:
+
+```bash
+openbrowser-ai daemon stop
+openbrowser-ai daemon status
+```
+
+`daemon stop` closes every tab, exits Chrome, flushes saved cookies/login state to the profile, and shuts down the daemon process. `daemon status` should report the daemon is not running. If it still reports running, the daemon is wedged, force-kill it:
+
+```bash
+pkill -f 'openbrowser.*daemon' || true
+```
+
+If your skill invocation can fail mid-workflow (network error, assertion failure, CDP timeout), guarantee cleanup with a shell trap so the browser is never left orphaned:
+
+```bash
+trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT
+# ... openbrowser-ai -c calls here ...
+```
+
+Do not rely on the idle timeout. Do not call `done()` as a substitute, `done()` only marks the task complete inside the agent loop, it does not close the browser.

--- a/plugin/skills/e2e-testing/SKILL.md
+++ b/plugin/skills/e2e-testing/SKILL.md
@@ -207,3 +207,29 @@ EOF
 - Use `await wait(N)` after interactions that trigger page loads or animations.
 - Variables persist between `-c` calls while the daemon is running, so you can accumulate test results across calls.
 - Use `evaluate()` for DOM state assertions and `browser.get_browser_state_summary()` for page metadata.
+
+## Cleanup
+
+This step is **mandatory**. Run it after the test run finishes, whether assertions passed or failed. Without it, the daemon keeps Chrome running until its 10-minute idle timeout, leaving a stale browser process, a locked profile, and (on macOS/Linux desktop) a visible window.
+
+Stop the daemon, then verify it is gone:
+
+```bash
+openbrowser-ai daemon stop
+openbrowser-ai daemon status
+```
+
+`daemon stop` closes every tab, exits Chrome, flushes saved cookies/login state to the profile, and shuts down the daemon process. `daemon status` should report the daemon is not running. If it still reports running, the daemon is wedged, force-kill it:
+
+```bash
+pkill -f 'openbrowser.*daemon' || true
+```
+
+E2E runs fail often by design (that is what assertions are for). Guarantee cleanup with a shell trap so a failed assertion never leaks a browser:
+
+```bash
+trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT
+# ... openbrowser-ai -c calls here ...
+```
+
+Do not rely on the idle timeout. Do not call `done()` as a substitute, `done()` only marks the task complete inside the agent loop, it does not close the browser.

--- a/plugin/skills/file-download/SKILL.md
+++ b/plugin/skills/file-download/SKILL.md
@@ -200,3 +200,29 @@ EOF
 - Use `list_downloads()` to see all files saved in the downloads directory.
 - For large files, `download_file()` has a 120-second timeout.
 - The fallback strategy uses Python `requests` if the browser fetch fails (e.g., CORS restrictions), but without browser cookies.
+
+## Cleanup
+
+This step is **mandatory**. Run it after every download run, whether the file landed successfully or the request failed. Without it, the daemon keeps Chrome running until its 10-minute idle timeout, leaving a stale browser process, a locked profile, and (on macOS/Linux desktop) a visible window.
+
+Stop the daemon, then verify it is gone:
+
+```bash
+openbrowser-ai daemon stop
+openbrowser-ai daemon status
+```
+
+`daemon stop` closes every tab, exits Chrome, flushes saved cookies/login state to the profile, and shuts down the daemon process. `daemon status` should report the daemon is not running. If it still reports running, the daemon is wedged, force-kill it:
+
+```bash
+pkill -f 'openbrowser.*daemon' || true
+```
+
+If a download can fail mid-workflow (timeout, 4xx/5xx, CORS), guarantee cleanup with a shell trap so the browser is never left orphaned:
+
+```bash
+trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT
+# ... openbrowser-ai -c calls here ...
+```
+
+Downloaded files in `~/.config/openbrowser/downloads/` survive `daemon stop`, only the browser process is terminated. Do not rely on the idle timeout. Do not call `done()` as a substitute, `done()` only marks the task complete inside the agent loop, it does not close the browser.

--- a/plugin/skills/form-filling/SKILL.md
+++ b/plugin/skills/form-filling/SKILL.md
@@ -199,3 +199,29 @@ EOF
 - Use `evaluate()` to bypass custom components that do not respond to standard click/type.
 - Variables persist between `-c` calls while the daemon is running, so you can store field indices in one call and use them in the next.
 - Check for CAPTCHA or bot detection; notify the user if manual intervention is needed.
+
+## Cleanup
+
+This step is **mandatory**. Run it after the form submission finishes, whether the submit succeeded or the form rejected the input. Without it, the daemon keeps Chrome running until its 10-minute idle timeout, leaving a stale browser process, a locked profile, and (on macOS/Linux desktop) a visible window with the form still on screen.
+
+Stop the daemon, then verify it is gone:
+
+```bash
+openbrowser-ai daemon stop
+openbrowser-ai daemon status
+```
+
+`daemon stop` closes every tab, exits Chrome, flushes saved cookies/login state to the profile (so the next run reuses the login), and shuts down the daemon process. `daemon status` should report the daemon is not running. If it still reports running, the daemon is wedged, force-kill it:
+
+```bash
+pkill -f 'openbrowser.*daemon' || true
+```
+
+Form runs can fail mid-workflow (validation error, CAPTCHA, network drop). Guarantee cleanup with a shell trap so a half-filled form never leaks a browser:
+
+```bash
+trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT
+# ... openbrowser-ai -c calls here ...
+```
+
+Do not rely on the idle timeout. Do not call `done()` as a substitute, `done()` only marks the task complete inside the agent loop, it does not close the browser.

--- a/plugin/skills/page-analysis/SKILL.md
+++ b/plugin/skills/page-analysis/SKILL.md
@@ -225,3 +225,29 @@ EOF
 - Use Python regex on extracted text for pattern matching (emails, phones, dates, prices).
 - For long pages, use `await scroll(down=True)` and re-extract to analyze below-fold content.
 - Variables persist between `-c` calls while the daemon is running, so you can build a comprehensive analysis incrementally.
+
+## Cleanup
+
+This step is **mandatory**. Run it after the analysis finishes, whether extraction succeeded or the page failed to load. Without it, the daemon keeps Chrome running until its 10-minute idle timeout, leaving a stale browser process, a locked profile, and (on macOS/Linux desktop) a visible window.
+
+Stop the daemon, then verify it is gone:
+
+```bash
+openbrowser-ai daemon stop
+openbrowser-ai daemon status
+```
+
+`daemon stop` closes every tab, exits Chrome, flushes saved cookies/login state to the profile, and shuts down the daemon process. `daemon status` should report the daemon is not running. If it still reports running, the daemon is wedged, force-kill it:
+
+```bash
+pkill -f 'openbrowser.*daemon' || true
+```
+
+If your invocation can fail mid-workflow (timeout, navigation error, malformed DOM), guarantee cleanup with a shell trap so the browser is never left orphaned:
+
+```bash
+trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT
+# ... openbrowser-ai -c calls here ...
+```
+
+Do not rely on the idle timeout. Do not call `done()` as a substitute, `done()` only marks the task complete inside the agent loop, it does not close the browser.

--- a/plugin/skills/web-scraping/SKILL.md
+++ b/plugin/skills/web-scraping/SKILL.md
@@ -205,3 +205,29 @@ EOF
 - For large datasets, process pages incrementally rather than loading everything into memory.
 - Check for rate limiting; add `await wait(2)` between page loads if needed.
 - Variables persist between `-c` calls while the daemon is running, so you can build up results across multiple calls.
+
+## Cleanup
+
+This step is **mandatory**. Run it after the scrape finishes, whether you collected every page or hit a rate limit halfway through. Without it, the daemon keeps Chrome running until its 10-minute idle timeout, leaving a stale browser process, a locked profile, and (on macOS/Linux desktop) a visible window.
+
+Stop the daemon, then verify it is gone:
+
+```bash
+openbrowser-ai daemon stop
+openbrowser-ai daemon status
+```
+
+`daemon stop` closes every tab, exits Chrome, flushes saved cookies/login state to the profile, and shuts down the daemon process. `daemon status` should report the daemon is not running. If it still reports running, the daemon is wedged, force-kill it:
+
+```bash
+pkill -f 'openbrowser.*daemon' || true
+```
+
+Long scrapes fail often (rate limits, network drops, pagination dead-ends). Guarantee cleanup with a shell trap so a partial run never leaks a browser:
+
+```bash
+trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT
+# ... openbrowser-ai -c calls here ...
+```
+
+Persist scraped data to disk *before* calling `daemon stop`, in-memory variables die with the daemon. Do not rely on the idle timeout. Do not call `done()` as a substitute, `done()` only marks the task complete inside the agent loop, it does not close the browser.


### PR DESCRIPTION
## Summary

- Strengthen the `## Cleanup` section in every plugin skill so the browser process, profile lock, and on-screen window are reliably released after every run.
- Make cleanup mandatory on success **and** failure paths (was implicitly optional).
- Add verification (`openbrowser-ai daemon status`) and force-kill fallback (`pkill -f 'openbrowser.*daemon'`) for wedged daemons.
- Document the shell `trap ... EXIT` pattern so failed runs never leak a browser.
- Note that `done()` does NOT close the browser (daemon runs with `keep_alive=True`), a common point of confusion.
- Tailor each skill's cleanup rationale to its dominant failure mode (assertion failure, rate limit, validation error, CORS, etc.).

## Changes

- `plugin/skills/accessibility-audit/SKILL.md` -- mandatory cleanup, trap, verify
- `plugin/skills/e2e-testing/SKILL.md` -- cleanup runs even when assertions fail
- `plugin/skills/file-download/SKILL.md` -- cleanup runs even on download failure; downloads survive `daemon stop`
- `plugin/skills/form-filling/SKILL.md` -- cleanup runs even on validation failure / CAPTCHA
- `plugin/skills/page-analysis/SKILL.md` -- cleanup runs even on navigation/DOM failure
- `plugin/skills/web-scraping/SKILL.md` -- cleanup runs even on rate-limit / partial run; persist data before stop

## Tested

- Validated each updated SKILL.md contains the required tokens (`mandatory`, `daemon stop`, `daemon status`, `pkill`, `trap`, note about `done()`).
- Smoke-tested daemon lifecycle locally: `-c` start -> `daemon stop` -> `daemon status` reports stopped, no stray daemon processes.
- Validated the `trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT` pattern fires and cleans up even when the wrapping shell exits with a non-zero status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cleanup mandatory across all six plugin skills to prevent orphaned Chrome processes, locked profiles, and stray windows. Adds verification and trap patterns so cleanup runs on both success and failure.

- **Migration**
  - After every run, call `openbrowser-ai daemon stop` and verify with `openbrowser-ai daemon status`.
  - If the daemon is wedged, run `pkill -f 'openbrowser.*daemon'`.
  - Add a shell trap: `trap 'openbrowser-ai daemon stop >/dev/null 2>&1 || true' EXIT`.
  - Do not rely on `done()`; it doesn’t close the browser.
  - Skill notes: downloads persist after stop (file-download); persist scraped data before stop (web-scraping).

<sup>Written for commit 35e4f4240741aabaa8019e23bfd3659460b373e4. Summary will update on new commits. <a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill documentation across multiple capabilities with comprehensive cleanup guidance (accessibility audits, E2E testing, file downloads, form filling, page analysis, and web scraping).
  * Added best practices for properly shutting down browser resources, including fallback procedures for edge cases.
  * Clarified cleanup requirements to prevent resource leaks and stale processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/billy-enrizky/openbrowser-ai/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->