### PR TITLE
fix: daemon headless default, deep-research robustness, skills.sh manifest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -262,6 +262,51 @@ jobs:
         run: |
           gh release upload "$GITHUB_REF_NAME" install.sh install.ps1 --clobber
 
+  validate-skills-manifest:
+    name: Validate skills.sh Manifest
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate plugin/skills.sh.json against schema
+        run: |
+          python3 - <<'PYEOF'
+          import json, sys, os
+
+          manifest_path = "plugin/skills.sh.json"
+          skills_dir = "plugin/skills"
+
+          with open(manifest_path) as f:
+              manifest = json.load(f)
+
+          errors = []
+
+          # Collect all skill names from groupings
+          grouped = set()
+          for group in manifest.get("groupings", []):
+              for skill in group.get("skills", []):
+                  grouped.add(skill)
+                  skill_dir = os.path.join(skills_dir, skill)
+                  if not os.path.isdir(skill_dir):
+                      errors.append(f"Skill '{skill}' in groupings but directory '{skill_dir}' not found")
+                  elif not os.path.isfile(os.path.join(skill_dir, "SKILL.md")):
+                      errors.append(f"Skill '{skill}' directory exists but SKILL.md missing")
+
+          # Check all SKILL.md files are represented
+          if os.path.isdir(skills_dir):
+              for entry in os.listdir(skills_dir):
+                  if os.path.isfile(os.path.join(skills_dir, entry, "SKILL.md")) and entry not in grouped:
+                      print(f"WARNING: skill '{entry}' has SKILL.md but is not listed in skills.sh.json groupings")
+
+          if errors:
+              for e in errors: print(f"ERROR: {e}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"OK: skills.sh.json valid ({len(grouped)} skills across {len(manifest.get('groupings',[]))} groups)")
+          PYEOF
+
   sync-plugin-version:
     name: Sync Claude Code Plugin Version
     needs: publish-to-pypi

--- a/plugin/skills.sh.json
+++ b/plugin/skills.sh.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Research",
+      "description": "Skills for conducting deep, cited web research using a real browser.",
+      "skills": [
+        "deep-research"
+      ]
+    },
+    {
+      "title": "Browser Automation",
+      "description": "Skills for interacting with web pages: scraping, form filling, testing, and file downloading.",
+      "skills": [
+        "web-scraping",
+        "form-filling",
+        "e2e-testing",
+        "file-download",
+        "page-analysis",
+        "accessibility-audit"
+      ]
+    }
+  ]
+}

--- a/plugin/skills/deep-research/SKILL.md
+++ b/plugin/skills/deep-research/SKILL.md
@@ -243,22 +243,29 @@ After all sub-agents return, the orchestrator collects findings:
 
 ```bash
 openbrowser-ai -c - <<'EOF'
-import os, json, glob
+import os, json
 global _findings
 PROJECT_ROOT = "<ABSOLUTE_PATH_TO_PROJECT_ROOT>"
 partial_dir = os.path.join(PROJECT_ROOT, "local_docs", "research", "_partial")
 
 _findings = []
-for path in sorted(glob.glob(os.path.join(partial_dir, "agent-*.json"))):
+for fname in sorted(os.listdir(partial_dir)):
+    if not (fname.startswith("agent-") and fname.endswith(".json")):
+        continue
+    path = os.path.join(partial_dir, fname)
     try:
         with open(path) as fh:
             arr = json.load(fh)
         if isinstance(arr, list):
+            # normalize exact_url -> url (sub-agents may use either key)
+            for item in arr:
+                if "exact_url" in item and "url" not in item:
+                    item["url"] = item.pop("exact_url")
             _findings.extend(arr)
     except Exception as e:
         print(f"skip {path}: {e}")
 
-print(f"merged {len(_findings)} findings from {len(glob.glob(os.path.join(partial_dir, 'agent-*.json')))} partials")
+print(f"merged {len(_findings)} findings from {len(os.listdir(partial_dir))} partials")
 EOF
 ```
 
