### PR TITLE
test(daemon): fix _read_pid tests failing after socket connectivity check added in v0.1.48

### DIFF
--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -46,13 +46,23 @@ class TestDaemonServerHelpers:
             assert result is None
 
     def test_read_pid_alive_process(self, tmp_path):
-        """_read_pid returns PID when process is alive."""
+        """_read_pid returns PID when process is alive and socket is connectable."""
+        import socket as _socket
         pid_file = tmp_path / "daemon.pid"
+        sock_file = tmp_path / "daemon.sock"
         current_pid = os.getpid()
         pid_file.write_text(str(current_pid))
-        with patch("openbrowser.daemon.server.get_pid_path", return_value=pid_file):
-            result = _read_pid()
-            assert result == current_pid
+        # Bind a real Unix socket so the connectivity check passes
+        server_sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        server_sock.bind(str(sock_file))
+        server_sock.listen(1)
+        try:
+            with patch("openbrowser.daemon.server.get_pid_path", return_value=pid_file), \
+                 patch("openbrowser.daemon.server.get_socket_path", return_value=sock_file):
+                result = _read_pid()
+                assert result == current_pid
+        finally:
+            server_sock.close()
 
     def test_write_pid(self, tmp_path):
         """_write_pid creates PID file with correct content and permissions."""

--- a/tests/test_daemon_server_coverage.py
+++ b/tests/test_daemon_server_coverage.py
@@ -39,20 +39,27 @@ class TestPidFunctions:
             assert _read_pid() is None
 
     def test_read_pid_valid(self):
-        """Test _read_pid with valid PID."""
+        """Test _read_pid with valid PID and connectable socket."""
+        import socket as _socket
         from openbrowser.daemon.server import _read_pid
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".pid", delete=False) as f:
-            f.write(str(os.getpid()))
-            f.flush()
-
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sock_path = Path(tmpdir) / "daemon.sock"
             mock_path = MagicMock()
             mock_path.exists.return_value = True
             mock_path.read_text.return_value = str(os.getpid())
 
-            with patch("openbrowser.daemon.server.get_pid_path", return_value=mock_path):
-                result = _read_pid()
-                assert result == os.getpid()
+            # Bind a real Unix socket so the connectivity check passes
+            server_sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+            server_sock.bind(str(sock_path))
+            server_sock.listen(1)
+            try:
+                with patch("openbrowser.daemon.server.get_pid_path", return_value=mock_path), \
+                     patch("openbrowser.daemon.server.get_socket_path", return_value=sock_path):
+                    result = _read_pid()
+                    assert result == os.getpid()
+            finally:
+                server_sock.close()
 
     def test_read_pid_stale(self):
         """Test _read_pid with stale PID."""


### PR DESCRIPTION
## Summary

- Fix two CI test failures introduced by the v0.1.48 socket connectivity check in `_read_pid()`
- Tests mocked `get_pid_path` but not `get_socket_path`, so the new socket connect attempt hit a non-existent path and returned `None` instead of the PID

## Changes

- `tests/test_daemon_server.py`: `test_read_pid_alive_process` now binds a real Unix socket and patches `get_socket_path` so the connectivity check passes
- `tests/test_daemon_server_coverage.py`: `test_read_pid_valid` same fix, uses `TemporaryDirectory` for socket path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing `_read_pid()` tests introduced by the v0.1.48 socket connectivity check by binding a real Unix socket and patching `get_socket_path`. Restores CI stability and properly exercises the socket check.

- **Bug Fixes**
  - `tests/test_daemon_server.py`: `test_read_pid_alive_process` binds a real AF_UNIX socket and patches `get_socket_path`.
  - `tests/test_daemon_server_coverage.py`: `test_read_pid_valid` uses `TemporaryDirectory`, binds a socket, and patches `get_socket_path`.

<sup>Written for commit 3a28bae0ee819fa576355b955e0d13a8119e9809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved daemon process tests to use a real connectable Unix socket, making PID checks more realistic and reliable.
  * Updated coverage for PID validation to better reflect how the running service is detected in practice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->