### PR TITLE
fix: stale daemon PID lock after SIGKILL; add mcp to base deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "posthog>=3.7.0",
     "reportlab",
     "modal>=1.4.2",
+    "mcp>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -44,7 +45,7 @@ groq = ["groq>=0.30.0"]
 ollama = ["ollama>=0.5.1"]
 aws = ["boto3"]
 azure = ["openai"]
-mcp = ["mcp>=1.0.0", "posthog>=3.7.0"]
+mcp = ["posthog>=3.7.0"]
 telemetry = ["posthog>=3.7.0"]
 pdf = ["pypdf", "reportlab"]
 dev = [

--- a/src/openbrowser/cli.py
+++ b/src/openbrowser/cli.py
@@ -10,7 +10,6 @@ if '--mcp' in sys.argv:
 
 	os.environ['OPENBROWSER_LOGGING_LEVEL'] = 'critical'
 	os.environ['OPENBROWSER_SETUP_LOGGING'] = 'false'
-	logging.disable(logging.CRITICAL)
 
 	# Early exit: run MCP server directly without loading heavy CLI dependencies
 	# (anthropic, openai, etc. are not needed for MCP server mode)
@@ -29,8 +28,13 @@ if '--mcp' in sys.argv:
 	except Exception:
 		pass
 
-	from openbrowser.mcp.server import main as mcp_main
+	try:
+		from openbrowser.mcp.server import main as mcp_main
+	except ImportError as e:
+		sys.stderr.write(f"ERROR: mcp SDK not installed ({e}). Fix: pip install 'openbrowser-ai[mcp]'\n")
+		sys.exit(1)
 
+	logging.disable(logging.CRITICAL)
 	asyncio.run(mcp_main())
 	sys.exit(0)
 

--- a/src/openbrowser/daemon/server.py
+++ b/src/openbrowser/daemon/server.py
@@ -25,18 +25,37 @@ DEFAULT_EXEC_TIMEOUT = 300  # 5 minutes max per code execution
 
 
 def _read_pid() -> int | None:
-    """Read PID from file, return None if stale or missing."""
+    """Read PID from file, return None if stale or missing.
+
+    A PID file with a live process is only considered valid if the daemon
+    socket is also connectable. A process killed with SIGKILL skips
+    finally/_cleanup_pid(), leaving a stale PID + dead socket.
+    """
     pid_path = get_pid_path()
     if not pid_path.exists():
         return None
     try:
         pid = int(pid_path.read_text().strip())
-        # Check if process is alive
-        os.kill(pid, 0)
-        return pid
+        os.kill(pid, 0)  # raises OSError if dead
     except (ValueError, OSError):
         pid_path.unlink(missing_ok=True)
         return None
+
+    if not IS_WINDOWS:
+        import socket as _socket
+        sock_path = str(get_socket_path())
+        try:
+            s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+            s.settimeout(1.0)
+            s.connect(sock_path)
+            s.close()
+        except OSError:
+            logger.warning('PID %d alive but socket unresponsive -- cleaning stale lock', pid)
+            pid_path.unlink(missing_ok=True)
+            get_socket_path().unlink(missing_ok=True)
+            return None
+
+    return pid
 
 
 def _write_pid() -> None:


### PR DESCRIPTION
## Summary

- Fix daemon `start` failing with "Another daemon is already running" when previous process was killed with SIGKILL
- Add `mcp>=1.0.0` to base dependencies so `--mcp` mode works on a clean install without extras
- Surface `ImportError` with a clear message before silencing logs in MCP fast path

## Changes

- `src/openbrowser/daemon/server.py`: `_read_pid()` now attempts a socket connection after confirming PID is alive; if socket is unreachable the stale PID + socket files are cleaned and `None` is returned
- `pyproject.toml`: moved `mcp>=1.0.0` from `[mcp]` extra into base `[project.dependencies]`
- `src/openbrowser/cli.py`: wrapped `from openbrowser.mcp.server import main` in try/except, moved `logging.disable(CRITICAL)` to after the import so errors are visible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix daemon start failures from stale PID/socket locks after SIGKILL. Add `mcp>=1.0.0` to base deps so `--mcp` works on clean installs, and surface clear ImportError before disabling logs.

- **Bug Fixes**
  - `_read_pid()` now confirms the daemon socket is connectable; if not, it cleans stale PID and socket files and returns None.
  - In `--mcp` mode, move `logging.disable` after import and show a helpful error with an install hint if the MCP SDK is missing.

- **Dependencies**
  - Moved `mcp>=1.0.0` to `[project.dependencies]` for out-of-the-box MCP support.
  - Trimmed `[project.optional-dependencies].mcp` to only include `posthog`.

<sup>Written for commit 74f315e9e48676978d14d408f14e501f4e4988ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for the MCP-related command flow as a standard dependency.
  * The CLI now shows a clear install hint if MCP support is missing.

* **Bug Fixes**
  * Improved MCP startup handling so the app fails gracefully instead of crashing when support isn’t installed.
  * Strengthened daemon cleanup by detecting stale lock/socket states and removing invalid leftovers more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->