@@ -319,16 +326,22 @@ After all retry sub-agents return, merge their partials into `_findings`:
 
 ```bash
 openbrowser-ai -c - <<'EOF'
-import os, json, glob
+import os, json
 global _findings
 PROJECT_ROOT = "<ABSOLUTE_PATH_TO_PROJECT_ROOT>"
 partial_dir = os.path.join(PROJECT_ROOT, "local_docs", "research", "_partial")
 extra = []
-for path in sorted(glob.glob(os.path.join(partial_dir, "agent-retry-*.json"))):
+for fname in sorted(os.listdir(partial_dir)):
+    if not (fname.startswith("agent-retry-") and fname.endswith(".json")):
+        continue
+    path = os.path.join(partial_dir, fname)
     try:
         with open(path) as fh:
             arr = json.load(fh)
         if isinstance(arr, list):
+            for item in arr:
+                if "exact_url" in item and "url" not in item:
+                    item["url"] = item.pop("exact_url")
             extra.extend(arr)
     except Exception as e:
         print(f"skip {path}: {e}")
@@ -391,18 +404,23 @@ After all drilldown sub-agents return, merge their partials into `_findings`:
 
 ```bash
 openbrowser-ai -c - <<'EOF'
-import os, json, glob
+import os, json
 global _findings
 PROJECT_ROOT = "<ABSOLUTE_PATH_TO_PROJECT_ROOT>"
 partial_dir = os.path.join(PROJECT_ROOT, "local_docs", "research", "_partial")
 extra = []
-for path in sorted(glob.glob(os.path.join(partial_dir, "agent-drill-*.json"))):
+for fname in sorted(os.listdir(partial_dir)):
+    if not (fname.startswith("agent-drill-") and fname.endswith(".json")):
+        continue
+    path = os.path.join(partial_dir, fname)
     try:
         with open(path) as fh:
             arr = json.load(fh)
         if isinstance(arr, list):
             for f in arr:
                 f["needs_depth"] = False  # cap reached
+                if "exact_url" in f and "url" not in f:
+                    f["url"] = f.pop("exact_url")
             extra.extend(arr)
     except Exception as e:
         print(f"skip {path}: {e}")
@@ -421,6 +439,11 @@ from urllib.parse import urlparse
 
 # `global` so reassignment of daemon-namespace var doesn't shadow it
 global _findings, _sources
+
+# Normalize exact_url -> url (sub-agents may use either key)
+for f in _findings:
+    if "exact_url" in f and "url" not in f:
+        f["url"] = f.pop("exact_url")
 
 # Dedup by URL, keep first occurrence
 seen_urls = {}
