### PR TITLE
test(daemon): use /tmp socket path to avoid AF_UNIX 104-char limit on macOS CI

### DIFF
--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -48,21 +48,23 @@ class TestDaemonServerHelpers:
     def test_read_pid_alive_process(self, tmp_path):
         """_read_pid returns PID when process is alive and socket is connectable."""
         import socket as _socket
+        import tempfile
         pid_file = tmp_path / "daemon.pid"
-        sock_file = tmp_path / "daemon.sock"
         current_pid = os.getpid()
         pid_file.write_text(str(current_pid))
-        # Bind a real Unix socket so the connectivity check passes
+        # Use /tmp directly: macOS CI tmp_path can exceed the 104-char AF_UNIX limit
+        sock_path = Path(tempfile.mktemp(suffix='.sock', dir='/tmp'))
         server_sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
-        server_sock.bind(str(sock_file))
+        server_sock.bind(str(sock_path))
         server_sock.listen(1)
         try:
             with patch("openbrowser.daemon.server.get_pid_path", return_value=pid_file), \
-                 patch("openbrowser.daemon.server.get_socket_path", return_value=sock_file):
+                 patch("openbrowser.daemon.server.get_socket_path", return_value=sock_path):
                 result = _read_pid()
                 assert result == current_pid
         finally:
             server_sock.close()
+            sock_path.unlink(missing_ok=True)
 
     def test_write_pid(self, tmp_path):
         """_write_pid creates PID file with correct content and permissions."""

--- a/tests/test_daemon_server_coverage.py
+++ b/tests/test_daemon_server_coverage.py
@@ -43,23 +43,23 @@ class TestPidFunctions:
         import socket as _socket
         from openbrowser.daemon.server import _read_pid
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            sock_path = Path(tmpdir) / "daemon.sock"
-            mock_path = MagicMock()
-            mock_path.exists.return_value = True
-            mock_path.read_text.return_value = str(os.getpid())
+        # Use /tmp directly: macOS CI tmpdir paths can exceed the 104-char AF_UNIX limit
+        sock_path = Path(tempfile.mktemp(suffix='.sock', dir='/tmp'))
+        mock_path = MagicMock()
+        mock_path.exists.return_value = True
+        mock_path.read_text.return_value = str(os.getpid())
 
-            # Bind a real Unix socket so the connectivity check passes
-            server_sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
-            server_sock.bind(str(sock_path))
-            server_sock.listen(1)
-            try:
-                with patch("openbrowser.daemon.server.get_pid_path", return_value=mock_path), \
-                     patch("openbrowser.daemon.server.get_socket_path", return_value=sock_path):
-                    result = _read_pid()
-                    assert result == os.getpid()
-            finally:
-                server_sock.close()
+        server_sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        server_sock.bind(str(sock_path))
+        server_sock.listen(1)
+        try:
+            with patch("openbrowser.daemon.server.get_pid_path", return_value=mock_path), \
+                 patch("openbrowser.daemon.server.get_socket_path", return_value=sock_path):
+                result = _read_pid()
+                assert result == os.getpid()
+        finally:
+            server_sock.close()
+            sock_path.unlink(missing_ok=True)
 
     def test_read_pid_stale(self):
         """Test _read_pid with stale PID."""


### PR DESCRIPTION
## Summary

- Fix CI test failure: `OSError: AF_UNIX path too long` on macOS CI where pytest's `tmp_path` and `TemporaryDirectory` produce paths longer than the 104-char Unix socket limit
- Switch both `_read_pid` tests to use `tempfile.mktemp(suffix='.sock', dir='/tmp')` which always produces short paths (~21 chars)

## Changes

- `tests/test_daemon_server.py`: `test_read_pid_alive_process` uses `/tmp` socket path, cleans up with `unlink(missing_ok=True)`
- `tests/test_daemon_server_coverage.py`: `test_read_pid_valid` same fix, drops `TemporaryDirectory` wrapper

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS CI test failures by forcing daemon test UNIX sockets to live in /tmp so paths stay under the 104‑char AF_UNIX limit. Ensures the socket connectivity check passes and avoids OSError.

- **Bug Fixes**
  - tests/test_daemon_server.py: test_read_pid_alive_process now uses tempfile.mktemp(..., dir='/tmp') and cleans up with Path.unlink(missing_ok=True).
  - tests/test_daemon_server_coverage.py: test_read_pid_valid uses the same /tmp approach and removes TemporaryDirectory usage.

<sup>Written for commit 316f53d52ad48db48f2e6ab4587187dbed2baa9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/billy-enrizky/openbrowser-ai/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved daemon socket test coverage by using real Unix socket paths during validation.
  * Strengthened cleanup after socket use to reduce leftover temporary files and flaky test behavior.
  * Increased confidence in daemon process detection and connectivity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->