@@ -540,11 +563,17 @@ Fail loud if any prose sentence outside headings, quotes, code, or source list l
 Do the verify in plain shell `python3` (not the daemon). `sys.exit` inside the daemon namespace kills the daemon.
 
 ```bash
-python3 - <<'EOF'
-import re, sys, json, glob, os
+python3 - "$PROJECT_ROOT" <<'EOF'
+import re, sys, os
 
-# Find latest report file under local_docs/research/
-files = sorted(glob.glob("local_docs/research/*.md"), key=os.path.getmtime, reverse=True)
+project_root = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
+research_dir = os.path.join(project_root, "local_docs", "research")
+
+# Find latest report file -- use os.listdir + absolute path (glob fails on non-shell CWD)
+files = sorted(
+    [os.path.join(research_dir, f) for f in os.listdir(research_dir) if f.endswith(".md")],
+    key=os.path.getmtime, reverse=True
+)
 if not files:
     print("No report found"); sys.exit(1)
 md_path = files[0]
@@ -615,6 +644,8 @@ rm -rf "<ABSOLUTE_PATH_TO_PROJECT_ROOT>/local_docs/research/_partial" 2>/dev/nul
 - **Heredoc quoting:** always use `<<'EOF'` (single-quoted) so `$`, backticks, and `!` inside Python don't expand in the shell.
 - **Daemon namespace:** `_plan`, `_findings`, `_sources` persist across orchestrator `-c` calls. Sub-agents share the same daemon and so see the same namespace, but each operates in its own tab. Don't restart the daemon mid-run.
 - **Partial files as the contract:** sub-agents write to `local_docs/research/_partial/agent-NN.json`, the orchestrator reads them back. Sub-agents do NOT communicate findings via stdout. If a partial file is missing or empty, that sub-agent failed; rerun it or fall through to Step 2b.
+- **`exact_url` normalization:** sub-agents may write `exact_url` instead of `url`. All merge steps (Step 2a, 2b, 3) normalize this automatically. Step 4 has a final safety pass. Never rely on `url` being set before the merge step runs.
+- **Daemon restart recovery:** if the daemon restarts mid-session, `_plan`/`_findings`/`_sources` are lost from namespace. The partial JSON files on disk survive. Re-run the merge step (Step 2a collect block) with `PROJECT_ROOT` hardcoded to reload `_findings` from disk. Re-run Step 1 with the same `QUERY` and `PROJECT_ROOT` to restore `_plan`; the slug-collision bump will avoid overwriting the existing output file.
 - **No `-p`, ever:** this skill never shells out to `openbrowser-ai -p`. The `-p` mode runs the full Browser Agent loop with LLM-driven navigation and requires an OpenAI / Anthropic / Google API key (`cli.py:434-490` `get_llm()`). The `-c` daemon path needs no API key. If you see `-p` anywhere in skill code, that is a bug.
 - **Source diversity:** if dedup leaves <60% of findings (heavy domain repetition), rerun the affected sub-agent with explicit "prefer different domains than: <list>" appended to its prompt.
 - **Drilldown cost:** drilldown dispatches up to `len(sub_questions) * 3` extra parallel sub-agents. Reserve for genuinely deep topics.

--- a/src/openbrowser/daemon/server.py
+++ b/src/openbrowser/daemon/server.py
@@ -86,6 +86,17 @@ class DaemonServer:
             },
             CONFIG.OPENBROWSER_PROFILES_DIR / 'daemon',
         )
+        # Stored config (profile_config) may have headless=False from a previous
+        # non-headless session, overriding the daemon default above. Apply the env
+        # var override last so OPENBROWSER_HEADLESS=false is the only way to opt
+        # into a visible window; omitting the var keeps daemon headless by default.
+        env_headless = os.environ.get('OPENBROWSER_HEADLESS', '').lower()
+        if env_headless in ('true', '1', 'yes'):
+            profile_data['headless'] = True
+        elif env_headless in ('false', '0', 'no'):
+            profile_data['headless'] = False
+        else:
+            profile_data['headless'] = True  # daemon default: always headless
         return BrowserProfile(**profile_data)
 
     async def _ensure_executor(self):


### PR DESCRIPTION
## Summary

- Fix daemon always starting headless by default: stored browser profile with `headless=False` was overriding `server.py`'s base `headless=True` via `**profile_config` merge. Now applies env var + hard fallback after the merge so daemon is headless unless `OPENBROWSER_HEADLESS=false` is explicitly set.
- Fix deep-research skill robustness: replace `glob()` with `os.listdir()` in all merge steps, normalize `exact_url` -> `url` key from sub-agents, fix Step 6 verifier to use absolute path via `PROJECT_ROOT` argv. Add tips for `exact_url` normalization and daemon-restart recovery.
- Add `plugin/skills.sh.json` manifest grouping 7 skills into Research + Browser Automation categories. Add CI `validate-skills-manifest` job that verifies every listed skill has a `SKILL.md` on each release.

## Changes

- `src/openbrowser/daemon/server.py`: after `**profile_config` merge, apply `OPENBROWSER_HEADLESS` env var then fall back to `headless=True` unconditionally
- `plugin/skills/deep-research/SKILL.md`: `os.listdir` over `glob`, `exact_url` normalization in Steps 2a/2b/3/4, verifier uses `PROJECT_ROOT` argv, two new Tips entries
- `plugin/skills.sh.json`: new manifest for skills.sh display grouping
- `.github/workflows/publish.yml`: new `validate-skills-manifest` job on release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the daemon reliably headless by default, harden `deep-research` merges and verification, and add a `skills.sh` manifest with release-time validation.

- **Bug Fixes**
  - Daemon: enforce `headless=True` after profile merge; only show a window when `OPENBROWSER_HEADLESS=false`.
  - `deep-research`: use `os.listdir()` instead of `glob()` for partial merges; normalize `exact_url` to `url`; verifier uses absolute path via `PROJECT_ROOT`.

- **New Features**
  - Added `plugin/skills.sh.json` to group 7 skills under Research and Browser Automation for `skills.sh`.
  - New CI job `validate-skills-manifest` on release to ensure each listed skill exists and has a `SKILL.md` (warns on unlisted skills).

<sup>Written for commit 60aae4a0747c1ef9900342e2042a5fc7828ca204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skills grouping metadata for Research and Browser Automation.
  * Browser daemon now supports an environment-based headless mode override.

* **Bug Fixes**
  * Improved reliability when merging partial research results and validating generated reports.
  * Strengthened URL normalization and citation checking to reduce inconsistencies.

* **Documentation**
  * Updated usage notes for the deep research workflow and recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->